### PR TITLE
Fix pulse check page after brand styling merge conflict

### DIFF
--- a/app/(dashboard)/pulse-check/page.tsx
+++ b/app/(dashboard)/pulse-check/page.tsx
@@ -175,27 +175,13 @@ export default function PulseCheckPage() {
 
   const hasCycles = enrollments.length > 0;
 
-  if (enrollments.length === 0) {
-    return (
-      <div className="mx-auto max-w-2xl text-center py-20">
-        <h1 className="text-2xl font-bold text-white">
-          Pulse Check
-        </h1>
-        <p className="mt-4 text-cloud/80">
-          No active cycles found. Pulse checks are available when you are
-          enrolled in an active build cycle.
-        </p>
-      </div>
-    );
-  }
-
   return (
     <div className="mx-auto max-w-2xl">
       <h1 className="mb-2 text-2xl font-bold text-white">
         Pulse Check
       </h1>
       <p className="mb-6 text-sm text-cloud/80">
-        Share what you accomplished this week and how things are going.
+        Take a moment to reflect on your week.
       </p>
 
       {/* Mode toggle — only shown when the user has active cycles */}
@@ -307,62 +293,17 @@ export default function PulseCheckPage() {
           />
         </label>
 
-        {aiTools.length > 0 && (
-          <div>
-            <span className="text-sm font-medium text-cloud">
-              AI Tools Used
-            </span>
-            <div className="mt-2 flex flex-wrap gap-3">
-              {aiTools.map((tool) => (
-                <label key={tool.id} className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    name="tools_used"
-                    value={tool.id}
-                    className="rounded border-white/20 bg-white/[0.05] text-teal"
-                  />
-                  <span className="text-sm text-cloud">
-                    {tool.value}
-                  </span>
-                </label>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {pulseBenefits.length > 0 && (
-          <div>
-            <span className="text-sm font-medium text-cloud">
-              Benefits this week (max 3)
-            </span>
-            <div className="mt-2 space-y-2">
-              {pulseBenefits.map((b) => (
-                <label key={b.id} className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    name="benefits"
-                    value={b.id}
-                    className="rounded border-white/20 bg-white/[0.05] text-teal"
-                  />
-                  <span className="text-sm text-cloud">
-                    {b.value}
-                  </span>
-                </label>
-              ))}
-            </div>
-          </div>
-        )}
-
+        {/* Highlight */}
         <label className="block">
           <span className="text-sm font-medium text-cloud">
-            New connections made
+            What was the highlight of your week?
           </span>
-          <input
-            name="new_connections"
-            type="number"
-            min={0}
+          <textarea
+            name="highlight"
+            maxLength={1000}
+            rows={2}
             className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
-            placeholder="Number of new collaborators you met"
+            placeholder="A win, a moment of clarity, something that made you smile..."
           />
         </label>
 
@@ -515,12 +456,10 @@ export default function PulseCheckPage() {
                     </span>
                     {entry.survey_responses.energy_level && (
                       <span
-                        className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+                        className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium text-aqua"
                         title={`Energy: ${ENERGY_LABELS[entry.survey_responses.energy_level - 1]}`}
                       >
-                        {entry.survey_responses.energy_level <= 2
-                          ? "Energy " + entry.survey_responses.energy_level + "/5"
-                          : "Energy " + entry.survey_responses.energy_level + "/5"}
+                        Energy {entry.survey_responses.energy_level}/5
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
The brand styling PR (#9) overwrote our always-available pulse check functionality. This restores the correct structure while keeping brand styles (aqua, midnight, cloud tokens):

- Remove the "no active cycles" dead-end (the whole point of this feature)
- Fix duplicate fields (AI tools, benefits, connections were outside the cycle-only block)
- Restore the missing highlight field
- Update subtitle to reflective copy

https://claude.ai/code/session_01BVaex7dYUZxTprkXJeTy1P