### PR TITLE
Add quarterly cycle phase indicator to participant dashboard

### DIFF
--- a/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
@@ -14,6 +14,8 @@ type Config = {
   max_projects: number;
   project_min: number;
   project_max: number;
+  phase_2_start: string | null;
+  phase_3_start: string | null;
   problem_statement_open: string | null;
   problem_statement_close: string | null;
   voting_open: string | null;
@@ -89,6 +91,8 @@ export function CycleScheduleForm({
     const fd = new FormData(e.currentTarget);
 
     const body: Record<string, string | null> = {};
+    body.phase_2_start = fromLocal(fd.get("phase_2_start") as string);
+    body.phase_3_start = fromLocal(fd.get("phase_3_start") as string);
     for (const phase of PHASES) {
       body[phase.open] = fromLocal(fd.get(phase.open) as string);
       body[phase.close] = fromLocal(fd.get(phase.close) as string);
@@ -113,6 +117,46 @@ export function CycleScheduleForm({
 
   return (
     <form onSubmit={handleSubmit}>
+      {/* Cycle phase milestones */}
+      <div className="mb-6 rounded-lg border border-zinc-200 p-4 dark:border-zinc-800 dark:bg-zinc-900/50">
+        <h3 className="mb-3 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+          Cycle Phases
+        </h3>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label
+              htmlFor="phase_2_start"
+              className="mb-1 block text-sm text-zinc-600 dark:text-zinc-400"
+            >
+              Meet The Pods (Phase 1 &rarr; 2)
+            </label>
+            <input
+              id="phase_2_start"
+              type="datetime-local"
+              name="phase_2_start"
+              defaultValue={toLocal(config.phase_2_start)}
+              className="w-full rounded-md border border-zinc-300 px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="phase_3_start"
+              className="mb-1 block text-sm text-zinc-600 dark:text-zinc-400"
+            >
+              Meet The Projects (Phase 2 &rarr; 3)
+            </label>
+            <input
+              id="phase_3_start"
+              type="datetime-local"
+              name="phase_3_start"
+              defaultValue={toLocal(config.phase_3_start)}
+              className="w-full rounded-md border border-zinc-300 px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Operational windows */}
       <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
         <table className="w-full text-sm">
           <thead className="bg-zinc-50 dark:bg-zinc-800">

--- a/app/(dashboard)/cycles/cycle-phase-indicator.tsx
+++ b/app/(dashboard)/cycles/cycle-phase-indicator.tsx
@@ -1,0 +1,263 @@
+type CycleConfig = {
+  phase_2_start: string | null;
+  phase_3_start: string | null;
+  problem_statement_open: string | null;
+  problem_statement_close: string | null;
+  voting_open: string | null;
+  voting_close: string | null;
+  pod_registration_open: string | null;
+  pod_registration_close: string | null;
+  solution_proposal_open: string | null;
+  solution_proposal_close: string | null;
+  solution_voting_open: string | null;
+  solution_voting_close: string | null;
+  project_registration_open: string | null;
+  project_registration_close: string | null;
+};
+
+type Cycle = {
+  name: string;
+  start_date: string;
+  end_date: string;
+};
+
+const OPERATIONAL_WINDOWS = [
+  { label: "Problem Statements", field: "problem_statement" },
+  { label: "Voting", field: "voting" },
+  { label: "Pod Registration", field: "pod_registration" },
+  { label: "Solution Proposals", field: "solution_proposal" },
+  { label: "Solution Voting", field: "solution_voting" },
+  { label: "Project Registration", field: "project_registration" },
+] as const;
+
+type WindowField = (typeof OPERATIONAL_WINDOWS)[number]["field"];
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function getCurrentPhase(
+  now: Date,
+  startDate: Date,
+  phase2Start: Date,
+  phase3Start: Date,
+  endDate: Date
+): number {
+  if (now < startDate) return 0; // before cycle
+  if (now < phase2Start) return 1;
+  if (now < phase3Start) return 2;
+  if (now <= endDate) return 3;
+  return 4; // after cycle
+}
+
+function getActiveWindows(
+  config: CycleConfig,
+  now: Date
+): { label: string; closesAt: string }[] {
+  const active: { label: string; closesAt: string }[] = [];
+  for (const w of OPERATIONAL_WINDOWS) {
+    const openKey = `${w.field}_open` as keyof CycleConfig;
+    const closeKey = `${w.field}_close` as keyof CycleConfig;
+    const openVal = config[openKey];
+    const closeVal = config[closeKey];
+    if (openVal && closeVal) {
+      const openDate = new Date(openVal);
+      const closeDate = new Date(closeVal);
+      if (now >= openDate && now <= closeDate) {
+        active.push({ label: w.label, closesAt: closeVal });
+      }
+    }
+  }
+  return active;
+}
+
+function getUpcomingWindow(
+  config: CycleConfig,
+  now: Date
+): { label: string; opensAt: string } | null {
+  for (const w of OPERATIONAL_WINDOWS) {
+    const openKey = `${w.field}_open` as keyof CycleConfig;
+    const openVal = config[openKey];
+    if (openVal && new Date(openVal) > now) {
+      return { label: w.label, opensAt: openVal };
+    }
+  }
+  return null;
+}
+
+const PHASES = [
+  { number: 1, name: "Phase 1", milestone: "Meet The Pods" },
+  { number: 2, name: "Phase 2", milestone: "Meet The Projects" },
+  { number: 3, name: "Phase 3", milestone: "Demo Day" },
+];
+
+export default function CyclePhaseIndicator({
+  cycle,
+  config,
+}: {
+  cycle: Cycle;
+  config: CycleConfig;
+}) {
+  if (!config.phase_2_start || !config.phase_3_start) {
+    return null;
+  }
+
+  const now = new Date();
+  const startDate = new Date(cycle.start_date);
+  const phase2Start = new Date(config.phase_2_start);
+  const phase3Start = new Date(config.phase_3_start);
+  const endDate = new Date(cycle.end_date);
+
+  const currentPhase = getCurrentPhase(
+    now,
+    startDate,
+    phase2Start,
+    phase3Start,
+    endDate
+  );
+
+  // Progress within the full cycle (0–100)
+  const totalDuration = endDate.getTime() - startDate.getTime();
+  const elapsed = Math.max(0, Math.min(now.getTime() - startDate.getTime(), totalDuration));
+  const overallProgress = totalDuration > 0 ? (elapsed / totalDuration) * 100 : 0;
+
+  // Phase boundary positions as percentages of the full bar
+  const phase2Pct =
+    totalDuration > 0
+      ? ((phase2Start.getTime() - startDate.getTime()) / totalDuration) * 100
+      : 33;
+  const phase3Pct =
+    totalDuration > 0
+      ? ((phase3Start.getTime() - startDate.getTime()) / totalDuration) * 100
+      : 66;
+
+  const activeWindows = getActiveWindows(config, now);
+  const upcomingWindow =
+    activeWindows.length === 0 ? getUpcomingWindow(config, now) : null;
+
+  return (
+    <div className="mb-8 rounded-lg border border-whisper bg-white/[0.02] p-5">
+      {/* Header */}
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-white">{cycle.name}</h2>
+        {currentPhase >= 1 && currentPhase <= 3 && (
+          <span className="rounded-full bg-teal/20 px-3 py-1 text-xs font-medium text-aqua">
+            {PHASES[currentPhase - 1].name}
+          </span>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      <div className="relative mb-2 h-2.5 w-full overflow-hidden rounded-full bg-white/[0.06]">
+        {/* Filled progress */}
+        <div
+          className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-teal to-aqua transition-all"
+          style={{ width: `${overallProgress}%` }}
+        />
+        {/* Phase boundary markers */}
+        <div
+          className="absolute inset-y-0 w-px bg-white/30"
+          style={{ left: `${phase2Pct}%` }}
+        />
+        <div
+          className="absolute inset-y-0 w-px bg-white/30"
+          style={{ left: `${phase3Pct}%` }}
+        />
+      </div>
+
+      {/* Phase labels row */}
+      <div className="relative mb-4 flex text-xs">
+        {/* Phase 1 */}
+        <div style={{ width: `${phase2Pct}%` }} className="pr-2">
+          <span
+            className={
+              currentPhase === 1
+                ? "font-semibold text-aqua"
+                : currentPhase > 1
+                  ? "text-cloud/40"
+                  : "text-cloud/60"
+            }
+          >
+            Phase 1
+          </span>
+          <div className="text-cloud/40">{formatDate(cycle.start_date)}</div>
+        </div>
+        {/* Phase 2 */}
+        <div
+          style={{ width: `${phase3Pct - phase2Pct}%` }}
+          className="border-l border-white/10 pl-2 pr-2"
+        >
+          <span
+            className={
+              currentPhase === 2
+                ? "font-semibold text-aqua"
+                : currentPhase > 2
+                  ? "text-cloud/40"
+                  : "text-cloud/60"
+            }
+          >
+            Phase 2
+          </span>
+          <div className="text-cloud/40">
+            {formatDate(config.phase_2_start)}
+          </div>
+          <div className="text-cloud/30">Meet The Pods</div>
+        </div>
+        {/* Phase 3 */}
+        <div
+          style={{ width: `${100 - phase3Pct}%` }}
+          className="border-l border-white/10 pl-2"
+        >
+          <span
+            className={
+              currentPhase === 3
+                ? "font-semibold text-aqua"
+                : currentPhase > 3
+                  ? "text-cloud/40"
+                  : "text-cloud/60"
+            }
+          >
+            Phase 3
+          </span>
+          <div className="text-cloud/40">
+            {formatDate(config.phase_3_start)}
+          </div>
+          <div className="text-cloud/30">Meet The Projects</div>
+        </div>
+      </div>
+
+      {/* End date / Demo Day */}
+      <div className="mb-4 flex justify-end text-xs text-cloud/40">
+        Demo Day &middot; {formatDate(cycle.end_date)}
+      </div>
+
+      {/* Active operational windows */}
+      {activeWindows.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {activeWindows.map((w) => (
+            <span
+              key={w.label}
+              className="inline-flex items-center gap-1.5 rounded-full bg-teal/10 px-3 py-1 text-xs font-medium text-aqua"
+            >
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-aqua" />
+              {w.label} &middot; closes {formatDate(w.closesAt)}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Upcoming window (when nothing is active) */}
+      {upcomingWindow && (
+        <div className="flex flex-wrap gap-2">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-white/[0.04] px-3 py-1 text-xs text-cloud/50">
+            Up next: {upcomingWindow.label} &middot; opens{" "}
+            {formatDate(upcomingWindow.opensAt)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/page.tsx
+++ b/app/(dashboard)/cycles/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import CyclePhaseIndicator from "./cycle-phase-indicator";
 
 export default async function CyclesPage() {
   const supabase = await createClient();
@@ -9,11 +10,33 @@ export default async function CyclesPage() {
     .select("id, name, slug, start_date, end_date, status")
     .order("start_date", { ascending: false });
 
+  // Fetch config for the active cycle to power the phase indicator
+  const activeCycle = cycles?.find((c) => c.status === "active") ?? null;
+  let activeCycleConfig = null;
+  if (activeCycle) {
+    const serviceClient = createServiceClient();
+    const { data } = await serviceClient
+      .from("cycle_config")
+      .select(
+        "phase_2_start, phase_3_start, problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close"
+      )
+      .eq("cycle_id", activeCycle.id)
+      .single();
+    activeCycleConfig = data;
+  }
+
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold text-white">
         Build Cycles
       </h1>
+
+      {activeCycle && activeCycleConfig && (
+        <CyclePhaseIndicator
+          cycle={activeCycle}
+          config={activeCycleConfig}
+        />
+      )}
       {!cycles || cycles.length === 0 ? (
         <p className="text-cloud/60">No cycles yet.</p>
       ) : (

--- a/supabase/migrations/00006_add_cycle_phases.sql
+++ b/supabase/migrations/00006_add_cycle_phases.sql
@@ -1,0 +1,8 @@
+-- Add quarterly cycle phase milestone columns to cycle_config.
+-- Phase 1 runs from cycles.start_date → phase_2_start ("Meet The Pods").
+-- Phase 2 runs from phase_2_start → phase_3_start ("Meet The Projects").
+-- Phase 3 runs from phase_3_start → cycles.end_date ("Demo Day / Showcase / Summit").
+
+ALTER TABLE cycle_config
+  ADD COLUMN phase_2_start TIMESTAMP,
+  ADD COLUMN phase_3_start TIMESTAMP;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -71,7 +71,8 @@ INSERT INTO cycle_config (
   pod_registration_open, pod_registration_close,
   solution_proposal_open, solution_proposal_close,
   solution_voting_open, solution_voting_close,
-  project_registration_open, project_registration_close
+  project_registration_open, project_registration_close,
+  phase_2_start, phase_3_start
 ) VALUES (
   1, 1,
   3, 1, 5, 8, 5,
@@ -82,7 +83,8 @@ INSERT INTO cycle_config (
   '2026-03-29 09:00:00', '2026-04-02 23:59:59',
   '2026-04-03 09:00:00', '2026-04-07 23:59:59',
   '2026-04-08 09:00:00', '2026-04-10 23:59:59',
-  '2026-04-11 09:00:00', '2026-04-16 23:59:59'
+  '2026-04-11 09:00:00', '2026-04-16 23:59:59',
+  '2026-04-13 00:00:00', '2026-05-11 00:00:00'
 );
 
 -- 3. Participants (20 DC-area profiles)


### PR DESCRIPTION
Users now see a visual progress bar showing where they are in the active cycle's 3 macro phases (Phase 1 → Meet The Pods → Phase 2 → Meet The Projects → Phase 3 → Demo Day). Active and upcoming operational windows (voting, registration, etc.) display as contextual chips below the bar.

- Migration 00006: adds phase_2_start / phase_3_start to cycle_config
- New CyclePhaseIndicator server component on /cycles dashboard
- Admin schedule form gains "Cycle Phases" section for milestone dates

https://claude.ai/code/session_01JPwbPR5pYLmFSvKSTLXEXv