### PR TITLE
Refine brand design: restrained editorial aesthetic per OLOS PRD

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -15,7 +15,7 @@ export default function LoginPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-sm space-y-6 rounded-2xl border border-white/[0.05] bg-white/[0.02] p-8 backdrop-blur-sm">
+      <div className="w-full max-w-sm space-y-6 rounded-md border border-whisper bg-white/[0.02] p-8">
         <div className="text-center">
           <h1 className="text-2xl font-bold tracking-tight text-white">
             The Upskilling Labs
@@ -26,7 +26,7 @@ export default function LoginPage() {
         </div>
         <button
           onClick={handleLogin}
-          className="flex w-full items-center justify-center gap-3 rounded-full border border-white/20 bg-white/[0.05] px-4 py-3 text-sm font-medium text-white transition-all hover:border-aqua hover:text-aqua"
+          className="flex w-full items-center justify-center gap-3 rounded-md border border-white/[0.12] bg-white/[0.03] px-4 py-3 text-sm font-medium text-white transition-colors hover:border-aqua hover:text-aqua"
         >
           <svg className="h-5 w-5" viewBox="0 0 24 24">
             <path

--- a/app/(auth)/register/register-form.tsx
+++ b/app/(auth)/register/register-form.tsx
@@ -91,7 +91,7 @@ export default function RegisterForm({
   return (
     <>
       {error && (
-        <div className="mb-4 rounded-xl border border-red/20 bg-red/10 p-3 text-sm text-red-300">
+        <div className="mb-4 rounded-md border border-red/20 bg-red/10 p-3 text-sm text-red-300">
           {error}
         </div>
       )}
@@ -109,7 +109,7 @@ export default function RegisterForm({
               <input
                 name="first_name"
                 required
-                className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+                className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
               />
             </label>
             <label className="block">
@@ -119,7 +119,7 @@ export default function RegisterForm({
               <input
                 name="last_name"
                 required
-                className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+                className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
               />
             </label>
           </div>
@@ -130,7 +130,7 @@ export default function RegisterForm({
             <input
               value={email}
               readOnly
-              className="mt-1 block w-full rounded-xl border border-white/[0.05] bg-white/[0.03] px-3 py-2 text-sm text-cloud/60"
+              className="mt-1 block w-full rounded-md border border-white/[0.05] bg-white/[0.03] px-3 py-2 text-sm text-cloud/60"
             />
           </label>
           <label className="block">
@@ -139,7 +139,7 @@ export default function RegisterForm({
             </span>
             <input
               name="preferred_name"
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             />
           </label>
           <label className="block">
@@ -148,7 +148,7 @@ export default function RegisterForm({
             </span>
             <input
               name="gender"
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             />
           </label>
         </fieldset>
@@ -164,7 +164,7 @@ export default function RegisterForm({
             <select
               name="state"
               required
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white"
             >
               <option value="">Select...</option>
               <option value="MD">Maryland</option>
@@ -180,7 +180,7 @@ export default function RegisterForm({
             <input
               name="neighborhood"
               required
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             />
           </label>
         </fieldset>
@@ -196,7 +196,7 @@ export default function RegisterForm({
             <select
               name="dcpl_card"
               required
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white"
             >
               <option value="">Select...</option>
               <option value="yes">Yes</option>
@@ -217,7 +217,7 @@ export default function RegisterForm({
             <select
               name="work_situation"
               required
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white"
             >
               <option value="">Select...</option>
               <option value="employed full time">Employed full time</option>
@@ -240,7 +240,7 @@ export default function RegisterForm({
             <select
               name="main_focus"
               required
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white"
             >
               <option value="">Select...</option>
               <option value="finding a new role">Finding a new role</option>
@@ -264,7 +264,7 @@ export default function RegisterForm({
             </span>
             <input
               name="sector"
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             />
           </label>
           <label className="block">
@@ -273,7 +273,7 @@ export default function RegisterForm({
             </span>
             <input
               name="current_title"
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             />
           </label>
           <label className="block">
@@ -283,7 +283,7 @@ export default function RegisterForm({
             <input
               name="linkedin"
               type="url"
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             />
           </label>
         </fieldset>
@@ -302,7 +302,7 @@ export default function RegisterForm({
               min={1}
               max={5}
               required
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             />
           </label>
           {options.ai_tools && (
@@ -427,7 +427,7 @@ export default function RegisterForm({
             </span>
             <select
               name="participation_commitment"
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white"
             >
               <option value="">Select...</option>
               <option value="yes">Yes</option>
@@ -440,7 +440,7 @@ export default function RegisterForm({
             </span>
             <input
               name="primary_expertise"
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             />
           </label>
           <label className="block">
@@ -449,7 +449,7 @@ export default function RegisterForm({
             </span>
             <input
               name="volunteer_interest"
-              className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+              className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             />
           </label>
         </fieldset>
@@ -484,7 +484,7 @@ export default function RegisterForm({
         <button
           type="submit"
           disabled={submitting}
-          className="w-full rounded-full bg-aqua px-6 py-3 text-sm font-semibold text-midnight transition-transform hover:scale-105 disabled:opacity-50 disabled:hover:scale-100"
+          className="w-full rounded-md bg-aqua px-6 py-3 text-sm font-semibold text-midnight transition-colors hover:bg-teal disabled:opacity-50"
         >
           {submitting ? "Submitting..." : "Become an Upskiller"}
         </button>

--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -64,17 +64,17 @@ export default async function CycleDetailPage({
       </div>
 
       <div className="mb-8 grid gap-4 sm:grid-cols-3">
-        <div className="rounded-2xl border border-white/[0.05] bg-white/[0.02] p-4 backdrop-blur-sm">
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-4">
           <p className="text-sm text-cloud/60">Total Enrolled</p>
           <p className="text-2xl font-bold text-white">
             {enrollments?.length || 0}
           </p>
         </div>
-        <div className="rounded-2xl border border-white/[0.05] bg-white/[0.02] p-4 backdrop-blur-sm">
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-4">
           <p className="text-sm text-cloud/60">Active</p>
           <p className="text-2xl font-bold text-aqua">{activeCount}</p>
         </div>
-        <div className="rounded-2xl border border-white/[0.05] bg-white/[0.02] p-4 backdrop-blur-sm">
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-4">
           <p className="text-sm text-cloud/60">Pods</p>
           <p className="text-2xl font-bold text-white">
             {pods?.length || 0}
@@ -92,7 +92,7 @@ export default async function CycleDetailPage({
               <Link
                 key={pod.id}
                 href={`/pods/${pod.id}`}
-                className="rounded-2xl border border-white/[0.05] bg-white/[0.02] p-4 backdrop-blur-sm transition-all hover:border-white/10 hover:bg-white/[0.04]"
+                className="rounded-md border border-whisper bg-white/[0.02] p-4 transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]"
               >
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-white">

--- a/app/(dashboard)/cycles/page.tsx
+++ b/app/(dashboard)/cycles/page.tsx
@@ -22,7 +22,7 @@ export default async function CyclesPage() {
             <Link
               key={cycle.id}
               href={`/cycles/${cycle.id}`}
-              className="rounded-2xl border border-white/[0.05] bg-white/[0.02] p-6 backdrop-blur-sm transition-all hover:border-white/10 hover:bg-white/[0.04]"
+              className="rounded-md border border-whisper bg-white/[0.02] p-6 transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]"
             >
               <div className="flex items-start justify-between">
                 <h2 className="text-lg font-semibold text-white">

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -38,8 +38,8 @@ export default async function DashboardLayout({
 
   return (
     <div className="flex min-h-screen flex-col">
-      <header className="sticky top-0 z-50 border-b border-white/5 bg-midnight/85 backdrop-blur-lg">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
+      <header className="sticky top-0 z-50 border-b border-whisper bg-[rgba(11,16,22,0.97)]">
+        <div className="mx-auto flex h-[60px] max-w-7xl items-center justify-between px-4">
           <Link
             href="/cycles"
             className="text-lg font-bold text-white"
@@ -70,7 +70,7 @@ export default async function DashboardLayout({
                   className="h-7 w-7 rounded-full"
                 />
               ) : (
-                <span className="flex h-7 w-7 items-center justify-center rounded-full bg-shadow text-xs font-medium text-cloud">
+                <span className="flex h-7 w-7 items-center justify-center rounded bg-shadow text-xs font-medium text-cloud">
                   {initials}
                 </span>
               )}

--- a/app/(dashboard)/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/pods/[pod_id]/page.tsx
@@ -62,8 +62,8 @@ export default async function PodDetailPage({
       </div>
 
       {ps?.statement_text && (
-        <div className="mb-6 rounded-2xl border border-white/[0.05] bg-white/[0.02] p-4 backdrop-blur-sm">
-          <h3 className="mb-1 text-sm font-medium text-cloud/60">
+        <div className="mb-6 rounded-md border-l-2 border-l-teal border border-whisper bg-white/[0.02] p-4">
+          <h3 className="mb-1 text-sm font-medium text-muted">
             Problem Statement
           </h3>
           <p className="text-white">
@@ -76,28 +76,28 @@ export default async function PodDetailPage({
         <h2 className="mb-3 text-lg font-semibold text-white">
           Members ({members?.length || 0})
         </h2>
-        <div className="overflow-hidden rounded-2xl border border-white/[0.05]">
+        <div className="overflow-hidden rounded-md border border-whisper">
           <table className="w-full text-left text-sm">
-            <thead className="bg-white/[0.05]">
+            <thead className="bg-teal/[0.08]">
               <tr>
-                <th className="px-4 py-2 font-medium text-cloud/80">
+                <th className="px-4 py-2 text-xs font-semibold text-aqua">
                   Name
                 </th>
-                <th className="px-4 py-2 font-medium text-cloud/80">
+                <th className="px-4 py-2 text-xs font-semibold text-aqua">
                   Status
                 </th>
-                <th className="px-4 py-2 font-medium text-cloud/80">
+                <th className="px-4 py-2 text-xs font-semibold text-aqua">
                   Joined
                 </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-white/[0.05]">
+            <tbody className="divide-y divide-whisper">
               {(members || []).map((m) => {
                 const p = (m.participants as unknown) as Record<string, string> | null;
                 return (
                   <tr
                     key={m.participant_id}
-                    className="bg-white/[0.02]"
+                    className="bg-white/[0.01]"
                   >
                     <td className="px-4 py-2 text-white">
                       {p?.preferred_name || p?.first_name} {p?.last_name}
@@ -133,7 +133,7 @@ export default async function PodDetailPage({
             {projects.map((project) => (
               <div
                 key={project.id}
-                className="rounded-2xl border border-white/[0.05] bg-white/[0.02] p-4 backdrop-blur-sm"
+                className="rounded-md border border-whisper bg-white/[0.02] p-4"
               >
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-white">

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -51,9 +51,9 @@ export default async function ProfilePage() {
 
   return (
     <div className="mx-auto max-w-3xl">
-      <div className="rounded-2xl border border-white/[0.05] bg-white/[0.02] p-8 backdrop-blur-sm">
+      <div className="rounded-md border border-whisper bg-white/[0.02] p-8">
         {/* Header with avatar */}
-        <div className="flex items-center gap-6 border-b border-white/[0.05] pb-6">
+        <div className="flex items-center gap-6 border-b border-whisper pb-6">
           {avatarUrl ? (
             <img
               src={avatarUrl}
@@ -61,7 +61,7 @@ export default async function ProfilePage() {
               className="h-20 w-20 rounded-full"
             />
           ) : (
-            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-shadow text-2xl font-bold text-cloud">
+            <div className="flex h-20 w-20 items-center justify-center rounded-md bg-shadow text-2xl font-bold text-cloud">
               {participant.first_name[0]}
               {participant.last_name[0]}
             </div>

--- a/app/(dashboard)/pulse-check/page.tsx
+++ b/app/(dashboard)/pulse-check/page.tsx
@@ -186,11 +186,11 @@ export default function PulseCheckPage() {
 
       {/* Mode toggle — only shown when the user has active cycles */}
       {hasCycles && (
-        <div className="mb-6 flex rounded-xl border border-white/10 p-1">
+        <div className="mb-6 flex rounded-md border border-whisper p-1">
           <button
             type="button"
             onClick={() => setMode("cycle")}
-            className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+            className={`flex-1 rounded px-3 py-2 text-sm font-medium transition-colors ${
               mode === "cycle"
                 ? "bg-aqua text-midnight"
                 : "text-cloud/60 hover:text-aqua"
@@ -201,7 +201,7 @@ export default function PulseCheckPage() {
           <button
             type="button"
             onClick={() => setMode("standalone")}
-            className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+            className={`flex-1 rounded px-3 py-2 text-sm font-medium transition-colors ${
               mode === "standalone"
                 ? "bg-aqua text-midnight"
                 : "text-cloud/60 hover:text-aqua"
@@ -221,7 +221,7 @@ export default function PulseCheckPage() {
           <select
             value={selectedCycleId ?? ""}
             onChange={(e) => setSelectedCycleId(Number(e.target.value))}
-            className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white"
+            className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white"
           >
             {enrollments.map((en) => (
               <option key={en.cycle_id} value={en.cycle_id}>
@@ -233,20 +233,20 @@ export default function PulseCheckPage() {
       )}
 
       {success && (
-        <div className="mb-4 rounded-xl border border-teal/20 bg-teal/10 p-3 text-sm text-aqua">
+        <div className="mb-4 rounded-md border border-teal/20 bg-teal/10 p-3 text-sm text-aqua">
           Pulse check submitted successfully!
         </div>
       )}
 
       {error && (
-        <div className="mb-4 rounded-xl border border-red/20 bg-red/10 p-3 text-sm text-red-300">
+        <div className="mb-4 rounded-md border border-red/20 bg-red/10 p-3 text-sm text-red-300">
           {error}
         </div>
       )}
 
       <form
         onSubmit={handleSubmit}
-        className="space-y-6 rounded-2xl border border-white/[0.05] bg-white/[0.02] p-6 backdrop-blur-sm"
+        className="space-y-6 rounded-md border border-whisper bg-white/[0.02] p-6"
       >
         {/* === Reflective fields (both modes) === */}
 
@@ -264,10 +264,10 @@ export default function PulseCheckPage() {
                   key={level}
                   type="button"
                   onClick={() => setEnergyLevel(selected ? null : level)}
-                  className={`flex flex-1 flex-col items-center rounded-lg border px-2 py-2 text-xs transition-colors ${
+                  className={`flex flex-1 flex-col items-center rounded-md border px-2 py-2 text-xs transition-colors ${
                     selected
                       ? "border-aqua bg-aqua text-midnight"
-                      : "border-white/10 text-cloud/60 hover:border-white/20"
+                      : "border-whisper text-cloud/60 hover:border-white/[0.15]"
                   }`}
                 >
                   <span className="text-base font-semibold">{level}</span>
@@ -288,7 +288,7 @@ export default function PulseCheckPage() {
             required
             maxLength={1000}
             rows={4}
-            className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+            className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             placeholder="Describe your progress, wins, or what you worked on..."
           />
         </label>
@@ -302,7 +302,7 @@ export default function PulseCheckPage() {
             name="highlight"
             maxLength={1000}
             rows={2}
-            className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+            className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             placeholder="A win, a moment of clarity, something that made you smile..."
           />
         </label>
@@ -316,7 +316,7 @@ export default function PulseCheckPage() {
             name="challenge"
             maxLength={1000}
             rows={2}
-            className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+            className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
             placeholder="Anything blocking you, frustrating you, or keeping you up at night..."
           />
         </label>
@@ -378,7 +378,7 @@ export default function PulseCheckPage() {
                 name="new_connections"
                 type="number"
                 min={0}
-                className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+                className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
                 placeholder="Number of new collaborators you met"
               />
             </label>
@@ -391,7 +391,7 @@ export default function PulseCheckPage() {
                 name="help_needed"
                 maxLength={1000}
                 rows={3}
-                className="mt-1 block w-full rounded-xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+                className="mt-1 block w-full rounded-md border border-white/[0.1] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
                 placeholder="Describe any support or resources you need..."
               />
             </label>
@@ -424,7 +424,7 @@ export default function PulseCheckPage() {
         <button
           type="submit"
           disabled={submitting}
-          className="w-full rounded-full bg-aqua px-6 py-3 text-sm font-semibold text-midnight transition-transform hover:scale-105 disabled:opacity-50 disabled:hover:scale-100"
+          className="w-full rounded-md bg-aqua px-6 py-3 text-sm font-semibold text-midnight transition-colors hover:bg-teal disabled:opacity-50"
         >
           {submitting ? "Submitting..." : "Submit Pulse Check"}
         </button>
@@ -440,7 +440,7 @@ export default function PulseCheckPage() {
             {history.map((entry) => (
               <div
                 key={entry.scheduled_date}
-                className="rounded-2xl border border-white/[0.05] bg-white/[0.02] p-4 backdrop-blur-sm"
+                className="rounded-md border border-whisper bg-white/[0.02] p-4"
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 @theme inline {
-  --color-midnight: #101820;
+  --color-midnight: #0b1016;
   --color-teal: #0094a0;
   --color-red: #ee1c25;
   --color-aqua: #4dbbc2;
@@ -9,14 +9,16 @@
   --color-crimson: #7a0f14;
   --color-cloud: #e6e6e6;
   --color-ghost: #ffffff;
+  --color-muted: rgba(255,255,255,0.3);
+  --color-whisper: rgba(255,255,255,0.07);
   --font-sans: 'Geologica', sans-serif;
 }
 
 body {
-  background-color: #101820;
-  background-image: radial-gradient(100% 150% at 50% 0%, #006b73 0%, #101820 80%);
+  background-color: #0b1016;
+  background-image: radial-gradient(ellipse 80% 60% at 50% 0%, rgba(0,148,160,0.07) 0%, transparent 70%);
   background-attachment: fixed;
-  color: #e6e6e6;
+  color: rgba(255,255,255,0.65);
   font-family: 'Geologica', sans-serif;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Replace glassmorphic/frosted design with a cleaner editorial look:
- Darker background (#0b1016), subtle teal radial glow instead of heavy gradient
- 6px border radius (rounded-md) throughout, replacing rounded-2xl
- Remove all backdrop-blur effects from cards and forms
- Whisper borders (rgba 0.07) for cards, tables, and dividers
- Teal-tinted table headers with aqua text
- Problem statement callout with 2px left teal bar
- Solid nav background (rgba 0.97) with fixed 60px height
- Restrained buttons (rounded-md, color hover instead of scale transform)
- Muted text token for tertiary content

https://claude.ai/code/session_018jXSoXCxSBeqUwkCHxjDJ3