### PR TITLE
Emphasize pulse check as critical requirement for staying active

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -127,6 +127,28 @@ export default async function CycleDetailPage({
         </div>
       )}
 
+      {/* Pulse Check — always-on requirement */}
+      {cycle.status === "active" && (
+        <div className="mb-8 space-y-3">
+          <Link
+            href="/pulse-check"
+            className="flex items-center justify-between rounded-md border border-yellow-500/20 bg-yellow-500/[0.04] p-4 transition-colors hover:border-yellow-500/40 hover:bg-yellow-500/[0.07]"
+          >
+            <div className="flex items-center gap-3">
+              <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-yellow-400" />
+              <div>
+                <span className="font-medium text-white">Weekly Pulse Check</span>
+                <p className="mt-0.5 text-sm text-cloud/50">
+                  Complete your weekly check-in to stay active and retain access
+                  to GitHub, Google Docs, Slack, and Google Groups
+                </p>
+              </div>
+            </div>
+            <span className="text-sm font-medium text-yellow-300">&rarr;</span>
+          </Link>
+        </div>
+      )}
+
       <div className="mb-8 grid gap-4 sm:grid-cols-3">
         <div className="rounded-md border border-whisper bg-white/[0.02] p-4">
           <p className="text-sm text-cloud/60">Total Enrolled</p>

--- a/app/(dashboard)/cycles/page.tsx
+++ b/app/(dashboard)/cycles/page.tsx
@@ -34,6 +34,26 @@ export default async function CyclesPage() {
         <CyclePhaseIndicator cycle={activeCycle} config={activeCycleConfig} />
       )}
 
+      {/* Pulse Check CTA — always-on requirement */}
+      {activeCycle && (
+        <Link
+          href="/pulse-check"
+          className="mb-4 flex items-center justify-between rounded-md border border-yellow-500/20 bg-yellow-500/[0.04] p-4 transition-colors hover:border-yellow-500/40 hover:bg-yellow-500/[0.07]"
+        >
+          <div className="flex items-center gap-3">
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-yellow-400" />
+            <div>
+              <span className="font-medium text-white">Weekly Pulse Check</span>
+              <p className="text-sm text-cloud/50">
+                Stay active &mdash; complete your check-in to keep access to
+                cycle tools
+              </p>
+            </div>
+          </div>
+          <span className="text-sm font-medium text-yellow-300">&rarr;</span>
+        </Link>
+      )}
+
       {/* Active cycle quick-link */}
       {activeCycle && (
         <Link

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -60,8 +60,9 @@ export default async function DashboardLayout({
             </Link>
             <Link
               href="/pulse-check"
-              className="text-sm text-cloud transition-colors hover:text-aqua"
+              className="inline-flex items-center gap-1.5 rounded-full bg-yellow-500/10 px-3 py-1 text-sm font-medium text-yellow-300 transition-colors hover:bg-yellow-500/20"
             >
+              <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-yellow-400" />
               Pulse Check
             </Link>
             {adminUser && (

--- a/app/(dashboard)/pulse-check/page.tsx
+++ b/app/(dashboard)/pulse-check/page.tsx
@@ -180,9 +180,39 @@ export default function PulseCheckPage() {
       <h1 className="mb-2 text-2xl font-bold text-white">
         Pulse Check
       </h1>
-      <p className="mb-6 text-sm text-cloud/80">
-        Take a moment to reflect on your week.
+      <p className="mb-4 text-sm text-cloud/80">
+        Your weekly check-in keeps you active and connected to your
+        pod&rsquo;s tools and resources.
       </p>
+
+      {/* Consequence awareness banner */}
+      <div className="mb-6 rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-4">
+        <div className="flex items-start gap-3">
+          <svg
+            className="mt-0.5 h-5 w-5 flex-shrink-0 text-yellow-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+            />
+          </svg>
+          <div>
+            <p className="text-sm font-semibold text-yellow-300">
+              Pulse checks keep your status active
+            </p>
+            <p className="mt-1 text-sm text-cloud/70">
+              Missing 2 consecutive pulse checks triggers automatic revocation
+              of access to cycle infrastructure &mdash; GitHub repos, Google
+              Docs, Slack channels, and Google Groups.
+            </p>
+          </div>
+        </div>
+      </div>
 
       {/* Mode toggle — only shown when the user has active cycles */}
       {hasCycles && (


### PR DESCRIPTION
Add amber-styled warnings and CTAs across 4 touchpoints to make clear that weekly pulse checks are required to maintain access to cycle infrastructure (GitHub, Google Docs, Slack, Google Groups). Missing 2 consecutive checks triggers automatic revocation.

- Pulse check page: warning banner with consequence messaging
- Nav header: amber pill with pulsing dot to stand out from other links
- Cycles page: CTA card below phase indicator linking to pulse check
- Cycle detail page: CTA card in active windows area for active cycles

https://claude.ai/code/session_01DW2CwjHBA3FRwuUDHH8WfN