### PR TITLE
Add admin panel with cycle management, participants, and revocations

### DIFF
--- a/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useState } from "react";
+
+type Config = {
+  cycle_id: number;
+  submitter_votes: number;
+  non_submitter_votes: number;
+  vote_threshold: number;
+  max_pods: number;
+  pod_min: number;
+  project_submitter_votes: number;
+  project_vote_threshold: number;
+  max_projects: number;
+  project_min: number;
+  project_max: number;
+  problem_statement_open: string | null;
+  problem_statement_close: string | null;
+  voting_open: string | null;
+  voting_close: string | null;
+  pod_registration_open: string | null;
+  pod_registration_close: string | null;
+  solution_proposal_open: string | null;
+  solution_proposal_close: string | null;
+  solution_voting_open: string | null;
+  solution_voting_close: string | null;
+  project_registration_open: string | null;
+  project_registration_close: string | null;
+};
+
+// Convert stored timestamp to datetime-local input value (treats as UTC)
+function toLocal(iso: string | null): string {
+  if (!iso) return "";
+  return iso.replace(" ", "T").slice(0, 16);
+}
+
+// Convert datetime-local input value back to a storable timestamp string
+function fromLocal(val: string): string | null {
+  if (!val) return null;
+  return `${val}:00`;
+}
+
+// ─── Schedule form ────────────────────────────────────────────────────────────
+
+const PHASES = [
+  {
+    label: "Problem Statement",
+    open: "problem_statement_open",
+    close: "problem_statement_close",
+  },
+  { label: "Voting", open: "voting_open", close: "voting_close" },
+  {
+    label: "Pod Registration",
+    open: "pod_registration_open",
+    close: "pod_registration_close",
+  },
+  {
+    label: "Solution Proposal",
+    open: "solution_proposal_open",
+    close: "solution_proposal_close",
+  },
+  {
+    label: "Solution Voting",
+    open: "solution_voting_open",
+    close: "solution_voting_close",
+  },
+  {
+    label: "Project Registration",
+    open: "project_registration_open",
+    close: "project_registration_close",
+  },
+] as const;
+
+export function CycleScheduleForm({
+  cycleId,
+  config,
+}: {
+  cycleId: number;
+  config: Config;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSaved(false);
+    setError(null);
+    const fd = new FormData(e.currentTarget);
+
+    const body: Record<string, string | null> = {};
+    for (const phase of PHASES) {
+      body[phase.open] = fromLocal(fd.get(phase.open) as string);
+      body[phase.close] = fromLocal(fd.get(phase.close) as string);
+    }
+
+    setLoading(true);
+    const res = await fetch(`/api/cycles/${cycleId}/config`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    setLoading(false);
+
+    if (res.ok) {
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to save schedule");
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
+        <table className="w-full text-sm">
+          <thead className="bg-zinc-50 dark:bg-zinc-800">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                Phase
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                Opens (UTC)
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                Closes (UTC)
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-200 bg-white dark:divide-zinc-800 dark:bg-zinc-900">
+            {PHASES.map((phase) => (
+              <tr key={phase.label}>
+                <td className="px-4 py-3 font-medium text-zinc-900 dark:text-zinc-50">
+                  {phase.label}
+                </td>
+                <td className="px-4 py-3">
+                  <input
+                    type="datetime-local"
+                    name={phase.open}
+                    defaultValue={toLocal(
+                      config[phase.open as keyof Config] as string | null
+                    )}
+                    className="rounded-md border border-zinc-300 px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+                  />
+                </td>
+                <td className="px-4 py-3">
+                  <input
+                    type="datetime-local"
+                    name={phase.close}
+                    defaultValue={toLocal(
+                      config[phase.close as keyof Config] as string | null
+                    )}
+                    className="rounded-md border border-zinc-300 px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-3 flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          {loading ? "Saving…" : "Save Schedule"}
+        </button>
+        {saved && <span className="text-sm text-green-600">Saved!</span>}
+        {error && <span className="text-sm text-red-600">{error}</span>}
+      </div>
+    </form>
+  );
+}
+
+// ─── Parameters form ──────────────────────────────────────────────────────────
+
+const PARAM_GROUPS = [
+  {
+    heading: "Problem Voting",
+    fields: [
+      { label: "Submitter votes", name: "submitter_votes" },
+      { label: "Non-submitter votes", name: "non_submitter_votes" },
+      { label: "Vote threshold (pods)", name: "vote_threshold" },
+      { label: "Max pods", name: "max_pods" },
+      { label: "Pod minimum size", name: "pod_min" },
+    ],
+  },
+  {
+    heading: "Project Voting",
+    fields: [
+      { label: "Submitter votes", name: "project_submitter_votes" },
+      { label: "Vote threshold (projects)", name: "project_vote_threshold" },
+      { label: "Max projects per pod", name: "max_projects" },
+      { label: "Project min members", name: "project_min" },
+      { label: "Project max members", name: "project_max" },
+    ],
+  },
+] as const;
+
+export function CycleParamsForm({
+  cycleId,
+  config,
+}: {
+  cycleId: number;
+  config: Config;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSaved(false);
+    setError(null);
+    const fd = new FormData(e.currentTarget);
+
+    const body: Record<string, number> = {};
+    for (const group of PARAM_GROUPS) {
+      for (const field of group.fields) {
+        const val = fd.get(field.name) as string;
+        if (val !== "") body[field.name] = parseInt(val, 10);
+      }
+    }
+
+    setLoading(true);
+    const res = await fetch(`/api/cycles/${cycleId}/config`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    setLoading(false);
+
+    if (res.ok) {
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to save parameters");
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="grid gap-8 sm:grid-cols-2">
+        {PARAM_GROUPS.map((group) => (
+          <div key={group.heading}>
+            <h3 className="mb-3 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+              {group.heading}
+            </h3>
+            <div className="space-y-3">
+              {group.fields.map((field) => (
+                <div
+                  key={field.name}
+                  className="flex items-center justify-between gap-4"
+                >
+                  <label
+                    htmlFor={field.name}
+                    className="text-sm text-zinc-600 dark:text-zinc-400"
+                  >
+                    {field.label}
+                  </label>
+                  <input
+                    id={field.name}
+                    type="number"
+                    name={field.name}
+                    min={0}
+                    defaultValue={
+                      config[field.name as keyof Config] as number
+                    }
+                    className="w-20 rounded-md border border-zinc-300 px-2 py-1 text-right text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          {loading ? "Saving…" : "Save Parameters"}
+        </button>
+        {saved && <span className="text-sm text-green-600">Saved!</span>}
+        {error && <span className="text-sm text-red-600">{error}</span>}
+      </div>
+    </form>
+  );
+}

--- a/app/(dashboard)/admin/cycles/[cycle_id]/cycle-status-form.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/cycle-status-form.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+const NEXT_STATUS: Record<string, string | null> = {
+  draft: "active",
+  active: "closed",
+  closed: null,
+};
+
+const BUTTON_LABELS: Record<string, string> = {
+  active: "Activate Cycle",
+  closed: "Close Cycle",
+};
+
+export default function CycleStatusForm({
+  cycleId,
+  currentStatus,
+}: {
+  cycleId: number;
+  currentStatus: string;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  const nextStatus = NEXT_STATUS[currentStatus] ?? null;
+
+  async function advance() {
+    if (!nextStatus) return;
+    if (
+      !confirm(
+        `Advance cycle status to "${nextStatus}"? ${nextStatus === "closed" ? "This cannot be undone." : ""}`
+      )
+    )
+      return;
+
+    setLoading(true);
+    setError(null);
+
+    const res = await fetch(`/api/cycles/${cycleId}/status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: nextStatus }),
+    });
+
+    setLoading(false);
+    if (res.ok) {
+      router.refresh();
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to update status");
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-4">
+      <span className="text-sm text-zinc-500">
+        Current status:{" "}
+        <span
+          className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+            currentStatus === "active"
+              ? "bg-green-100 text-green-800"
+              : currentStatus === "closed"
+                ? "bg-zinc-100 text-zinc-600"
+                : "bg-yellow-100 text-yellow-800"
+          }`}
+        >
+          {currentStatus}
+        </span>
+      </span>
+
+      {nextStatus ? (
+        <button
+          onClick={advance}
+          disabled={loading}
+          className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
+            nextStatus === "closed"
+              ? "bg-red-600 text-white hover:bg-red-700"
+              : "bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          }`}
+        >
+          {loading ? "Updating…" : BUTTON_LABELS[nextStatus]}
+        </button>
+      ) : (
+        <span className="text-sm text-zinc-400">
+          Cycle is closed — no further transitions.
+        </span>
+      )}
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/cycles/[cycle_id]/finalize-voting-button.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/finalize-voting-button.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type Pod = {
+  id: number;
+  name: string;
+  problem_statement_id: number;
+  total_votes: number;
+};
+
+export default function FinalizeVotingButton({ cycleId }: { cycleId: number }) {
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<{ pods: Pod[] } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function finalize() {
+    if (
+      !confirm(
+        "Finalize voting and create pods? This uses AI to name pods and cannot be undone."
+      )
+    )
+      return;
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    const res = await fetch(`/api/voting/finalize/${cycleId}`, {
+      method: "POST",
+    });
+
+    setLoading(false);
+    if (res.ok) {
+      const data = await res.json();
+      setResult(data);
+      router.refresh();
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to finalize voting");
+    }
+  }
+
+  return (
+    <div>
+      <button
+        onClick={finalize}
+        disabled={loading}
+        className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        {loading ? "Finalizing…" : "Finalize Pod Voting"}
+      </button>
+
+      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+
+      {result && (
+        <div
+          className={`mt-4 rounded-lg border p-4 ${
+            result.pods.length > 0
+              ? "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950"
+              : "border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900"
+          }`}
+        >
+          {result.pods.length === 0 ? (
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+              No eligible problem statements met the vote threshold.
+            </p>
+          ) : (
+            <>
+              <p className="mb-2 text-sm font-medium text-green-800 dark:text-green-200">
+                {result.pods.length} pod
+                {result.pods.length !== 1 ? "s" : ""} created.
+              </p>
+              <ul className="space-y-1">
+                {result.pods.map((pod) => (
+                  <li
+                    key={pod.id}
+                    className="text-sm text-green-700 dark:text-green-300"
+                  >
+                    <span className="font-medium">{pod.name}</span> &mdash;{" "}
+                    {pod.total_votes} votes
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
@@ -1,0 +1,328 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { redirect, notFound } from "next/navigation";
+import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
+import CycleStatusForm from "./cycle-status-form";
+import { CycleScheduleForm, CycleParamsForm } from "./cycle-config-form";
+import ParticipantsTable from "./participants-table";
+import FinalizeVotingButton from "./finalize-voting-button";
+import RevocationsSection from "./revocations-section";
+
+export type ParticipantRow = {
+  participant_id: number;
+  first_name: string;
+  last_name: string;
+  preferred_name: string | null;
+  email: string;
+  status: string;
+  inactive_date: string | null;
+  pods: number[];
+  roles: string[];
+};
+
+export default async function AdminCycleDetailPage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const serviceClient = createServiceClient();
+  const userRoles = await resolveUserRoles(serviceClient, user.id);
+  if (!isAdmin(userRoles)) redirect("/cycles");
+
+  const cycleId = parseInt(cycle_id);
+
+  const [{ data: cycle }, { data: config }] = await Promise.all([
+    serviceClient
+      .from("cycles")
+      .select("id, name, start_date, end_date, status")
+      .eq("id", cycleId)
+      .single(),
+    serviceClient
+      .from("cycle_config")
+      .select("*")
+      .eq("cycle_id", cycleId)
+      .single(),
+  ]);
+
+  if (!cycle) notFound();
+
+  // Enrollments with participant data
+  const { data: enrollments } = await serviceClient
+    .from("cycle_enrollments")
+    .select(
+      `participant_id, status, inactive_date,
+       participants ( id, first_name, last_name, preferred_name, email )`
+    )
+    .eq("cycle_id", cycleId);
+
+  // Pods
+  const { data: pods } = await serviceClient
+    .from("pods")
+    .select("id, name, status")
+    .eq("cycle_id", cycleId)
+    .order("created_at");
+
+  // Pod memberships
+  const podIds = pods?.map((p) => p.id) ?? [];
+  const { data: podMemberships } = podIds.length
+    ? await serviceClient
+        .from("pod_memberships")
+        .select("participant_id, pod_id")
+        .in("pod_id", podIds)
+        .is("inactive_at", null)
+    : { data: [] as { participant_id: number; pod_id: number }[] };
+
+  const podsByParticipant: Record<number, number[]> = {};
+  for (const m of podMemberships ?? []) {
+    (podsByParticipant[m.participant_id] ??= []).push(m.pod_id);
+  }
+
+  // Elevated roles for participants
+  const participantIds = enrollments?.map((e) => e.participant_id) ?? [];
+  const { data: elevatedRoles } = participantIds.length
+    ? await serviceClient
+        .from("user_roles")
+        .select("participant_id, role")
+        .in("participant_id", participantIds)
+        .is("revoked_at", null)
+    : { data: [] as { participant_id: number; role: string }[] };
+
+  const rolesByParticipant: Record<number, string[]> = {};
+  for (const r of elevatedRoles ?? []) {
+    (rolesByParticipant[r.participant_id] ??= []).push(r.role);
+  }
+
+  const participants: ParticipantRow[] = (enrollments ?? []).map((e) => {
+    const p = (e.participants as unknown) as {
+      first_name: string;
+      last_name: string;
+      preferred_name: string | null;
+      email: string;
+    } | null;
+    return {
+      participant_id: e.participant_id,
+      first_name: p?.first_name ?? "",
+      last_name: p?.last_name ?? "",
+      preferred_name: p?.preferred_name ?? null,
+      email: p?.email ?? "",
+      status: e.status,
+      inactive_date: e.inactive_date,
+      pods: podsByParticipant[e.participant_id] ?? [],
+      roles: rolesByParticipant[e.participant_id] ?? [],
+    };
+  });
+
+  // Revocations
+  const { data: revocations } = await serviceClient
+    .from("access_revocations")
+    .select("participant_id, reason, revocation_scope, revoked_at, revoked_systems")
+    .eq("cycle_id", cycleId)
+    .order("revoked_at", { ascending: false });
+
+  const activeCount = participants.filter((p) => p.status === "active").length;
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-8">
+        <Link
+          href="/admin"
+          className="text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+        >
+          &larr; Admin
+        </Link>
+        <div className="mt-2 flex flex-wrap items-center gap-3">
+          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+            {cycle.name}
+          </h1>
+          <span
+            className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+              cycle.status === "active"
+                ? "bg-green-100 text-green-800"
+                : cycle.status === "closed"
+                  ? "bg-zinc-100 text-zinc-600"
+                  : "bg-yellow-100 text-yellow-800"
+            }`}
+          >
+            {cycle.status}
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-zinc-500">
+          {new Date(cycle.start_date).toLocaleDateString()} &ndash;{" "}
+          {new Date(cycle.end_date).toLocaleDateString()}
+        </p>
+      </div>
+
+      {/* Stats */}
+      <div className="mb-10 grid grid-cols-3 gap-4">
+        <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-sm text-zinc-500">Enrolled</p>
+          <p className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+            {participants.length}
+          </p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-sm text-zinc-500">Active</p>
+          <p className="text-2xl font-bold text-green-600">{activeCount}</p>
+        </div>
+        <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <p className="text-sm text-zinc-500">Pods</p>
+          <p className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+            {pods?.length ?? 0}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-10">
+        {/* Status */}
+        <section>
+          <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            Cycle Status
+          </h2>
+          <CycleStatusForm cycleId={cycle.id} currentStatus={cycle.status} />
+        </section>
+
+        <hr className="border-zinc-200 dark:border-zinc-800" />
+
+        {/* Schedule */}
+        <section>
+          <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            Schedule
+          </h2>
+          <p className="mb-4 text-sm text-zinc-500">
+            Open and close times for each phase.
+          </p>
+          {config && <CycleScheduleForm cycleId={cycle.id} config={config} />}
+        </section>
+
+        <hr className="border-zinc-200 dark:border-zinc-800" />
+
+        {/* Parameters */}
+        <section>
+          <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            Parameters
+          </h2>
+          <p className="mb-4 text-sm text-zinc-500">
+            Voting thresholds and pod / project limits.
+          </p>
+          {config && <CycleParamsForm cycleId={cycle.id} config={config} />}
+        </section>
+
+        <hr className="border-zinc-200 dark:border-zinc-800" />
+
+        {/* Pod Voting */}
+        <section>
+          <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            Pod Voting
+          </h2>
+          <p className="mb-4 text-sm text-zinc-500">
+            Finalize problem-statement voting to create pods. Uses AI to
+            generate pod names.
+          </p>
+          <FinalizeVotingButton cycleId={cycle.id} />
+        </section>
+
+        {pods && pods.length > 0 && (
+          <>
+            <hr className="border-zinc-200 dark:border-zinc-800" />
+            <section>
+              <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+                Pods ({pods.length})
+              </h2>
+              <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
+                <table className="w-full text-sm">
+                  <thead className="bg-zinc-50 dark:bg-zinc-800">
+                    <tr>
+                      <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                        Pod
+                      </th>
+                      <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                        Status
+                      </th>
+                      <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                        Members
+                      </th>
+                      <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400" />
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-zinc-200 bg-white dark:divide-zinc-800 dark:bg-zinc-900">
+                    {pods.map((pod) => {
+                      const memberCount = (podMemberships ?? []).filter(
+                        (m) => m.pod_id === pod.id
+                      ).length;
+                      return (
+                        <tr key={pod.id}>
+                          <td className="px-4 py-3 font-medium text-zinc-900 dark:text-zinc-50">
+                            {pod.name ?? `Pod ${pod.id}`}
+                          </td>
+                          <td className="px-4 py-3">
+                            <span
+                              className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                                pod.status === "active"
+                                  ? "bg-green-100 text-green-800"
+                                  : pod.status === "forming"
+                                    ? "bg-blue-100 text-blue-800"
+                                    : "bg-zinc-100 text-zinc-600"
+                              }`}
+                            >
+                              {pod.status}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3 text-zinc-500">
+                            {memberCount}
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            <Link
+                              href={`/pods/${pod.id}`}
+                              className="text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+                            >
+                              View &rarr;
+                            </Link>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </>
+        )}
+
+        <hr className="border-zinc-200 dark:border-zinc-800" />
+
+        {/* Participants */}
+        <section>
+          <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            Participants ({participants.length})
+          </h2>
+          <ParticipantsTable participants={participants} />
+        </section>
+
+        <hr className="border-zinc-200 dark:border-zinc-800" />
+
+        {/* Revocations */}
+        <section>
+          <h2 className="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            Access Revocations
+          </h2>
+          <p className="mb-4 text-sm text-zinc-500">
+            Check for inactive participants and manage revocations.
+          </p>
+          <RevocationsSection
+            cycleId={cycle.id}
+            initialRevocations={revocations ?? []}
+            participants={participants}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import type { ParticipantRow } from "./page";
+
+export default function ParticipantsTable({
+  participants,
+}: {
+  participants: ParticipantRow[];
+}) {
+  const [grantedIds, setGrantedIds] = useState<Set<number>>(new Set());
+  const [loadingIds, setLoadingIds] = useState<Set<number>>(new Set());
+  const [errors, setErrors] = useState<Record<number, string>>({});
+
+  async function grantObserver(participantId: number) {
+    setLoadingIds((prev) => new Set(prev).add(participantId));
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next[participantId];
+      return next;
+    });
+
+    const res = await fetch("/api/roles/observer", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ participant_id: participantId }),
+    });
+
+    setLoadingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(participantId);
+      return next;
+    });
+
+    if (res.ok) {
+      setGrantedIds((prev) => new Set(prev).add(participantId));
+    } else {
+      const data = await res.json();
+      setErrors((prev) => ({
+        ...prev,
+        [participantId]: data.error ?? "Failed",
+      }));
+    }
+  }
+
+  if (participants.length === 0) {
+    return <p className="text-sm text-zinc-500">No participants enrolled.</p>;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
+      <table className="w-full text-sm">
+        <thead className="bg-zinc-50 dark:bg-zinc-800">
+          <tr>
+            <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+              Name
+            </th>
+            <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+              Email
+            </th>
+            <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+              Status
+            </th>
+            <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+              Pods
+            </th>
+            <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+              Role
+            </th>
+            <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-200 bg-white dark:divide-zinc-800 dark:bg-zinc-900">
+          {participants.map((p) => {
+            const displayName = p.preferred_name
+              ? `${p.preferred_name} ${p.last_name}`
+              : `${p.first_name} ${p.last_name}`;
+
+            const alreadyElevated = p.roles.some((r) =>
+              ["owner", "admin", "observer"].includes(r)
+            );
+            const justGranted = grantedIds.has(p.participant_id);
+
+            const topRole = p.roles.includes("owner")
+              ? "owner"
+              : p.roles.includes("admin")
+                ? "admin"
+                : p.roles.includes("observer")
+                  ? "observer"
+                  : null;
+
+            return (
+              <tr key={p.participant_id}>
+                <td className="px-4 py-3 font-medium text-zinc-900 dark:text-zinc-50">
+                  {displayName}
+                </td>
+                <td className="px-4 py-3 text-zinc-500">{p.email}</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                      p.status === "active"
+                        ? "bg-green-100 text-green-800"
+                        : p.status === "revoked"
+                          ? "bg-red-100 text-red-700"
+                          : "bg-zinc-100 text-zinc-600"
+                    }`}
+                  >
+                    {p.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-zinc-500">{p.pods.length}</td>
+                <td className="px-4 py-3">
+                  {(topRole ?? justGranted) && (
+                    <span className="rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900 dark:text-purple-200">
+                      {justGranted && !topRole ? "observer" : topRole}
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {errors[p.participant_id] && (
+                    <span className="mr-2 text-xs text-red-600">
+                      {errors[p.participant_id]}
+                    </span>
+                  )}
+                  {!alreadyElevated && !justGranted && (
+                    <button
+                      onClick={() => grantObserver(p.participant_id)}
+                      disabled={loadingIds.has(p.participant_id)}
+                      className="rounded px-2.5 py-1 text-xs font-medium text-zinc-600 ring-1 ring-zinc-300 hover:bg-zinc-50 disabled:opacity-50 dark:text-zinc-400 dark:ring-zinc-700 dark:hover:bg-zinc-800"
+                    >
+                      {loadingIds.has(p.participant_id) ? "…" : "Grant Observer"}
+                    </button>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/cycles/[cycle_id]/revocations-section.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/revocations-section.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { ParticipantRow } from "./page";
+
+type Revocation = {
+  participant_id: number;
+  reason: string;
+  revocation_scope: string;
+  revoked_at: string;
+  revoked_systems: string[];
+};
+
+const REASON_LABELS: Record<string, string> = {
+  not_in_pod: "Not in pod",
+  missed_pulse_checks: "Missed pulse checks",
+  reactivated: "Reactivated",
+};
+
+export default function RevocationsSection({
+  cycleId,
+  initialRevocations,
+  participants,
+}: {
+  cycleId: number;
+  initialRevocations: Revocation[];
+  participants: ParticipantRow[];
+}) {
+  const [revocations, setRevocations] = useState(initialRevocations);
+  const [checkLoading, setCheckLoading] = useState(false);
+  const [checkResult, setCheckResult] = useState<{
+    count: number;
+  } | null>(null);
+  const [checkError, setCheckError] = useState<string | null>(null);
+  const [reactivatingIds, setReactivatingIds] = useState<Set<number>>(
+    new Set()
+  );
+  const [reactivatedIds, setReactivatedIds] = useState<Set<number>>(new Set());
+  const [reactivateErrors, setReactivateErrors] = useState<
+    Record<number, string>
+  >({});
+  const router = useRouter();
+
+  const nameMap = new Map(
+    participants.map((p) => [
+      p.participant_id,
+      p.preferred_name
+        ? `${p.preferred_name} ${p.last_name}`
+        : `${p.first_name} ${p.last_name}`,
+    ])
+  );
+
+  async function runCheck() {
+    if (
+      !confirm(
+        "Run inactivity check? This may revoke access for inactive participants."
+      )
+    )
+      return;
+
+    setCheckLoading(true);
+    setCheckError(null);
+    setCheckResult(null);
+
+    const res = await fetch(`/api/revocations/check/${cycleId}`, {
+      method: "POST",
+    });
+    setCheckLoading(false);
+
+    if (res.ok) {
+      const data = await res.json();
+      const count = data.transitioned_to_inactive?.length ?? 0;
+      setCheckResult({ count });
+
+      // Refresh revocations list
+      const revRes = await fetch(`/api/revocations/${cycleId}`);
+      if (revRes.ok) setRevocations(await revRes.json());
+      if (count > 0) router.refresh();
+    } else {
+      const data = await res.json();
+      setCheckError(data.error ?? "Check failed");
+    }
+  }
+
+  async function reactivate(participantId: number) {
+    setReactivatingIds((prev) => new Set(prev).add(participantId));
+    setReactivateErrors((prev) => {
+      const next = { ...prev };
+      delete next[participantId];
+      return next;
+    });
+
+    const res = await fetch(`/api/revocations/reactivate/${participantId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cycle_id: cycleId }),
+    });
+
+    setReactivatingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(participantId);
+      return next;
+    });
+
+    if (res.ok) {
+      setReactivatedIds((prev) => new Set(prev).add(participantId));
+      router.refresh();
+    } else {
+      const data = await res.json();
+      setReactivateErrors((prev) => ({
+        ...prev,
+        [participantId]: data.error ?? "Failed",
+      }));
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <button
+          onClick={runCheck}
+          disabled={checkLoading}
+          className="rounded-lg border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+        >
+          {checkLoading ? "Checking…" : "Run Inactivity Check"}
+        </button>
+        {checkResult && (
+          <span className="text-sm text-zinc-600 dark:text-zinc-400">
+            {checkResult.count === 0
+              ? "No new revocations."
+              : `${checkResult.count} participant${checkResult.count !== 1 ? "s" : ""} revoked.`}
+          </span>
+        )}
+        {checkError && (
+          <span className="text-sm text-red-600">{checkError}</span>
+        )}
+      </div>
+
+      {revocations.length === 0 ? (
+        <p className="text-sm text-zinc-500">No revocations for this cycle.</p>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
+          <table className="w-full text-sm">
+            <thead className="bg-zinc-50 dark:bg-zinc-800">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                  Participant
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                  Reason
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                  Revoked
+                </th>
+                <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-200 bg-white dark:divide-zinc-800 dark:bg-zinc-900">
+              {revocations.map((rev, i) => {
+                const name =
+                  nameMap.get(rev.participant_id) ??
+                  `Participant ${rev.participant_id}`;
+                const isReactivated = reactivatedIds.has(rev.participant_id);
+                return (
+                  <tr key={i}>
+                    <td className="px-4 py-3 text-zinc-900 dark:text-zinc-50">
+                      {name}
+                    </td>
+                    <td className="px-4 py-3 text-zinc-500">
+                      {REASON_LABELS[rev.reason] ?? rev.reason}
+                    </td>
+                    <td className="px-4 py-3 text-zinc-500">
+                      {new Date(rev.revoked_at).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {reactivateErrors[rev.participant_id] && (
+                        <span className="mr-2 text-xs text-red-600">
+                          {reactivateErrors[rev.participant_id]}
+                        </span>
+                      )}
+                      {isReactivated ? (
+                        <span className="text-xs text-green-600">
+                          Reactivated
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => reactivate(rev.participant_id)}
+                          disabled={reactivatingIds.has(rev.participant_id)}
+                          className="rounded px-2.5 py-1 text-xs font-medium text-zinc-600 ring-1 ring-zinc-300 hover:bg-zinc-50 disabled:opacity-50 dark:text-zinc-400 dark:ring-zinc-700 dark:hover:bg-zinc-800"
+                        >
+                          {reactivatingIds.has(rev.participant_id)
+                            ? "…"
+                            : "Reactivate"}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/cycles/create-cycle-form.tsx
+++ b/app/(dashboard)/admin/cycles/create-cycle-form.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function CreateCycleForm() {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    const fd = new FormData(e.currentTarget);
+    setLoading(true);
+
+    const res = await fetch("/api/cycles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: fd.get("name"),
+        start_date: new Date(fd.get("start_date") as string).toISOString(),
+        end_date: new Date(fd.get("end_date") as string).toISOString(),
+      }),
+    });
+
+    setLoading(false);
+    if (res.ok) {
+      const cycle = await res.json();
+      router.push(`/admin/cycles/${cycle.id}`);
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to create cycle");
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        + New Cycle
+      </button>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-700 dark:bg-zinc-900"
+    >
+      <h2 className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+        New Cycle
+      </h2>
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-zinc-500">Name</label>
+          <input
+            name="name"
+            required
+            placeholder="e.g. Spring 2026"
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-zinc-500">Start date</label>
+          <input
+            name="start_date"
+            type="date"
+            required
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-zinc-500">End date</label>
+          <input
+            name="end_date"
+            type="date"
+            required
+            className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-lg bg-zinc-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          {loading ? "Creating…" : "Create"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            setError(null);
+          }}
+          className="text-sm text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+        >
+          Cancel
+        </button>
+      </div>
+      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+    </form>
+  );
+}

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
+import CreateCycleForm from "./cycles/create-cycle-form";
+
+export default async function AdminPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const serviceClient = createServiceClient();
+  const userRoles = await resolveUserRoles(serviceClient, user.id);
+  if (!isAdmin(userRoles)) redirect("/cycles");
+
+  const { data: cycles } = await serviceClient
+    .from("cycles")
+    .select("id, name, start_date, end_date, status")
+    .order("start_date", { ascending: false });
+
+  const { data: enrollmentRows } = await serviceClient
+    .from("cycle_enrollments")
+    .select("cycle_id, status");
+
+  const countsByCycle = new Map<number, { total: number; active: number }>();
+  for (const e of enrollmentRows || []) {
+    const curr = countsByCycle.get(e.cycle_id) ?? { total: 0, active: 0 };
+    countsByCycle.set(e.cycle_id, {
+      total: curr.total + 1,
+      active: curr.active + (e.status === "active" ? 1 : 0),
+    });
+  }
+
+  return (
+    <div>
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+            Admin
+          </h1>
+          <p className="mt-1 text-sm text-zinc-500">
+            {cycles?.length ?? 0} cycle{cycles?.length !== 1 ? "s" : ""} total
+          </p>
+        </div>
+        <CreateCycleForm />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
+        <table className="w-full text-sm">
+          <thead className="bg-zinc-50 dark:bg-zinc-800">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                Cycle
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                Status
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                Dates
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-zinc-600 dark:text-zinc-400">
+                Participants
+              </th>
+              <th className="px-4 py-3 text-right font-medium text-zinc-600 dark:text-zinc-400" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-200 bg-white dark:divide-zinc-800 dark:bg-zinc-900">
+            {(cycles ?? []).map((cycle) => {
+              const counts = countsByCycle.get(cycle.id) ?? {
+                total: 0,
+                active: 0,
+              };
+              return (
+                <tr key={cycle.id}>
+                  <td className="px-4 py-3 font-medium text-zinc-900 dark:text-zinc-50">
+                    {cycle.name}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                        cycle.status === "active"
+                          ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                          : cycle.status === "closed"
+                            ? "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+                            : "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
+                      }`}
+                    >
+                      {cycle.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-zinc-500">
+                    {new Date(cycle.start_date).toLocaleDateString()} &ndash;{" "}
+                    {new Date(cycle.end_date).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 text-zinc-500">
+                    {counts.active} active / {counts.total} enrolled
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <Link
+                      href={`/admin/cycles/${cycle.id}`}
+                      className="text-sm font-medium text-zinc-700 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
+                    >
+                      Manage &rarr;
+                    </Link>
+                  </td>
+                </tr>
+              );
+            })}
+            {(!cycles || cycles.length === 0) && (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-4 py-8 text-center text-zinc-500"
+                >
+                  No cycles yet. Create one to get started.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
 
 export default async function DashboardLayout({
   children,
@@ -23,6 +24,9 @@ export default async function DashboardLayout({
     .select("preferred_name, first_name, last_name")
     .eq("auth_user_id", user.id)
     .maybeSingle();
+
+  const userRoles = await resolveUserRoles(serviceClient, user.id);
+  const adminUser = isAdmin(userRoles);
 
   const displayName =
     participant?.preferred_name ||
@@ -59,6 +63,14 @@ export default async function DashboardLayout({
             >
               Pulse Check
             </Link>
+            {adminUser && (
+              <Link
+                href="/admin"
+                className="text-sm text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+              >
+                Admin
+              </Link>
+            )}
             <Link
               href="/profile"
               className="flex items-center gap-2 text-sm text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"


### PR DESCRIPTION
- Admin nav link in dashboard header (visible to owners/admins only)
- /admin overview: cycle list with enrollment counts + create cycle form
- /admin/cycles/[id]: cycle detail with status advancement, schedule/params config forms, participants table (with observer grant), pod voting finalization, pods list, and access revocations (check + reactivate)

https://claude.ai/code/session_015CZDDV9PoXxXUxEN13gEZz