### PR TITLE
Enrich problem proposal form into guided 6-part workflow

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
@@ -35,6 +35,24 @@ export default async function ProposePage({
     now >= new Date(config.problem_statement_open) &&
     now <= new Date(config.problem_statement_close);
 
+  // Get user's name for pre-filling
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let participantName = "";
+  if (user) {
+    const { data: participant } = await supabase
+      .from("participants")
+      .select("first_name, last_name, preferred_name")
+      .eq("auth_user_id", user.id)
+      .single();
+    if (participant) {
+      participantName =
+        `${participant.preferred_name || participant.first_name || ""} ${participant.last_name || ""}`.trim();
+    }
+  }
+
   return (
     <div>
       <div className="mb-8">
@@ -45,15 +63,22 @@ export default async function ProposePage({
           &larr; {cycle.name}
         </Link>
         <h1 className="mt-2 text-2xl font-bold text-white">
-          Submit a Problem Statement
+          Open Cycle Problem Proposal
         </h1>
-        <p className="mt-1 text-sm text-cloud/50">
-          Propose a problem for the community to explore during this cycle.
+        <p className="mt-2 text-sm leading-relaxed text-cloud/50">
+          The Open Cycle accepts problem proposals year-round. At the start of
+          each Cycle, active participants vote to shortlist the strongest
+          proposals. Shortlisted proposals open for registration. If a Research
+          Pod reaches the minimum number of registrants, it officially forms.
+        </p>
+        <p className="mt-2 text-sm font-medium text-cloud/60">
+          Take your time with Part 2 — it&rsquo;s the most important section.
+          Everything else supports it.
         </p>
       </div>
 
       {isOpen ? (
-        <ProposeForm cycleId={cycleId} />
+        <ProposeForm cycleId={cycleId} participantName={participantName} />
       ) : (
         <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
           <p className="text-cloud/60">
@@ -65,7 +90,12 @@ export default async function ProposePage({
                 Opens{" "}
                 {new Date(config.problem_statement_open).toLocaleDateString(
                   "en-US",
-                  { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
+                  {
+                    month: "short",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit",
+                  }
                 )}
               </p>
             )}

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -1,45 +1,149 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 
-interface Submission {
-  id: number;
-  statement_text: string;
-  created_at: string;
-}
+const IMPACT_TRACKS = [
+  "Workforce & Economic Mobility",
+  "Civic Infrastructure & Public Services",
+  "Small Business & Entrepreneurship",
+  "Education & Skills",
+  "Health & Community Wellbeing",
+  "Technology & Digital Access",
+];
 
-export default function ProposeForm({ cycleId }: { cycleId: number }) {
-  const [text, setText] = useState("");
+type Step = 1 | 2 | 3 | 4 | 5 | 6;
+
+export default function ProposeForm({
+  cycleId,
+  participantName,
+}: {
+  cycleId: number;
+  participantName: string;
+}) {
+  const [step, setStep] = useState<Step>(1);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
-  const [success, setSuccess] = useState(false);
-  const [submissions, setSubmissions] = useState<Submission[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [submitted, setSubmitted] = useState(false);
 
-  useEffect(() => {
-    fetch(`/api/problem-statements/${cycleId}`)
-      .then((r) => r.json())
-      .then((data) => {
-        if (Array.isArray(data)) {
-          // Filter to show only current user's submissions
-          // The API returns all for the cycle; we'll show them all as context
-          setSubmissions(data);
-        }
-      })
-      .finally(() => setLoading(false));
-  }, [cycleId]);
+  // Part 1 — About You
+  const [name, setName] = useState(participantName);
+  const [background, setBackground] = useState("");
+  const [experience, setExperience] = useState<
+    "lived" | "witnessed" | "both" | ""
+  >("");
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  // Part 2 — The Problem
+  const [who, setWho] = useState("");
+  const [need, setNeed] = useState("");
+  const [barrier, setBarrier] = useState("");
+  const [success, setSuccess] = useState("");
+
+  // Part 3 — Your Problem Statement
+  const [statementText, setStatementText] = useState("");
+  const [question, setQuestion] = useState("");
+
+  // Part 4 — Where This Problem Lives
+  const [impactTrack, setImpactTrack] = useState("");
+  const [impactTrackOther, setImpactTrackOther] = useState("");
+  const [themeAlignment, setThemeAlignment] = useState<
+    "none" | "direct" | "adjacent"
+  >("none");
+  const [themeConnection, setThemeConnection] = useState("");
+
+  // Part 5 — Context for Voters
+  const [tried, setTried] = useState("");
+  const [scale, setScale] = useState("");
+  const [podWork, setPodWork] = useState("");
+  const [skillsNeeded, setSkillsNeeded] = useState("");
+
+  // Part 6 — Checklist
+  const [checkRealPerson, setCheckRealPerson] = useState(false);
+  const [checkAction, setCheckAction] = useState(false);
+  const [checkNoSolution, setCheckNoSolution] = useState(false);
+  const [checkSpecific, setCheckSpecific] = useState(false);
+  const [checkSamePicture, setCheckSamePicture] = useState(false);
+
+  const allChecked =
+    checkRealPerson &&
+    checkAction &&
+    checkNoSolution &&
+    checkSpecific &&
+    checkSamePicture;
+
+  function canAdvance(): boolean {
+    switch (step) {
+      case 1:
+        return !!name.trim();
+      case 2:
+        return (
+          !!who.trim() &&
+          !!need.trim() &&
+          !!barrier.trim() &&
+          !!success.trim()
+        );
+      case 3:
+        return !!statementText.trim() && !!question.trim();
+      case 4:
+        return true; // optional
+      case 5:
+        return true; // optional but valuable
+      case 6:
+        return allChecked;
+      default:
+        return false;
+    }
+  }
+
+  async function handleSubmit() {
     setError("");
-    setSuccess(false);
     setSubmitting(true);
+
+    const resolvedTrack =
+      impactTrack === "Other" ? impactTrackOther : impactTrack;
 
     try {
       const res = await fetch("/api/problem-statements", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ cycle_id: cycleId, statement_text: text.trim() }),
+        body: JSON.stringify({
+          cycle_id: cycleId,
+          statement_text: statementText.trim(),
+          proposal_data: {
+            about: {
+              background: background.trim() || undefined,
+              experience: experience || undefined,
+            },
+            problem: {
+              who: who.trim(),
+              need: need.trim(),
+              barrier: barrier.trim(),
+              success: success.trim(),
+            },
+            statement: {
+              text: statementText.trim(),
+              question: question.trim(),
+            },
+            context: {
+              impact_track: resolvedTrack || undefined,
+              theme_alignment:
+                themeAlignment !== "none" ? themeAlignment : undefined,
+              theme_connection: themeConnection.trim() || undefined,
+            },
+            voter_context: {
+              tried: tried.trim() || undefined,
+              scale: scale.trim() || undefined,
+              pod_work: podWork.trim() || undefined,
+              skills_needed: skillsNeeded.trim() || undefined,
+            },
+            checklist: {
+              real_person: checkRealPerson,
+              action_not_thing: checkAction,
+              no_solution: checkNoSolution,
+              specific_outcome: checkSpecific,
+              same_picture: checkSamePicture,
+            },
+          },
+        }),
       });
 
       if (!res.ok) {
@@ -48,13 +152,7 @@ export default function ProposeForm({ cycleId }: { cycleId: number }) {
         return;
       }
 
-      const created = await res.json();
-      setSuccess(true);
-      setText("");
-      setSubmissions((prev) => [
-        ...prev,
-        { id: created.id, statement_text: text.trim(), created_at: created.created_at },
-      ]);
+      setSubmitted(true);
     } catch {
       setError("Network error. Please try again.");
     } finally {
@@ -62,78 +160,598 @@ export default function ProposeForm({ cycleId }: { cycleId: number }) {
     }
   }
 
+  if (submitted) {
+    return (
+      <div className="rounded-md border border-teal/30 bg-teal/[0.04] p-8 text-center">
+        <h2 className="text-xl font-bold text-white">Proposal Submitted</h2>
+        <p className="mx-auto mt-3 max-w-lg text-sm leading-relaxed text-cloud/60">
+          Your proposal enters the Open Cycle queue. At the start of each Cycle,
+          active participants vote during Phase 1 to build a shortlist. If your
+          proposal makes the shortlist, it opens for registration. Research Pods
+          that reach the minimum number of registrants officially form and begin
+          work. You&rsquo;ll be notified at each stage.
+        </p>
+        <button
+          onClick={() => {
+            setSubmitted(false);
+            setStep(1);
+            setBackground("");
+            setExperience("");
+            setWho("");
+            setNeed("");
+            setBarrier("");
+            setSuccess("");
+            setStatementText("");
+            setQuestion("");
+            setImpactTrack("");
+            setImpactTrackOther("");
+            setThemeAlignment("none");
+            setThemeConnection("");
+            setTried("");
+            setScale("");
+            setPodWork("");
+            setSkillsNeeded("");
+            setCheckRealPerson(false);
+            setCheckAction(false);
+            setCheckNoSolution(false);
+            setCheckSpecific(false);
+            setCheckSamePicture(false);
+          }}
+          className="mt-6 rounded-md bg-teal/20 px-4 py-2 text-sm font-medium text-aqua transition-colors hover:bg-teal/30"
+        >
+          Submit another proposal
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-8">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label
-            htmlFor="statement_text"
-            className="mb-1.5 block text-sm font-medium text-cloud/70"
-          >
-            Your Problem Statement
-          </label>
-          <textarea
-            id="statement_text"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            maxLength={2000}
-            rows={5}
-            required
-            placeholder="Describe a problem you'd like the community to explore..."
-            className="w-full rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-white placeholder:text-cloud/30 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal"
+      {/* Step indicator */}
+      <div className="flex items-center gap-1">
+        {([1, 2, 3, 4, 5, 6] as Step[]).map((s) => (
+          <button
+            key={s}
+            onClick={() => {
+              if (s < step) setStep(s);
+            }}
+            className={`h-2 flex-1 rounded-full transition-colors ${
+              s === step
+                ? "bg-aqua"
+                : s < step
+                  ? "bg-teal/60 hover:bg-teal/80"
+                  : "bg-white/10"
+            }`}
           />
-          <p className="mt-1 text-xs text-cloud/40">
-            {text.length}/2000 characters
-          </p>
-        </div>
+        ))}
+      </div>
 
-        {error && (
-          <p className="rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-400">
-            {error}
-          </p>
-        )}
-
-        {success && (
-          <p className="rounded-md bg-teal/10 px-3 py-2 text-sm text-aqua">
-            Problem statement submitted successfully!
-          </p>
-        )}
-
-        <button
-          type="submit"
-          disabled={submitting || !text.trim()}
-          className="rounded-md bg-teal px-4 py-2 text-sm font-medium text-midnight transition-colors hover:bg-aqua disabled:opacity-50"
-        >
-          {submitting ? "Submitting..." : "Submit Problem Statement"}
-        </button>
-      </form>
-
-      {/* Existing submissions */}
-      {!loading && submissions.length > 0 && (
-        <div>
-          <h2 className="mb-3 text-sm font-medium uppercase tracking-widest text-cloud/40">
-            Submitted Problem Statements ({submissions.length})
-          </h2>
-          <div className="space-y-3">
-            {submissions.map((s) => (
-              <div
-                key={s.id}
-                className="rounded-md border border-whisper bg-white/[0.02] p-4"
-              >
-                <p className="text-sm text-cloud/80">{s.statement_text}</p>
-                <p className="mt-2 text-xs text-cloud/40">
-                  {new Date(s.created_at).toLocaleDateString("en-US", {
-                    month: "short",
-                    day: "numeric",
-                    hour: "numeric",
-                    minute: "2-digit",
-                  })}
-                </p>
-              </div>
-            ))}
+      {/* PART 1 */}
+      {step === 1 && (
+        <section className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              Part 1 — About You
+            </h2>
           </div>
-        </div>
+
+          <Field label="Your name" required>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className={inputClass}
+            />
+          </Field>
+
+          <Field label="Your background in one sentence" hint="What you do or have done — helps voters understand where this problem comes from.">
+            <input
+              type="text"
+              value={background}
+              onChange={(e) => setBackground(e.target.value)}
+              maxLength={500}
+              className={inputClass}
+            />
+          </Field>
+
+          <Field label="Have you personally experienced this problem, or are you bringing it on behalf of others you know?">
+            <div className="space-y-2">
+              {(
+                [
+                  ["lived", "I've lived it directly"],
+                  ["witnessed", "I've witnessed it in people I've worked with"],
+                  ["both", "Both"],
+                ] as const
+              ).map(([val, label]) => (
+                <label
+                  key={val}
+                  className="flex cursor-pointer items-center gap-2 text-sm text-cloud/70"
+                >
+                  <input
+                    type="radio"
+                    name="experience"
+                    value={val}
+                    checked={experience === val}
+                    onChange={() => setExperience(val)}
+                    className="accent-teal"
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+          </Field>
+        </section>
       )}
+
+      {/* PART 2 */}
+      {step === 2 && (
+        <section className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              Part 2 — The Problem
+            </h2>
+            <p className="mt-1 text-sm text-cloud/50">
+              This is the core of your proposal. Answer all four prompts
+              carefully.
+            </p>
+          </div>
+
+          <Field
+            label="2a. Who is struggling with this problem?"
+            hint={"Describe the person \u2014 not a category or institution. Include what they\u2019re doing, what they\u2019re up against, or how they\u2019re feeling."}
+            example={"Not: \u201Csmall business owners.\u201D Better: \u201Ca food truck operator in Southeast DC who built her business without a formal financial background and is now trying to figure out whether she qualifies for a city contract.\u201D"}
+            required
+          >
+            <textarea
+              value={who}
+              onChange={(e) => setWho(e.target.value)}
+              maxLength={2000}
+              rows={4}
+              className={textareaClass}
+            />
+            <CharCount value={who} max={2000} />
+          </Field>
+
+          <Field
+            label="2b. What do they need to be able to do?"
+            hint={"Express this as an action \u2014 something they\u2019re trying to accomplish, not something they\u2019re trying to acquire."}
+            example={"Not: \u201Cthey need better resources.\u201D Better: \u201Cthey need to navigate the city\u2019s procurement process without having to hire someone to explain it to them.\u201D"}
+            required
+          >
+            <textarea
+              value={need}
+              onChange={(e) => setNeed(e.target.value)}
+              maxLength={2000}
+              rows={4}
+              className={textareaClass}
+            />
+            <CharCount value={need} max={2000} />
+          </Field>
+
+          <Field
+            label={"2c. Why can\u2019t they do it right now?"}
+            hint={"This is your insight. What\u2019s actually in the way \u2014 not the obvious answer, but the real one?"}
+            example={"Not: \u201Cbecause the process is complicated.\u201D Better: \u201Cbecause the application assumes you already have a DUNS number and a registered business entity, and no one explains that until after you\u2019ve spent three hours filling out the form.\u201D"}
+            required
+          >
+            <textarea
+              value={barrier}
+              onChange={(e) => setBarrier(e.target.value)}
+              maxLength={2000}
+              rows={4}
+              className={textareaClass}
+            />
+            <CharCount value={barrier} max={2000} />
+          </Field>
+
+          <Field
+            label="2d. What does success actually look like for this person?"
+            hint={"Describe the specific outcome \u2014 what changes in their life or work when this problem is solved. Avoid vague words like \u201Cbetter\u201D or \u201Cimproved.\u201D"}
+            example={"Not: \u201Cthey feel more empowered.\u201D Better: \u201Cshe submits a complete procurement application on her own and makes it to the review stage for the first time.\u201D"}
+            required
+          >
+            <textarea
+              value={success}
+              onChange={(e) => setSuccess(e.target.value)}
+              maxLength={2000}
+              rows={4}
+              className={textareaClass}
+            />
+            <CharCount value={success} max={2000} />
+          </Field>
+        </section>
+      )}
+
+      {/* PART 3 */}
+      {step === 3 && (
+        <section className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              Part 3 — Your Problem Statement
+            </h2>
+            <p className="mt-1 text-sm text-cloud/50">
+              Using your answers above, assemble your statement in one sentence.
+            </p>
+          </div>
+
+          <div className="rounded-md border border-white/10 bg-white/[0.02] p-4 text-sm text-cloud/50">
+            <p className="font-medium text-cloud/70">Template:</p>
+            <p className="mt-1 italic">
+              [Who is struggling] needs to [what they need to do] because [why
+              they can&rsquo;t right now].
+            </p>
+          </div>
+
+          <Field label="Your problem statement" required>
+            <textarea
+              value={statementText}
+              onChange={(e) => setStatementText(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              placeholder="[Who] needs to [what] because [why]..."
+              className={textareaClass}
+            />
+            <CharCount value={statementText} max={2000} />
+          </Field>
+
+          <div className="rounded-md border border-white/10 bg-white/[0.02] p-4 text-sm text-cloud/50">
+            <p className="font-medium text-cloud/70">
+              Now reframe it as a question your Research Pod would work to
+              answer:
+            </p>
+            <p className="mt-1 italic">
+              How might we [action] for [who] so that [the outcome from 2d]?
+            </p>
+          </div>
+
+          <Field label="Your question" required>
+            <textarea
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              placeholder="How might we..."
+              className={textareaClass}
+            />
+            <CharCount value={question} max={2000} />
+          </Field>
+        </section>
+      )}
+
+      {/* PART 4 */}
+      {step === 4 && (
+        <section className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              Part 4 — Where This Problem Lives
+            </h2>
+            <p className="mt-1 text-sm text-cloud/50">
+              These fields help us connect your Pod to the right mentors and
+              advisors. Skip this section if your problem doesn&rsquo;t fit
+              neatly — it won&rsquo;t affect your proposal.
+            </p>
+          </div>
+
+          <Field label="Impact Track" hint="If your problem maps to one of these, select it. If it cuts across more than one, pick the primary.">
+            <div className="space-y-2">
+              {IMPACT_TRACKS.map((track) => (
+                <label
+                  key={track}
+                  className="flex cursor-pointer items-center gap-2 text-sm text-cloud/70"
+                >
+                  <input
+                    type="radio"
+                    name="impact_track"
+                    value={track}
+                    checked={impactTrack === track}
+                    onChange={() => setImpactTrack(track)}
+                    className="accent-teal"
+                  />
+                  {track}
+                </label>
+              ))}
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-cloud/70">
+                <input
+                  type="radio"
+                  name="impact_track"
+                  value="Other"
+                  checked={impactTrack === "Other"}
+                  onChange={() => setImpactTrack("Other")}
+                  className="accent-teal"
+                />
+                Other
+              </label>
+              {impactTrack === "Other" && (
+                <input
+                  type="text"
+                  value={impactTrackOther}
+                  onChange={(e) => setImpactTrackOther(e.target.value)}
+                  placeholder="Specify..."
+                  className={`ml-6 ${inputClass}`}
+                />
+              )}
+            </div>
+          </Field>
+
+          <Field label="Cycle Theme Alignment" hint="Each Cycle recruits mentors and advisors around a specific industry theme. If your problem connects to the current theme, note it here.">
+            <div className="space-y-2">
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-cloud/70">
+                <input
+                  type="radio"
+                  name="theme"
+                  checked={themeAlignment === "none"}
+                  onChange={() => setThemeAlignment("none")}
+                  className="accent-teal"
+                />
+                No particular connection
+              </label>
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-cloud/70">
+                <input
+                  type="radio"
+                  name="theme"
+                  checked={themeAlignment === "direct"}
+                  onChange={() => setThemeAlignment("direct")}
+                  className="accent-teal"
+                />
+                My problem sits directly inside this theme
+              </label>
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-cloud/70">
+                <input
+                  type="radio"
+                  name="theme"
+                  checked={themeAlignment === "adjacent"}
+                  onChange={() => setThemeAlignment("adjacent")}
+                  className="accent-teal"
+                />
+                My problem touches this theme from an adjacent angle
+              </label>
+            </div>
+            {themeAlignment !== "none" && (
+              <textarea
+                value={themeConnection}
+                onChange={(e) => setThemeConnection(e.target.value)}
+                maxLength={1000}
+                rows={2}
+                placeholder="Describe the connection briefly..."
+                className={`mt-3 ${textareaClass}`}
+              />
+            )}
+          </Field>
+        </section>
+      )}
+
+      {/* PART 5 */}
+      {step === 5 && (
+        <section className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              Part 5 — Context for Voters
+            </h2>
+            <p className="mt-1 text-sm text-cloud/50">
+              This section is read by active Cycle participants during the
+              voting window. Give them enough to make a real decision — about
+              whether the problem matters and whether they want to work on it.
+            </p>
+          </div>
+
+          <Field
+            label="What has already been tried?"
+            hint={"Programs, tools, workarounds \u2014 even if they partially work. \u201CNothing I know of\u201D is a valid answer."}
+          >
+            <textarea
+              value={tried}
+              onChange={(e) => setTried(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className={textareaClass}
+            />
+          </Field>
+
+          <Field
+            label="Why does this problem matter beyond the individual?"
+            hint={"Who else is affected \u2014 a neighborhood, a sector, a workforce? What\u2019s the scale?"}
+          >
+            <textarea
+              value={scale}
+              onChange={(e) => setScale(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className={textareaClass}
+            />
+          </Field>
+
+          <Field
+            label="What would this Research Pod actually do together?"
+            hint="A pilot, a toolkit, a guide, a mapped process, a prototype — give voters a picture of the work, even a rough one."
+          >
+            <textarea
+              value={podWork}
+              onChange={(e) => setPodWork(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className={textareaClass}
+            />
+          </Field>
+
+          <Field
+            label="What kinds of people or skills would make this Research Pod stronger?"
+            hint={"Be specific \u2014 \u201Csomeone who has worked in city government,\u201D \u201Ca designer,\u201D \u201Csomeone who has used this system themselves.\u201D"}
+          >
+            <textarea
+              value={skillsNeeded}
+              onChange={(e) => setSkillsNeeded(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className={textareaClass}
+            />
+          </Field>
+        </section>
+      )}
+
+      {/* PART 6 */}
+      {step === 6 && (
+        <section className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              Part 6 — Before You Submit
+            </h2>
+            <p className="mt-1 text-sm text-cloud/50">
+              Read your problem statement one more time. Check each box
+              honestly.
+            </p>
+          </div>
+
+          <div className="rounded-md border border-white/10 bg-white/[0.02] p-4">
+            <p className="text-sm italic text-cloud/70">
+              &ldquo;{statementText}&rdquo;
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <CheckItem
+              checked={checkRealPerson}
+              onChange={setCheckRealPerson}
+              label="The problem describes a real person, not an institution or a system"
+            />
+            <CheckItem
+              checked={checkAction}
+              onChange={setCheckAction}
+              label="The need is something to do, not something to have"
+            />
+            <CheckItem
+              checked={checkNoSolution}
+              onChange={setCheckNoSolution}
+              label="The statement contains no solution — just the problem"
+            />
+            <CheckItem
+              checked={checkSpecific}
+              onChange={setCheckSpecific}
+              label={"The outcome in 2d is specific enough that you\u2019d know when you\u2019d reached it"}
+            />
+            <CheckItem
+              checked={checkSamePicture}
+              onChange={setCheckSamePicture}
+              label="Two strangers reading this would picture the same situation"
+            />
+          </div>
+
+          {!allChecked && (
+            <p className="text-sm text-cloud/40">
+              If any box is unchecked, revise before submitting. A sharper
+              proposal earns more votes.
+            </p>
+          )}
+        </section>
+      )}
+
+      {/* Error */}
+      {error && (
+        <p className="rounded-md bg-red-500/10 px-3 py-2 text-sm text-red-400">
+          {error}
+        </p>
+      )}
+
+      {/* Navigation */}
+      <div className="flex items-center justify-between border-t border-whisper pt-6">
+        <div>
+          {step > 1 && (
+            <button
+              onClick={() => setStep((step - 1) as Step)}
+              className="rounded-md bg-white/[0.06] px-4 py-2 text-sm font-medium text-cloud/70 transition-colors hover:bg-white/[0.1]"
+            >
+              &larr; Back
+            </button>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-cloud/40">Part {step} of 6</span>
+          {step < 6 ? (
+            <button
+              onClick={() => setStep((step + 1) as Step)}
+              disabled={!canAdvance()}
+              className="rounded-md bg-teal px-4 py-2 text-sm font-medium text-midnight transition-colors hover:bg-aqua disabled:opacity-50"
+            >
+              Continue &rarr;
+            </button>
+          ) : (
+            <button
+              onClick={handleSubmit}
+              disabled={submitting || !allChecked}
+              className="rounded-md bg-teal px-5 py-2 text-sm font-medium text-midnight transition-colors hover:bg-aqua disabled:opacity-50"
+            >
+              {submitting ? "Submitting..." : "Submit Proposal"}
+            </button>
+          )}
+        </div>
+      </div>
     </div>
+  );
+}
+
+/* ── Shared helpers ──────────────────────────────────────────────── */
+
+const inputClass =
+  "w-full rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-white placeholder:text-cloud/30 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal";
+
+const textareaClass =
+  "w-full rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-white placeholder:text-cloud/30 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal";
+
+function Field({
+  label,
+  hint,
+  example,
+  required,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  example?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-sm font-medium text-cloud/70">
+        {label}
+        {required && <span className="ml-0.5 text-aqua">*</span>}
+      </label>
+      {hint && <p className="mb-2 text-xs leading-relaxed text-cloud/40">{hint}</p>}
+      {example && (
+        <p className="mb-3 rounded border border-white/5 bg-white/[0.02] px-3 py-2 text-xs italic leading-relaxed text-cloud/35">
+          {example}
+        </p>
+      )}
+      {children}
+    </div>
+  );
+}
+
+function CharCount({ value, max }: { value: string; max: number }) {
+  return (
+    <p className="mt-1 text-xs text-cloud/40">
+      {value.length}/{max}
+    </p>
+  );
+}
+
+function CheckItem({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-3 text-sm text-cloud/70">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 accent-teal"
+      />
+      {label}
+    </label>
   );
 }

--- a/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
@@ -2,10 +2,23 @@
 
 import { useState, useEffect } from "react";
 
+interface ProposalData {
+  about?: { background?: string; experience?: string };
+  problem?: { who?: string; need?: string; barrier?: string; success?: string };
+  statement?: { text?: string; question?: string };
+  voter_context?: {
+    tried?: string;
+    scale?: string;
+    pod_work?: string;
+    skills_needed?: string;
+  };
+}
+
 interface ProblemStatement {
   id: number;
   participant_id: number;
   statement_text: string;
+  proposal_data: ProposalData | null;
   created_at: string;
 }
 
@@ -32,6 +45,7 @@ export default function VoteBallot({
   const [error, setError] = useState("");
   const [successId, setSuccessId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
 
   useEffect(() => {
     Promise.all([
@@ -44,12 +58,10 @@ export default function VoteBallot({
     });
   }, [cycleId]);
 
-  // Determine budget based on whether user has submitted a problem statement
-  // (We approximate: if the API rejects with budget error, we'll show it)
-  // The actual budget enforcement happens server-side
-
   function getTallyFor(stmtId: number): number {
-    return tallies.find((t) => t.problem_statement_id === stmtId)?.total_votes ?? 0;
+    return (
+      tallies.find((t) => t.problem_statement_id === stmtId)?.total_votes ?? 0
+    );
   }
 
   async function castVote(problemStatementId: number) {
@@ -110,7 +122,7 @@ export default function VoteBallot({
   const remaining = budget - totalUsed;
 
   if (loading) {
-    return <p className="text-cloud/50">Loading problem statements...</p>;
+    return <p className="text-cloud/50">Loading proposals...</p>;
   }
 
   if (statements.length === 0) {
@@ -144,52 +156,157 @@ export default function VoteBallot({
         </p>
       )}
 
-      {/* Problem statements list */}
+      {/* Proposals list */}
       <div className="space-y-4">
-        {statements.map((stmt) => (
-          <div
-            key={stmt.id}
-            className="rounded-md border border-whisper bg-white/[0.02] p-4"
-          >
-            <p className="text-sm text-cloud/80">{stmt.statement_text}</p>
-            <div className="mt-3 flex items-center justify-between">
-              <span className="text-xs text-cloud/40">
-                {getTallyFor(stmt.id)} vote{getTallyFor(stmt.id) !== 1 ? "s" : ""}
-              </span>
-              <div className="flex items-center gap-2">
-                <input
-                  type="number"
-                  min={1}
-                  max={remaining}
-                  value={pendingVotes[stmt.id] || ""}
-                  onChange={(e) =>
-                    setPendingVotes((prev) => ({
-                      ...prev,
-                      [stmt.id]: parseInt(e.target.value, 10) || 0,
-                    }))
-                  }
-                  placeholder="0"
-                  className="w-16 rounded border border-whisper bg-white/[0.04] px-2 py-1 text-center text-sm text-white placeholder:text-cloud/30 focus:border-teal focus:outline-none"
-                />
-                <button
-                  onClick={() => castVote(stmt.id)}
-                  disabled={
-                    submitting !== null ||
-                    !pendingVotes[stmt.id] ||
-                    pendingVotes[stmt.id] < 1
-                  }
-                  className="rounded bg-teal/20 px-3 py-1 text-xs font-medium text-aqua transition-colors hover:bg-teal/30 disabled:opacity-40"
-                >
-                  {submitting === stmt.id ? "..." : "Vote"}
-                </button>
-                {successId === stmt.id && (
-                  <span className="text-xs text-aqua">Voted!</span>
+        {statements.map((stmt) => {
+          const pd = stmt.proposal_data;
+          const isExpanded = expandedId === stmt.id;
+          const hasDetails = pd?.problem || pd?.voter_context;
+
+          return (
+            <div
+              key={stmt.id}
+              className="rounded-md border border-whisper bg-white/[0.02]"
+            >
+              <div className="p-4">
+                {/* Problem statement */}
+                <p className="font-medium text-white">
+                  {stmt.statement_text}
+                </p>
+
+                {/* HMW question */}
+                {pd?.statement?.question && (
+                  <p className="mt-2 text-sm italic text-cloud/50">
+                    {pd.statement.question}
+                  </p>
                 )}
+
+                {/* Submitter background */}
+                {pd?.about?.background && (
+                  <p className="mt-2 text-xs text-cloud/40">
+                    Submitted by: {pd.about.background}
+                  </p>
+                )}
+
+                {/* Expand toggle */}
+                {hasDetails && (
+                  <button
+                    onClick={() =>
+                      setExpandedId(isExpanded ? null : stmt.id)
+                    }
+                    className="mt-2 text-xs text-aqua hover:underline"
+                  >
+                    {isExpanded ? "Show less" : "Read full proposal"}
+                  </button>
+                )}
+
+                {/* Expanded details */}
+                {isExpanded && pd && (
+                  <div className="mt-4 space-y-3 border-t border-white/5 pt-4">
+                    {pd.problem?.who && (
+                      <DetailBlock
+                        label="Who is struggling"
+                        text={pd.problem.who}
+                      />
+                    )}
+                    {pd.problem?.need && (
+                      <DetailBlock
+                        label="What they need to do"
+                        text={pd.problem.need}
+                      />
+                    )}
+                    {pd.problem?.barrier && (
+                      <DetailBlock
+                        label="Why they can't do it now"
+                        text={pd.problem.barrier}
+                      />
+                    )}
+                    {pd.problem?.success && (
+                      <DetailBlock
+                        label="What success looks like"
+                        text={pd.problem.success}
+                      />
+                    )}
+                    {pd.voter_context?.tried && (
+                      <DetailBlock
+                        label="What has been tried"
+                        text={pd.voter_context.tried}
+                      />
+                    )}
+                    {pd.voter_context?.scale && (
+                      <DetailBlock
+                        label="Why it matters beyond the individual"
+                        text={pd.voter_context.scale}
+                      />
+                    )}
+                    {pd.voter_context?.pod_work && (
+                      <DetailBlock
+                        label="What the Research Pod would do"
+                        text={pd.voter_context.pod_work}
+                      />
+                    )}
+                    {pd.voter_context?.skills_needed && (
+                      <DetailBlock
+                        label="Skills & people needed"
+                        text={pd.voter_context.skills_needed}
+                      />
+                    )}
+                  </div>
+                )}
+
+                {/* Vote controls */}
+                <div className="mt-3 flex items-center justify-between">
+                  <span className="text-xs text-cloud/40">
+                    {getTallyFor(stmt.id)} vote
+                    {getTallyFor(stmt.id) !== 1 ? "s" : ""}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={1}
+                      max={remaining}
+                      value={pendingVotes[stmt.id] || ""}
+                      onChange={(e) =>
+                        setPendingVotes((prev) => ({
+                          ...prev,
+                          [stmt.id]: parseInt(e.target.value, 10) || 0,
+                        }))
+                      }
+                      placeholder="0"
+                      className="w-16 rounded border border-whisper bg-white/[0.04] px-2 py-1 text-center text-sm text-white placeholder:text-cloud/30 focus:border-teal focus:outline-none"
+                    />
+                    <button
+                      onClick={() => castVote(stmt.id)}
+                      disabled={
+                        submitting !== null ||
+                        !pendingVotes[stmt.id] ||
+                        pendingVotes[stmt.id] < 1
+                      }
+                      className="rounded bg-teal/20 px-3 py-1 text-xs font-medium text-aqua transition-colors hover:bg-teal/30 disabled:opacity-40"
+                    >
+                      {submitting === stmt.id ? "..." : "Vote"}
+                    </button>
+                    {successId === stmt.id && (
+                      <span className="text-xs text-aqua">Voted!</span>
+                    )}
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
+    </div>
+  );
+}
+
+function DetailBlock({ label, text }: { label: string; text: string }) {
+  return (
+    <div>
+      <p className="text-[11px] font-medium uppercase tracking-wider text-cloud/40">
+        {label}
+      </p>
+      <p className="mt-0.5 text-sm text-cloud/70">{text}</p>
     </div>
   );
 }

--- a/app/api/problem-statements/[cycle_id]/route.ts
+++ b/app/api/problem-statements/[cycle_id]/route.ts
@@ -11,7 +11,7 @@ export const GET = withAuth(
 
     const { data, error } = await auth.supabase
       .from("problem_statements")
-      .select("id, participant_id, statement_text, created_at")
+      .select("id, participant_id, statement_text, proposal_data, created_at")
       .eq("cycle_id", cycleId)
       .order("created_at");
 

--- a/app/api/problem-statements/route.ts
+++ b/app/api/problem-statements/route.ts
@@ -11,7 +11,7 @@ export const POST = withAuth(
   async (request: NextRequest, auth: AuthenticatedRequest) => {
     const body = await parseBody(request, problemStatementSchema);
     if (isErrorResponse(body)) return body;
-    const { cycle_id, statement_text } = body;
+    const { cycle_id, statement_text, proposal_data } = body;
     const participant_id = auth.user.participantId;
 
     if (!participant_id) {
@@ -29,9 +29,12 @@ export const POST = withAuth(
       return NextResponse.json({ error: "You must be an active participant in this cycle" }, { status: 403 });
     }
 
+    const row: Record<string, unknown> = { cycle_id, participant_id, statement_text };
+    if (proposal_data) row.proposal_data = proposal_data;
+
     const { data, error } = await auth.supabase
       .from("problem_statements")
-      .insert({ cycle_id, participant_id, statement_text })
+      .insert(row)
       .select("id, created_at")
       .single();
 

--- a/lib/validations/votes.ts
+++ b/lib/validations/votes.ts
@@ -1,11 +1,47 @@
 import { z } from "zod";
 
+export const proposalDataSchema = z.object({
+  about: z.object({
+    background: z.string().max(500).optional(),
+    experience: z.enum(["lived", "witnessed", "both"]).optional(),
+  }).optional(),
+  problem: z.object({
+    who: z.string().min(1).max(2000),
+    need: z.string().min(1).max(2000),
+    barrier: z.string().min(1).max(2000),
+    success: z.string().min(1).max(2000),
+  }),
+  statement: z.object({
+    text: z.string().min(1).max(2000),
+    question: z.string().min(1).max(2000),
+  }),
+  context: z.object({
+    impact_track: z.string().max(200).optional(),
+    theme_alignment: z.enum(["none", "direct", "adjacent"]).optional(),
+    theme_connection: z.string().max(1000).optional(),
+  }).optional(),
+  voter_context: z.object({
+    tried: z.string().max(2000).optional(),
+    scale: z.string().max(2000).optional(),
+    pod_work: z.string().max(2000).optional(),
+    skills_needed: z.string().max(2000).optional(),
+  }).optional(),
+  checklist: z.object({
+    real_person: z.boolean(),
+    action_not_thing: z.boolean(),
+    no_solution: z.boolean(),
+    specific_outcome: z.boolean(),
+    same_picture: z.boolean(),
+  }).optional(),
+});
+
 export const problemStatementSchema = z.object({
   cycle_id: z.number().int({ message: "cycle_id must be a number" }),
   statement_text: z
     .string()
     .min(1, "statement_text is required")
-    .max(2000, "statement_text must be 2000 characters or fewer"),
+    .max(5000, "statement_text must be 5000 characters or fewer"),
+  proposal_data: proposalDataSchema.optional(),
 });
 
 export const voteSchema = z.object({

--- a/supabase/migrations/00007_add_proposal_data.sql
+++ b/supabase/migrations/00007_add_proposal_data.sql
@@ -1,0 +1,5 @@
+-- Add structured proposal data column to problem_statements
+-- Stores the full multi-part proposal form data (about, problem breakdown,
+-- voter context, etc.) alongside the composed statement_text.
+ALTER TABLE problem_statements
+  ADD COLUMN proposal_data JSONB;


### PR DESCRIPTION
Replaces the single-textarea proposal form with a structured multi-step form matching the Open Cycle Problem Proposal design:

- Part 1: About You (name, background, experience)
- Part 2: The Problem (who, need, barrier, success) with inline coaching examples
- Part 3: Problem Statement + HMW question with templates
- Part 4: Impact Track & Cycle Theme Alignment (optional)
- Part 5: Voter Context (tried, scale, pod work, skills)
- Part 6: Self-assessment checklist gating submission

Backend: adds proposal_data JSONB column via migration, updates validation schema and API to accept structured data alongside statement_text. Vote ballot now shows expandable full proposals.

https://claude.ai/code/session_013Nt9V76hr7guj9nAE7bqoH