### PR TITLE
Add participant-facing activity pages and link active forms from dash…

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -1,6 +1,19 @@
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
+
+const WINDOW_ROUTES: {
+  label: string;
+  field: string;
+  route: string;
+}[] = [
+  { label: "Submit Problem Statements", field: "problem_statement", route: "propose" },
+  { label: "Vote on Problem Statements", field: "voting", route: "vote" },
+  { label: "Register for Pods", field: "pod_registration", route: "register-pods" },
+  { label: "Submit Solution Proposals", field: "solution_proposal", route: "solutions" },
+  { label: "Vote on Solutions", field: "solution_voting", route: "solution-vote" },
+  { label: "Register for Projects", field: "project_registration", route: "register-projects" },
+];
 
 export default async function CycleDetailPage({
   params,
@@ -32,6 +45,29 @@ export default async function CycleDetailPage({
   const activeCount =
     enrollments?.filter((e) => e.status === "active").length || 0;
 
+  // Fetch active windows
+  const serviceClient = createServiceClient();
+  const { data: config } = await serviceClient
+    .from("cycle_config")
+    .select(
+      "problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close"
+    )
+    .eq("cycle_id", cycle.id)
+    .single();
+
+  const now = new Date();
+  const activeWindows: { label: string; route: string; closesAt: string }[] = [];
+  if (config) {
+    for (const w of WINDOW_ROUTES) {
+      const configRecord = config as Record<string, string | null>;
+      const openVal = configRecord[`${w.field}_open`];
+      const closeVal = configRecord[`${w.field}_close`];
+      if (openVal && closeVal && now >= new Date(openVal) && now <= new Date(closeVal)) {
+        activeWindows.push({ label: w.label, route: w.route, closesAt: closeVal });
+      }
+    }
+  }
+
   return (
     <div>
       <div className="mb-8">
@@ -62,6 +98,34 @@ export default async function CycleDetailPage({
           </span>
         </div>
       </div>
+
+      {/* Active window CTAs */}
+      {activeWindows.length > 0 && (
+        <div className="mb-8 space-y-3">
+          {activeWindows.map((w) => (
+            <Link
+              key={w.route}
+              href={`/cycles/${cycle.id}/${w.route}`}
+              className="flex items-center justify-between rounded-md border border-teal/20 bg-teal/[0.04] p-4 transition-colors hover:border-teal/40 hover:bg-teal/[0.07]"
+            >
+              <div className="flex items-center gap-3">
+                <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-aqua" />
+                <span className="font-medium text-white">{w.label}</span>
+              </div>
+              <div className="flex items-center gap-2 text-sm text-cloud/50">
+                <span>
+                  closes{" "}
+                  {new Date(w.closesAt).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+                <span className="text-aqua">&rarr;</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
 
       <div className="mb-8 grid gap-4 sm:grid-cols-3">
         <div className="rounded-md border border-whisper bg-white/[0.02] p-4">

--- a/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import ProposeForm from "./propose-form";
+
+export default async function ProposePage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const cycleId = parseInt(cycle_id, 10);
+  const supabase = await createClient();
+
+  const { data: cycle } = await supabase
+    .from("cycles")
+    .select("id, name, status")
+    .eq("id", cycleId)
+    .single();
+
+  if (!cycle) notFound();
+
+  // Check if window is open
+  const serviceClient = createServiceClient();
+  const { data: config } = await serviceClient
+    .from("cycle_config")
+    .select("problem_statement_open, problem_statement_close")
+    .eq("cycle_id", cycleId)
+    .single();
+
+  const now = new Date();
+  const isOpen =
+    config?.problem_statement_open &&
+    config?.problem_statement_close &&
+    now >= new Date(config.problem_statement_open) &&
+    now <= new Date(config.problem_statement_close);
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href={`/cycles/${cycle.id}`}
+          className="text-sm text-cloud/60 hover:text-aqua"
+        >
+          &larr; {cycle.name}
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-white">
+          Submit a Problem Statement
+        </h1>
+        <p className="mt-1 text-sm text-cloud/50">
+          Propose a problem for the community to explore during this cycle.
+        </p>
+      </div>
+
+      {isOpen ? (
+        <ProposeForm cycleId={cycleId} />
+      ) : (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">
+            Problem statement submission is not currently open.
+          </p>
+          {config?.problem_statement_open &&
+            now < new Date(config.problem_statement_open) && (
+              <p className="mt-2 text-sm text-cloud/40">
+                Opens{" "}
+                {new Date(config.problem_statement_open).toLocaleDateString(
+                  "en-US",
+                  { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
+                )}
+              </p>
+            )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface Submission {
+  id: number;
+  statement_text: string;
+  created_at: string;
+}
+
+export default function ProposeForm({ cycleId }: { cycleId: number }) {
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+  const [submissions, setSubmissions] = useState<Submission[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/problem-statements/${cycleId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (Array.isArray(data)) {
+          // Filter to show only current user's submissions
+          // The API returns all for the cycle; we'll show them all as context
+          setSubmissions(data);
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [cycleId]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSuccess(false);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch("/api/problem-statements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cycle_id: cycleId, statement_text: text.trim() }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error || "Failed to submit");
+        return;
+      }
+
+      const created = await res.json();
+      setSuccess(true);
+      setText("");
+      setSubmissions((prev) => [
+        ...prev,
+        { id: created.id, statement_text: text.trim(), created_at: created.created_at },
+      ]);
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="statement_text"
+            className="mb-1.5 block text-sm font-medium text-cloud/70"
+          >
+            Your Problem Statement
+          </label>
+          <textarea
+            id="statement_text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            maxLength={2000}
+            rows={5}
+            required
+            placeholder="Describe a problem you'd like the community to explore..."
+            className="w-full rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-white placeholder:text-cloud/30 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal"
+          />
+          <p className="mt-1 text-xs text-cloud/40">
+            {text.length}/2000 characters
+          </p>
+        </div>
+
+        {error && (
+          <p className="rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            {error}
+          </p>
+        )}
+
+        {success && (
+          <p className="rounded-md bg-teal/10 px-3 py-2 text-sm text-aqua">
+            Problem statement submitted successfully!
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting || !text.trim()}
+          className="rounded-md bg-teal px-4 py-2 text-sm font-medium text-midnight transition-colors hover:bg-aqua disabled:opacity-50"
+        >
+          {submitting ? "Submitting..." : "Submit Problem Statement"}
+        </button>
+      </form>
+
+      {/* Existing submissions */}
+      {!loading && submissions.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-widest text-cloud/40">
+            Submitted Problem Statements ({submissions.length})
+          </h2>
+          <div className="space-y-3">
+            {submissions.map((s) => (
+              <div
+                key={s.id}
+                className="rounded-md border border-whisper bg-white/[0.02] p-4"
+              >
+                <p className="text-sm text-cloud/80">{s.statement_text}</p>
+                <p className="mt-2 text-xs text-cloud/40">
+                  {new Date(s.created_at).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/register-pods/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-pods/page.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import PodRegistration from "./pod-registration";
+
+export default async function RegisterPodsPage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const cycleId = parseInt(cycle_id, 10);
+  const supabase = await createClient();
+
+  const { data: cycle } = await supabase
+    .from("cycles")
+    .select("id, name, status")
+    .eq("id", cycleId)
+    .single();
+
+  if (!cycle) notFound();
+
+  const serviceClient = createServiceClient();
+  const { data: config } = await serviceClient
+    .from("cycle_config")
+    .select("pod_registration_open, pod_registration_close")
+    .eq("cycle_id", cycleId)
+    .single();
+
+  const now = new Date();
+  const isOpen =
+    config?.pod_registration_open &&
+    config?.pod_registration_close &&
+    now >= new Date(config.pod_registration_open) &&
+    now <= new Date(config.pod_registration_close);
+
+  // Get current user's participant_id
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let myPodIds: number[] = [];
+  if (user) {
+    const { data: participant } = await supabase
+      .from("participants")
+      .select("id")
+      .eq("auth_user_id", user.id)
+      .single();
+
+    if (participant) {
+      const { data: memberships } = await supabase
+        .from("pod_memberships")
+        .select("pod_id, pods!inner(cycle_id)")
+        .eq("participant_id", participant.id)
+        .eq("pods.cycle_id", cycleId)
+        .is("inactive_at", null);
+
+      myPodIds = (memberships || []).map((m) => m.pod_id);
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href={`/cycles/${cycle.id}`}
+          className="text-sm text-cloud/60 hover:text-aqua"
+        >
+          &larr; {cycle.name}
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-white">
+          Register for Pods
+        </h1>
+        <p className="mt-1 text-sm text-cloud/50">
+          Join up to 2 pods to explore problems that interest you.
+        </p>
+      </div>
+
+      {isOpen ? (
+        <PodRegistration cycleId={cycleId} initialMyPodIds={myPodIds} />
+      ) : (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">
+            Pod registration is not currently open.
+          </p>
+          {config?.pod_registration_open &&
+            now < new Date(config.pod_registration_open) && (
+              <p className="mt-2 text-sm text-cloud/40">
+                Opens{" "}
+                {new Date(config.pod_registration_open).toLocaleDateString(
+                  "en-US",
+                  { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
+                )}
+              </p>
+            )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface Pod {
+  id: number;
+  name: string | null;
+  status: string;
+  registrantCount: number;
+  problemStatement: string | null;
+  registered: boolean;
+}
+
+export default function PodRegistration({
+  cycleId,
+  initialMyPodIds,
+}: {
+  cycleId: number;
+  initialMyPodIds: number[];
+}) {
+  const [pods, setPods] = useState<Pod[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionPodId, setActionPodId] = useState<number | null>(null);
+  const [error, setError] = useState("");
+  const [successMsg, setSuccessMsg] = useState("");
+
+  useEffect(() => {
+    fetch(`/api/cycles/${cycleId}/pods`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setPods(
+            data.map(
+              (p: {
+                id: number;
+                name: string | null;
+                status: string;
+                registrant_count: number;
+                problem_statement_title: string | null;
+              }) => ({
+                id: p.id,
+                name: p.name,
+                status: p.status,
+                registrantCount: p.registrant_count,
+                problemStatement: p.problem_statement_title,
+                registered: initialMyPodIds.includes(p.id),
+              })
+            )
+          );
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [cycleId, initialMyPodIds]);
+
+  const registeredCount = pods.filter((p) => p.registered).length;
+
+  async function registerForPod(podId: number) {
+    setError("");
+    setSuccessMsg("");
+    setActionPodId(podId);
+
+    try {
+      const res = await fetch(`/api/pods/${podId}/register`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error || "Failed to register");
+        return;
+      }
+
+      setSuccessMsg("Registered successfully!");
+      setPods((prev) =>
+        prev.map((p) =>
+          p.id === podId
+            ? { ...p, registered: true, registrantCount: p.registrantCount + 1 }
+            : p
+        )
+      );
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setActionPodId(null);
+    }
+  }
+
+  async function unregisterFromPod(podId: number) {
+    setError("");
+    setSuccessMsg("");
+    setActionPodId(podId);
+
+    try {
+      const res = await fetch(`/api/pods/${podId}/register`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error || "Failed to unregister");
+        return;
+      }
+
+      setSuccessMsg("Unregistered successfully.");
+      setPods((prev) =>
+        prev.map((p) =>
+          p.id === podId
+            ? {
+                ...p,
+                registered: false,
+                registrantCount: Math.max(0, p.registrantCount - 1),
+              }
+            : p
+        )
+      );
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setActionPodId(null);
+    }
+  }
+
+  if (loading) {
+    return <p className="text-cloud/50">Loading pods...</p>;
+  }
+
+  if (pods.length === 0) {
+    return (
+      <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+        <p className="text-cloud/60">No pods available for registration yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4 rounded-md border border-teal/20 bg-teal/[0.04] p-4">
+        <div>
+          <p className="text-sm text-cloud/60">Registered Pods</p>
+          <p className="text-2xl font-bold text-aqua">{registeredCount}</p>
+          <p className="text-xs text-cloud/40">of 2 maximum</p>
+        </div>
+      </div>
+
+      {error && (
+        <p className="rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-400">
+          {error}
+        </p>
+      )}
+      {successMsg && (
+        <p className="rounded-md bg-teal/10 px-3 py-2 text-sm text-aqua">
+          {successMsg}
+        </p>
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {pods.map((pod) => (
+          <div
+            key={pod.id}
+            className={`rounded-md border p-4 ${
+              pod.registered
+                ? "border-teal/30 bg-teal/[0.04]"
+                : "border-whisper bg-white/[0.02]"
+            }`}
+          >
+            <div className="mb-2 flex items-start justify-between">
+              <div>
+                <p className="font-medium text-white">
+                  {pod.name || `Pod ${pod.id}`}
+                </p>
+                <p className="mt-0.5 text-xs text-cloud/40">
+                  {pod.registrantCount} member
+                  {pod.registrantCount !== 1 ? "s" : ""} &middot; {pod.status}
+                </p>
+              </div>
+              {pod.registered ? (
+                <button
+                  onClick={() => unregisterFromPod(pod.id)}
+                  disabled={actionPodId !== null}
+                  className="rounded bg-red-500/10 px-3 py-1 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20 disabled:opacity-40"
+                >
+                  {actionPodId === pod.id ? "..." : "Leave"}
+                </button>
+              ) : (
+                <button
+                  onClick={() => registerForPod(pod.id)}
+                  disabled={actionPodId !== null || registeredCount >= 2}
+                  className="rounded bg-teal/20 px-3 py-1 text-xs font-medium text-aqua transition-colors hover:bg-teal/30 disabled:opacity-40"
+                >
+                  {actionPodId === pod.id ? "..." : "Join"}
+                </button>
+              )}
+            </div>
+            {pod.problemStatement && (
+              <p className="text-xs text-cloud/50">{pod.problemStatement}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/register-projects/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-projects/page.tsx
@@ -1,0 +1,167 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import ProjectRegistration from "./project-registration";
+
+export default async function RegisterProjectsPage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const cycleId = parseInt(cycle_id, 10);
+  const supabase = await createClient();
+
+  const { data: cycle } = await supabase
+    .from("cycles")
+    .select("id, name, status")
+    .eq("id", cycleId)
+    .single();
+
+  if (!cycle) notFound();
+
+  const serviceClient = createServiceClient();
+  const { data: config } = await serviceClient
+    .from("cycle_config")
+    .select("project_registration_open, project_registration_close")
+    .eq("cycle_id", cycleId)
+    .single();
+
+  const now = new Date();
+  const isOpen =
+    config?.project_registration_open &&
+    config?.project_registration_close &&
+    now >= new Date(config.project_registration_open) &&
+    now <= new Date(config.project_registration_close);
+
+  // Get user's pods for this cycle
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let myPods: { id: number; name: string | null }[] = [];
+  let currentProjectId: number | null = null;
+
+  if (user) {
+    const { data: participant } = await supabase
+      .from("participants")
+      .select("id")
+      .eq("auth_user_id", user.id)
+      .single();
+
+    if (participant) {
+      const { data: memberships } = await supabase
+        .from("pod_memberships")
+        .select("pod_id, pods!inner(id, name, cycle_id)")
+        .eq("participant_id", participant.id)
+        .eq("pods.cycle_id", cycleId)
+        .is("inactive_at", null);
+
+      myPods = (memberships || []).map((m) => {
+        const pod = m.pods as unknown as { id: number; name: string | null };
+        return { id: pod.id, name: pod.name };
+      });
+
+      // Check current project registration
+      const { data: existingReg } = await supabase
+        .from("project_memberships")
+        .select("project_id")
+        .eq("participant_id", participant.id)
+        .eq("cycle_id", cycleId)
+        .is("left_at", null)
+        .maybeSingle();
+
+      currentProjectId = existingReg?.project_id ?? null;
+    }
+  }
+
+  // Fetch projects for the user's pods
+  const podIds = myPods.map((p) => p.id);
+  let projects: { id: number; name: string | null; status: string; pod_id: number; member_count: number }[] = [];
+  if (podIds.length > 0) {
+    const { data: projectData } = await supabase
+      .from("projects")
+      .select("id, name, status, pod_id")
+      .in("pod_id", podIds)
+      .order("created_at");
+
+    if (projectData) {
+      // Get member counts
+      const projectIds = projectData.map((p) => p.id);
+      const { data: projectMemberships } = await supabase
+        .from("project_memberships")
+        .select("project_id")
+        .in("project_id", projectIds.length > 0 ? projectIds : [0])
+        .is("left_at", null);
+
+      const countMap: Record<number, number> = {};
+      for (const m of projectMemberships || []) {
+        countMap[m.project_id] = (countMap[m.project_id] || 0) + 1;
+      }
+
+      projects = projectData.map((p) => ({
+        id: p.id,
+        name: p.name,
+        status: p.status,
+        pod_id: p.pod_id,
+        member_count: countMap[p.id] || 0,
+      }));
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href={`/cycles/${cycle.id}`}
+          className="text-sm text-cloud/60 hover:text-aqua"
+        >
+          &larr; {cycle.name}
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-white">
+          Register for a Project
+        </h1>
+        <p className="mt-1 text-sm text-cloud/50">
+          Join a project within your pod. You can register for one project per
+          cycle.
+        </p>
+      </div>
+
+      {!isOpen ? (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">
+            Project registration is not currently open.
+          </p>
+          {config?.project_registration_open &&
+            now < new Date(config.project_registration_open) && (
+              <p className="mt-2 text-sm text-cloud/40">
+                Opens{" "}
+                {new Date(config.project_registration_open).toLocaleDateString(
+                  "en-US",
+                  { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
+                )}
+              </p>
+            )}
+        </div>
+      ) : myPods.length === 0 ? (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">
+            You are not a member of any pods in this cycle.
+          </p>
+          <Link
+            href={`/cycles/${cycle.id}`}
+            className="mt-2 inline-block text-sm text-aqua hover:underline"
+          >
+            View cycle &rarr;
+          </Link>
+        </div>
+      ) : (
+        <ProjectRegistration
+          pods={myPods}
+          projects={projects}
+          initialCurrentProjectId={currentProjectId}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/register-projects/project-registration.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-projects/project-registration.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState } from "react";
+
+interface Project {
+  id: number;
+  name: string | null;
+  status: string;
+  pod_id: number;
+  member_count: number;
+}
+
+export default function ProjectRegistration({
+  pods,
+  projects,
+  initialCurrentProjectId,
+}: {
+  pods: { id: number; name: string | null }[];
+  projects: Project[];
+  initialCurrentProjectId: number | null;
+}) {
+  const [currentProjectId, setCurrentProjectId] = useState(
+    initialCurrentProjectId
+  );
+  const [projectCounts, setProjectCounts] = useState<Record<number, number>>(
+    () => {
+      const counts: Record<number, number> = {};
+      for (const p of projects) counts[p.id] = p.member_count;
+      return counts;
+    }
+  );
+  const [actionId, setActionId] = useState<number | null>(null);
+  const [error, setError] = useState("");
+  const [successMsg, setSuccessMsg] = useState("");
+
+  function getPodName(podId: number): string {
+    return pods.find((p) => p.id === podId)?.name || `Pod ${podId}`;
+  }
+
+  async function registerForProject(projectId: number) {
+    setError("");
+    setSuccessMsg("");
+    setActionId(projectId);
+
+    try {
+      const res = await fetch(`/api/projects/${projectId}/register`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error || "Failed to register");
+        return;
+      }
+
+      setCurrentProjectId(projectId);
+      setProjectCounts((prev) => ({
+        ...prev,
+        [projectId]: (prev[projectId] || 0) + 1,
+      }));
+      setSuccessMsg("Registered for project!");
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setActionId(null);
+    }
+  }
+
+  async function withdrawFromProject(projectId: number) {
+    setError("");
+    setSuccessMsg("");
+    setActionId(projectId);
+
+    try {
+      const res = await fetch(`/api/projects/${projectId}/register`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error || "Failed to withdraw");
+        return;
+      }
+
+      setCurrentProjectId(null);
+      setProjectCounts((prev) => ({
+        ...prev,
+        [projectId]: Math.max(0, (prev[projectId] || 0) - 1),
+      }));
+      setSuccessMsg("Withdrawn from project.");
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setActionId(null);
+    }
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+        <p className="text-cloud/60">
+          No projects available for registration yet.
+        </p>
+      </div>
+    );
+  }
+
+  // Group projects by pod
+  const byPod: Record<number, Project[]> = {};
+  for (const p of projects) {
+    if (!byPod[p.pod_id]) byPod[p.pod_id] = [];
+    byPod[p.pod_id].push(p);
+  }
+
+  return (
+    <div className="space-y-6">
+      {currentProjectId && (
+        <div className="rounded-md border border-teal/20 bg-teal/[0.04] p-4">
+          <p className="text-sm text-cloud/60">Currently registered for</p>
+          <p className="font-medium text-white">
+            {projects.find((p) => p.id === currentProjectId)?.name ||
+              `Project ${currentProjectId}`}
+          </p>
+          <p className="mt-1 text-xs text-cloud/40">
+            You can only be in one project per cycle. Withdraw to switch.
+          </p>
+        </div>
+      )}
+
+      {error && (
+        <p className="rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-400">
+          {error}
+        </p>
+      )}
+      {successMsg && (
+        <p className="rounded-md bg-teal/10 px-3 py-2 text-sm text-aqua">
+          {successMsg}
+        </p>
+      )}
+
+      {Object.entries(byPod).map(([podIdStr, podProjects]) => {
+        const podId = parseInt(podIdStr, 10);
+        return (
+          <div key={podId}>
+            <h2 className="mb-3 text-sm font-medium uppercase tracking-widest text-cloud/40">
+              {getPodName(podId)}
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {podProjects.map((project) => {
+                const isRegistered = currentProjectId === project.id;
+                return (
+                  <div
+                    key={project.id}
+                    className={`rounded-md border p-4 ${
+                      isRegistered
+                        ? "border-teal/30 bg-teal/[0.04]"
+                        : "border-whisper bg-white/[0.02]"
+                    }`}
+                  >
+                    <div className="flex items-start justify-between">
+                      <div>
+                        <p className="font-medium text-white">
+                          {project.name || `Project ${project.id}`}
+                        </p>
+                        <p className="mt-0.5 text-xs text-cloud/40">
+                          {projectCounts[project.id] || 0} member
+                          {(projectCounts[project.id] || 0) !== 1
+                            ? "s"
+                            : ""}{" "}
+                          &middot; {project.status}
+                        </p>
+                      </div>
+                      {isRegistered ? (
+                        <button
+                          onClick={() => withdrawFromProject(project.id)}
+                          disabled={actionId !== null}
+                          className="rounded bg-red-500/10 px-3 py-1 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20 disabled:opacity-40"
+                        >
+                          {actionId === project.id ? "..." : "Withdraw"}
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => registerForProject(project.id)}
+                          disabled={
+                            actionId !== null || currentProjectId !== null
+                          }
+                          className="rounded bg-teal/20 px-3 py-1 text-xs font-medium text-aqua transition-colors hover:bg-teal/30 disabled:opacity-40"
+                        >
+                          {actionId === project.id ? "..." : "Join"}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/solution-vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solution-vote/page.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import SolutionBallot from "./solution-ballot";
+
+export default async function SolutionVotePage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const cycleId = parseInt(cycle_id, 10);
+  const supabase = await createClient();
+
+  const { data: cycle } = await supabase
+    .from("cycles")
+    .select("id, name, status")
+    .eq("id", cycleId)
+    .single();
+
+  if (!cycle) notFound();
+
+  const serviceClient = createServiceClient();
+  const { data: config } = await serviceClient
+    .from("cycle_config")
+    .select("solution_voting_open, solution_voting_close, project_submitter_votes")
+    .eq("cycle_id", cycleId)
+    .single();
+
+  const now = new Date();
+  const isOpen =
+    config?.solution_voting_open &&
+    config?.solution_voting_close &&
+    now >= new Date(config.solution_voting_open) &&
+    now <= new Date(config.solution_voting_close);
+
+  // Get user's pods for this cycle
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let myPods: { id: number; name: string | null }[] = [];
+  if (user) {
+    const { data: participant } = await supabase
+      .from("participants")
+      .select("id")
+      .eq("auth_user_id", user.id)
+      .single();
+
+    if (participant) {
+      const { data: memberships } = await supabase
+        .from("pod_memberships")
+        .select("pod_id, pods!inner(id, name, cycle_id)")
+        .eq("participant_id", participant.id)
+        .eq("pods.cycle_id", cycleId)
+        .is("inactive_at", null);
+
+      myPods = (memberships || []).map((m) => {
+        const pod = m.pods as unknown as { id: number; name: string | null };
+        return { id: pod.id, name: pod.name };
+      });
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href={`/cycles/${cycle.id}`}
+          className="text-sm text-cloud/60 hover:text-aqua"
+        >
+          &larr; {cycle.name}
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-white">
+          Vote on Solutions
+        </h1>
+        <p className="mt-1 text-sm text-cloud/50">
+          Allocate your votes to the solutions you want your pod to build.
+        </p>
+      </div>
+
+      {!isOpen ? (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">
+            Solution voting is not currently open.
+          </p>
+          {config?.solution_voting_open &&
+            now < new Date(config.solution_voting_open) && (
+              <p className="mt-2 text-sm text-cloud/40">
+                Opens{" "}
+                {new Date(config.solution_voting_open).toLocaleDateString(
+                  "en-US",
+                  { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
+                )}
+              </p>
+            )}
+        </div>
+      ) : myPods.length === 0 ? (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">
+            You are not a member of any pods in this cycle.
+          </p>
+          <Link
+            href={`/cycles/${cycle.id}`}
+            className="mt-2 inline-block text-sm text-aqua hover:underline"
+          >
+            View cycle &rarr;
+          </Link>
+        </div>
+      ) : (
+        <SolutionBallot
+          pods={myPods}
+          voteBudget={config?.project_submitter_votes ?? 0}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/solution-vote/solution-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solution-vote/solution-ballot.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface Proposal {
+  id: number;
+  participant_id: number;
+  proposal_text: string;
+  created_at: string;
+}
+
+interface Tally {
+  solution_proposal_id: number;
+  total_votes: number;
+}
+
+export default function SolutionBallot({
+  pods,
+  voteBudget,
+}: {
+  pods: { id: number; name: string | null }[];
+  voteBudget: number;
+}) {
+  const [selectedPodId, setSelectedPodId] = useState(pods[0]?.id ?? 0);
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [tallies, setTallies] = useState<Tally[]>([]);
+  const [pendingVotes, setPendingVotes] = useState<Record<number, number>>({});
+  const [totalUsed, setTotalUsed] = useState(0);
+  const [submitting, setSubmitting] = useState<number | null>(null);
+  const [error, setError] = useState("");
+  const [successId, setSuccessId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!selectedPodId) return;
+    setLoading(true);
+    setTotalUsed(0);
+    setPendingVotes({});
+
+    Promise.all([
+      fetch(`/api/pods/${selectedPodId}/solution-proposals`).then((r) =>
+        r.json()
+      ),
+      fetch(`/api/pods/${selectedPodId}/project-votes`).then((r) => r.json()),
+    ]).then(([proposalData, voteData]) => {
+      if (Array.isArray(proposalData)) setProposals(proposalData);
+      if (voteData?.tallies) setTallies(voteData.tallies);
+      setLoading(false);
+    });
+  }, [selectedPodId]);
+
+  function getTallyFor(proposalId: number): number {
+    return (
+      tallies.find((t) => t.solution_proposal_id === proposalId)
+        ?.total_votes ?? 0
+    );
+  }
+
+  async function castVote(proposalId: number) {
+    const voteCount = pendingVotes[proposalId];
+    if (!voteCount || voteCount < 1) return;
+
+    setError("");
+    setSuccessId(null);
+    setSubmitting(proposalId);
+
+    try {
+      const res = await fetch(`/api/pods/${selectedPodId}/project-votes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          solution_proposal_id: proposalId,
+          vote_count: voteCount,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error || "Failed to cast vote");
+        return;
+      }
+
+      setSuccessId(proposalId);
+      setTotalUsed((prev) => prev + voteCount);
+      setTallies((prev) => {
+        const existing = prev.find(
+          (t) => t.solution_proposal_id === proposalId
+        );
+        if (existing) {
+          return prev.map((t) =>
+            t.solution_proposal_id === proposalId
+              ? { ...t, total_votes: t.total_votes + voteCount }
+              : t
+          );
+        }
+        return [
+          ...prev,
+          { solution_proposal_id: proposalId, total_votes: voteCount },
+        ];
+      });
+      setPendingVotes((prev) => ({ ...prev, [proposalId]: 0 }));
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(null);
+    }
+  }
+
+  const remaining = voteBudget - totalUsed;
+
+  return (
+    <div className="space-y-6">
+      {pods.length > 1 && (
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-cloud/70">
+            Select Pod
+          </label>
+          <select
+            value={selectedPodId}
+            onChange={(e) => setSelectedPodId(parseInt(e.target.value, 10))}
+            className="rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-white focus:border-teal focus:outline-none"
+          >
+            {pods.map((pod) => (
+              <option key={pod.id} value={pod.id}>
+                {pod.name || `Pod ${pod.id}`}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {pods.length === 1 && (
+        <p className="text-sm text-cloud/50">
+          Voting in{" "}
+          <span className="font-medium text-white">
+            {pods[0].name || `Pod ${pods[0].id}`}
+          </span>
+        </p>
+      )}
+
+      {/* Budget indicator */}
+      <div className="flex items-center gap-4 rounded-md border border-teal/20 bg-teal/[0.04] p-4">
+        <div>
+          <p className="text-sm text-cloud/60">Vote Budget</p>
+          <p className="text-2xl font-bold text-aqua">{remaining}</p>
+          <p className="text-xs text-cloud/40">votes remaining</p>
+        </div>
+      </div>
+
+      {error && (
+        <p className="rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-400">
+          {error}
+        </p>
+      )}
+
+      {loading ? (
+        <p className="text-cloud/50">Loading proposals...</p>
+      ) : proposals.length === 0 ? (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">
+            No solution proposals have been submitted yet.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {proposals.map((proposal) => (
+            <div
+              key={proposal.id}
+              className="rounded-md border border-whisper bg-white/[0.02] p-4"
+            >
+              <p className="text-sm text-cloud/80">{proposal.proposal_text}</p>
+              <div className="mt-3 flex items-center justify-between">
+                <span className="text-xs text-cloud/40">
+                  {getTallyFor(proposal.id)} vote
+                  {getTallyFor(proposal.id) !== 1 ? "s" : ""}
+                </span>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="number"
+                    min={1}
+                    max={remaining}
+                    value={pendingVotes[proposal.id] || ""}
+                    onChange={(e) =>
+                      setPendingVotes((prev) => ({
+                        ...prev,
+                        [proposal.id]: parseInt(e.target.value, 10) || 0,
+                      }))
+                    }
+                    placeholder="0"
+                    className="w-16 rounded border border-whisper bg-white/[0.04] px-2 py-1 text-center text-sm text-white placeholder:text-cloud/30 focus:border-teal focus:outline-none"
+                  />
+                  <button
+                    onClick={() => castVote(proposal.id)}
+                    disabled={
+                      submitting !== null ||
+                      !pendingVotes[proposal.id] ||
+                      pendingVotes[proposal.id] < 1
+                    }
+                    className="rounded bg-teal/20 px-3 py-1 text-xs font-medium text-aqua transition-colors hover:bg-teal/30 disabled:opacity-40"
+                  >
+                    {submitting === proposal.id ? "..." : "Vote"}
+                  </button>
+                  {successId === proposal.id && (
+                    <span className="text-xs text-aqua">Voted!</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/solutions/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solutions/page.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import ProposalForm from "./proposal-form";
+
+export default async function SolutionsPage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const cycleId = parseInt(cycle_id, 10);
+  const supabase = await createClient();
+
+  const { data: cycle } = await supabase
+    .from("cycles")
+    .select("id, name, status")
+    .eq("id", cycleId)
+    .single();
+
+  if (!cycle) notFound();
+
+  const serviceClient = createServiceClient();
+  const { data: config } = await serviceClient
+    .from("cycle_config")
+    .select("solution_proposal_open, solution_proposal_close")
+    .eq("cycle_id", cycleId)
+    .single();
+
+  const now = new Date();
+  const isOpen =
+    config?.solution_proposal_open &&
+    config?.solution_proposal_close &&
+    now >= new Date(config.solution_proposal_open) &&
+    now <= new Date(config.solution_proposal_close);
+
+  // Get user's pods for this cycle
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let myPods: { id: number; name: string | null }[] = [];
+  if (user) {
+    const { data: participant } = await supabase
+      .from("participants")
+      .select("id")
+      .eq("auth_user_id", user.id)
+      .single();
+
+    if (participant) {
+      const { data: memberships } = await supabase
+        .from("pod_memberships")
+        .select("pod_id, pods!inner(id, name, cycle_id)")
+        .eq("participant_id", participant.id)
+        .eq("pods.cycle_id", cycleId)
+        .is("inactive_at", null);
+
+      myPods = (memberships || []).map((m) => {
+        const pod = m.pods as unknown as { id: number; name: string | null };
+        return { id: pod.id, name: pod.name };
+      });
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href={`/cycles/${cycle.id}`}
+          className="text-sm text-cloud/60 hover:text-aqua"
+        >
+          &larr; {cycle.name}
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-white">
+          Solution Proposals
+        </h1>
+        <p className="mt-1 text-sm text-cloud/50">
+          Propose solutions for your pod to explore.
+        </p>
+      </div>
+
+      {!isOpen ? (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">
+            Solution proposal submission is not currently open.
+          </p>
+          {config?.solution_proposal_open &&
+            now < new Date(config.solution_proposal_open) && (
+              <p className="mt-2 text-sm text-cloud/40">
+                Opens{" "}
+                {new Date(config.solution_proposal_open).toLocaleDateString(
+                  "en-US",
+                  { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
+                )}
+              </p>
+            )}
+        </div>
+      ) : myPods.length === 0 ? (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">
+            You are not a member of any pods in this cycle.
+          </p>
+          <Link
+            href={`/cycles/${cycle.id}`}
+            className="mt-2 inline-block text-sm text-aqua hover:underline"
+          >
+            View cycle &rarr;
+          </Link>
+        </div>
+      ) : (
+        <ProposalForm pods={myPods} />
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/solutions/proposal-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solutions/proposal-form.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface Proposal {
+  id: number;
+  proposal_text: string;
+  created_at: string;
+}
+
+export default function ProposalForm({
+  pods,
+}: {
+  pods: { id: number; name: string | null }[];
+}) {
+  const [selectedPodId, setSelectedPodId] = useState(pods[0]?.id ?? 0);
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!selectedPodId) return;
+    setLoading(true);
+    fetch(`/api/pods/${selectedPodId}/solution-proposals`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (Array.isArray(data)) setProposals(data);
+      })
+      .finally(() => setLoading(false));
+  }, [selectedPodId]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSuccess(false);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch(
+        `/api/pods/${selectedPodId}/solution-proposals`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ proposal_text: text.trim() }),
+        }
+      );
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error || "Failed to submit");
+        return;
+      }
+
+      const created = await res.json();
+      setSuccess(true);
+      setText("");
+      setProposals((prev) => [
+        ...prev,
+        {
+          id: created.id,
+          proposal_text: text.trim(),
+          created_at: created.created_at,
+        },
+      ]);
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {pods.length > 1 && (
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-cloud/70">
+            Select Pod
+          </label>
+          <select
+            value={selectedPodId}
+            onChange={(e) => setSelectedPodId(parseInt(e.target.value, 10))}
+            className="rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-white focus:border-teal focus:outline-none"
+          >
+            {pods.map((pod) => (
+              <option key={pod.id} value={pod.id}>
+                {pod.name || `Pod ${pod.id}`}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {pods.length === 1 && (
+        <p className="text-sm text-cloud/50">
+          Proposing for{" "}
+          <span className="font-medium text-white">
+            {pods[0].name || `Pod ${pods[0].id}`}
+          </span>
+        </p>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="proposal_text"
+            className="mb-1.5 block text-sm font-medium text-cloud/70"
+          >
+            Your Solution Proposal
+          </label>
+          <textarea
+            id="proposal_text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            maxLength={2000}
+            rows={5}
+            required
+            placeholder="Describe a solution your pod could build..."
+            className="w-full rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-white placeholder:text-cloud/30 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal"
+          />
+          <p className="mt-1 text-xs text-cloud/40">
+            {text.length}/2000 characters
+          </p>
+        </div>
+
+        {error && (
+          <p className="rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            {error}
+          </p>
+        )}
+        {success && (
+          <p className="rounded-md bg-teal/10 px-3 py-2 text-sm text-aqua">
+            Proposal submitted successfully!
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting || !text.trim()}
+          className="rounded-md bg-teal px-4 py-2 text-sm font-medium text-midnight transition-colors hover:bg-aqua disabled:opacity-50"
+        >
+          {submitting ? "Submitting..." : "Submit Proposal"}
+        </button>
+      </form>
+
+      {!loading && proposals.length > 0 && (
+        <div>
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-widest text-cloud/40">
+            Submitted Proposals ({proposals.length})
+          </h2>
+          <div className="space-y-3">
+            {proposals.map((p) => (
+              <div
+                key={p.id}
+                className="rounded-md border border-whisper bg-white/[0.02] p-4"
+              >
+                <p className="text-sm text-cloud/80">{p.proposal_text}</p>
+                <p className="mt-2 text-xs text-cloud/40">
+                  {new Date(p.created_at).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import VoteBallot from "./vote-ballot";
+
+export default async function VotePage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const cycleId = parseInt(cycle_id, 10);
+  const supabase = await createClient();
+
+  const { data: cycle } = await supabase
+    .from("cycles")
+    .select("id, name, status")
+    .eq("id", cycleId)
+    .single();
+
+  if (!cycle) notFound();
+
+  // Check if window is open
+  const serviceClient = createServiceClient();
+  const { data: config } = await serviceClient
+    .from("cycle_config")
+    .select("voting_open, voting_close, submitter_votes, non_submitter_votes")
+    .eq("cycle_id", cycleId)
+    .single();
+
+  const now = new Date();
+  const isOpen =
+    config?.voting_open &&
+    config?.voting_close &&
+    now >= new Date(config.voting_open) &&
+    now <= new Date(config.voting_close);
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href={`/cycles/${cycle.id}`}
+          className="text-sm text-cloud/60 hover:text-aqua"
+        >
+          &larr; {cycle.name}
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-white">
+          Vote on Problem Statements
+        </h1>
+        <p className="mt-1 text-sm text-cloud/50">
+          Allocate your votes to the problems you want the community to tackle.
+        </p>
+      </div>
+
+      {isOpen ? (
+        <VoteBallot
+          cycleId={cycleId}
+          submitterBudget={config?.submitter_votes ?? 0}
+          nonSubmitterBudget={config?.non_submitter_votes ?? 0}
+        />
+      ) : (
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+          <p className="text-cloud/60">Voting is not currently open.</p>
+          {config?.voting_open && now < new Date(config.voting_open) && (
+            <p className="mt-2 text-sm text-cloud/40">
+              Opens{" "}
+              {new Date(config.voting_open).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                hour: "numeric",
+                minute: "2-digit",
+              })}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface ProblemStatement {
+  id: number;
+  participant_id: number;
+  statement_text: string;
+  created_at: string;
+}
+
+interface Tally {
+  problem_statement_id: number;
+  total_votes: number;
+}
+
+export default function VoteBallot({
+  cycleId,
+  submitterBudget,
+  nonSubmitterBudget,
+}: {
+  cycleId: number;
+  submitterBudget: number;
+  nonSubmitterBudget: number;
+}) {
+  const [statements, setStatements] = useState<ProblemStatement[]>([]);
+  const [tallies, setTallies] = useState<Tally[]>([]);
+  const [pendingVotes, setPendingVotes] = useState<Record<number, number>>({});
+  const [totalUsed, setTotalUsed] = useState(0);
+  const [budget, setBudget] = useState(nonSubmitterBudget);
+  const [submitting, setSubmitting] = useState<number | null>(null);
+  const [error, setError] = useState("");
+  const [successId, setSuccessId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      fetch(`/api/problem-statements/${cycleId}`).then((r) => r.json()),
+      fetch(`/api/votes/${cycleId}`).then((r) => r.json()),
+    ]).then(([stmts, voteData]) => {
+      if (Array.isArray(stmts)) setStatements(stmts);
+      if (voteData?.tallies) setTallies(voteData.tallies);
+      setLoading(false);
+    });
+  }, [cycleId]);
+
+  // Determine budget based on whether user has submitted a problem statement
+  // (We approximate: if the API rejects with budget error, we'll show it)
+  // The actual budget enforcement happens server-side
+
+  function getTallyFor(stmtId: number): number {
+    return tallies.find((t) => t.problem_statement_id === stmtId)?.total_votes ?? 0;
+  }
+
+  async function castVote(problemStatementId: number) {
+    const voteCount = pendingVotes[problemStatementId];
+    if (!voteCount || voteCount < 1) return;
+
+    setError("");
+    setSuccessId(null);
+    setSubmitting(problemStatementId);
+
+    try {
+      const res = await fetch("/api/votes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cycle_id: cycleId,
+          problem_statement_id: problemStatementId,
+          vote_count: voteCount,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        setError(body.error || "Failed to cast vote");
+        return;
+      }
+
+      const result = await res.json();
+      setSuccessId(problemStatementId);
+      setTotalUsed((prev) => prev + voteCount);
+      if (result.votes_remaining !== undefined) {
+        setBudget(result.votes_remaining + totalUsed + voteCount);
+      }
+      setTallies((prev) => {
+        const existing = prev.find(
+          (t) => t.problem_statement_id === problemStatementId
+        );
+        if (existing) {
+          return prev.map((t) =>
+            t.problem_statement_id === problemStatementId
+              ? { ...t, total_votes: t.total_votes + voteCount }
+              : t
+          );
+        }
+        return [
+          ...prev,
+          { problem_statement_id: problemStatementId, total_votes: voteCount },
+        ];
+      });
+      setPendingVotes((prev) => ({ ...prev, [problemStatementId]: 0 }));
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(null);
+    }
+  }
+
+  const remaining = budget - totalUsed;
+
+  if (loading) {
+    return <p className="text-cloud/50">Loading problem statements...</p>;
+  }
+
+  if (statements.length === 0) {
+    return (
+      <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
+        <p className="text-cloud/60">
+          No problem statements have been submitted yet.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Budget indicator */}
+      <div className="flex items-center gap-4 rounded-md border border-teal/20 bg-teal/[0.04] p-4">
+        <div>
+          <p className="text-sm text-cloud/60">Vote Budget</p>
+          <p className="text-2xl font-bold text-aqua">{remaining}</p>
+          <p className="text-xs text-cloud/40">votes remaining</p>
+        </div>
+        <div className="text-xs text-cloud/40">
+          <p>Submitters get {submitterBudget} votes</p>
+          <p>Non-submitters get {nonSubmitterBudget} votes</p>
+        </div>
+      </div>
+
+      {error && (
+        <p className="rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-400">
+          {error}
+        </p>
+      )}
+
+      {/* Problem statements list */}
+      <div className="space-y-4">
+        {statements.map((stmt) => (
+          <div
+            key={stmt.id}
+            className="rounded-md border border-whisper bg-white/[0.02] p-4"
+          >
+            <p className="text-sm text-cloud/80">{stmt.statement_text}</p>
+            <div className="mt-3 flex items-center justify-between">
+              <span className="text-xs text-cloud/40">
+                {getTallyFor(stmt.id)} vote{getTallyFor(stmt.id) !== 1 ? "s" : ""}
+              </span>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min={1}
+                  max={remaining}
+                  value={pendingVotes[stmt.id] || ""}
+                  onChange={(e) =>
+                    setPendingVotes((prev) => ({
+                      ...prev,
+                      [stmt.id]: parseInt(e.target.value, 10) || 0,
+                    }))
+                  }
+                  placeholder="0"
+                  className="w-16 rounded border border-whisper bg-white/[0.04] px-2 py-1 text-center text-sm text-white placeholder:text-cloud/30 focus:border-teal focus:outline-none"
+                />
+                <button
+                  onClick={() => castVote(stmt.id)}
+                  disabled={
+                    submitting !== null ||
+                    !pendingVotes[stmt.id] ||
+                    pendingVotes[stmt.id] < 1
+                  }
+                  className="rounded bg-teal/20 px-3 py-1 text-xs font-medium text-aqua transition-colors hover:bg-teal/30 disabled:opacity-40"
+                >
+                  {submitting === stmt.id ? "..." : "Vote"}
+                </button>
+                {successId === stmt.id && (
+                  <span className="text-xs text-aqua">Voted!</span>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/cycle-phase-indicator.tsx
+++ b/app/(dashboard)/cycles/cycle-phase-indicator.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 type CycleConfig = {
   phase_2_start: string | null;
   phase_3_start: string | null;
@@ -16,6 +18,7 @@ type CycleConfig = {
 };
 
 type Cycle = {
+  id: number;
   name: string;
   start_date: string;
   end_date: string;
@@ -53,12 +56,12 @@ const PHASES = [
 /* ── Helpers ───────────────────────────────────────────────────────── */
 
 const OPERATIONAL_WINDOWS = [
-  { label: "Problem Statements", field: "problem_statement" },
-  { label: "Voting", field: "voting" },
-  { label: "Pod Registration", field: "pod_registration" },
-  { label: "Solution Proposals", field: "solution_proposal" },
-  { label: "Solution Voting", field: "solution_voting" },
-  { label: "Project Registration", field: "project_registration" },
+  { label: "Problem Statements", field: "problem_statement", route: "propose" },
+  { label: "Voting", field: "voting", route: "vote" },
+  { label: "Pod Registration", field: "pod_registration", route: "register-pods" },
+  { label: "Solution Proposals", field: "solution_proposal", route: "solutions" },
+  { label: "Solution Voting", field: "solution_voting", route: "solution-vote" },
+  { label: "Project Registration", field: "project_registration", route: "register-projects" },
 ] as const;
 
 function formatDate(iso: string): string {
@@ -85,8 +88,8 @@ function getCurrentWeek(now: Date, start: Date, end: Date): number {
 function getActiveWindows(
   config: CycleConfig,
   now: Date
-): { label: string; closesAt: string }[] {
-  const active: { label: string; closesAt: string }[] = [];
+): { label: string; closesAt: string; route: string }[] {
+  const active: { label: string; closesAt: string; route: string }[] = [];
   for (const w of OPERATIONAL_WINDOWS) {
     const openKey = `${w.field}_open` as keyof CycleConfig;
     const closeKey = `${w.field}_close` as keyof CycleConfig;
@@ -94,7 +97,7 @@ function getActiveWindows(
     const closeVal = config[closeKey];
     if (openVal && closeVal) {
       if (now >= new Date(openVal) && now <= new Date(closeVal)) {
-        active.push({ label: w.label, closesAt: closeVal });
+        active.push({ label: w.label, closesAt: closeVal, route: w.route });
       }
     }
   }
@@ -354,13 +357,15 @@ export default function CyclePhaseIndicator({
       {(activeWindows.length > 0 || upcomingWindow) && (
         <div className="mt-4 flex flex-wrap gap-2">
           {activeWindows.map((w) => (
-            <span
+            <Link
               key={w.label}
-              className="inline-flex items-center gap-1.5 rounded-full bg-teal/10 px-3 py-1 text-xs font-medium text-aqua"
+              href={`/cycles/${cycle.id}/${w.route}`}
+              className="inline-flex items-center gap-1.5 rounded-full bg-teal/10 px-3 py-1 text-xs font-medium text-aqua transition-colors hover:bg-teal/20"
             >
               <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-aqua" />
               {w.label} &middot; closes {formatDate(w.closesAt)}
-            </span>
+              <span className="ml-0.5">&rarr;</span>
+            </Link>
           ))}
           {upcomingWindow && (
             <span className="inline-flex items-center gap-1.5 rounded-full bg-white/[0.04] px-3 py-1 text-xs text-cloud/50">


### PR DESCRIPTION
…board

The CyclePhaseIndicator active window chips are now clickable links that navigate to the appropriate activity page. The cycle detail page shows prominent CTAs for any currently-open windows.

New pages for all 6 cycle activities:
- /cycles/[id]/propose — problem statement submission
- /cycles/[id]/vote — problem statement voting ballot
- /cycles/[id]/register-pods — pod registration with join/leave
- /cycles/[id]/solutions — solution proposal hub (pod-scoped)
- /cycles/[id]/solution-vote — solution voting hub (pod-scoped)
- /cycles/[id]/register-projects — project registration hub

https://claude.ai/code/session_013Nt9V76hr7guj9nAE7bqoH