### PR TITLE
Add admin/moderator management and pulse check dashboards

### DIFF
--- a/app/(dashboard)/admin/cycles/[cycle_id]/assign-moderator-button.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/assign-moderator-button.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState } from "react";
+
+type Participant = {
+  participant_id: number;
+  name: string;
+};
+
+type Moderator = {
+  participant_id: number;
+  name: string;
+  assigned_at: string;
+};
+
+export default function AssignModeratorButton({
+  podId,
+  cycleId,
+  participants,
+  initialModerators,
+}: {
+  podId: number;
+  cycleId: number;
+  participants: Participant[];
+  initialModerators: Moderator[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [moderators, setModerators] = useState<Moderator[]>(initialModerators);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const currentModIds = new Set(moderators.map((m) => m.participant_id));
+  const available = participants.filter((p) => !currentModIds.has(p.participant_id));
+
+  async function assign() {
+    if (!selectedId) return;
+    setLoading(true);
+    setError(null);
+
+    const res = await fetch(`/api/pods/${podId}/moderators`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        participant_id: parseInt(selectedId, 10),
+        cycle_id: cycleId,
+      }),
+    });
+
+    setLoading(false);
+
+    if (res.ok) {
+      const data = await res.json();
+      const p = participants.find(
+        (p) => p.participant_id === parseInt(selectedId, 10)
+      );
+      setModerators((prev) => [
+        ...prev,
+        {
+          participant_id: parseInt(selectedId, 10),
+          name: p?.name ?? "",
+          assigned_at: data.assigned_at,
+        },
+      ]);
+      setSelectedId("");
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to assign");
+    }
+  }
+
+  async function remove(participantId: number) {
+    setLoading(true);
+    setError(null);
+
+    const res = await fetch(`/api/pods/${podId}/moderators/remove`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        participant_id: participantId,
+        cycle_id: cycleId,
+      }),
+    });
+
+    setLoading(false);
+
+    if (res.ok) {
+      setModerators((prev) =>
+        prev.filter((m) => m.participant_id !== participantId)
+      );
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to remove");
+    }
+  }
+
+  if (!open) {
+    return (
+      <div className="flex items-center gap-2">
+        {moderators.length > 0 && (
+          <span className="text-xs text-cloud/60">
+            {moderators.map((m) => m.name).join(", ")}
+          </span>
+        )}
+        <button
+          onClick={() => setOpen(true)}
+          className="rounded px-2 py-1 text-xs font-medium text-cloud/60 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud"
+        >
+          {moderators.length > 0 ? "Manage" : "Assign Moderator"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-whisper bg-white/[0.02] p-3 space-y-3">
+      {moderators.length > 0 && (
+        <div className="space-y-1">
+          {moderators.map((m) => (
+            <div
+              key={m.participant_id}
+              className="flex items-center justify-between text-sm"
+            >
+              <span className="text-white">{m.name}</span>
+              <button
+                onClick={() => remove(m.participant_id)}
+                disabled={loading}
+                className="text-xs text-red/70 hover:text-red disabled:opacity-50"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {available.length > 0 && (
+        <div className="flex items-center gap-2">
+          <select
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="flex-1 rounded border border-whisper bg-transparent px-2 py-1 text-xs text-white"
+          >
+            <option value="">Select participant...</option>
+            {available.map((p) => (
+              <option key={p.participant_id} value={p.participant_id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={assign}
+            disabled={!selectedId || loading}
+            className="rounded bg-teal/20 px-2.5 py-1 text-xs font-medium text-aqua hover:bg-teal/30 disabled:opacity-50"
+          >
+            {loading ? "…" : "Assign"}
+          </button>
+        </div>
+      )}
+
+      {error && <p className="text-xs text-red">{error}</p>}
+
+      <button
+        onClick={() => setOpen(false)}
+        className="text-xs text-cloud/40 hover:text-cloud/60"
+      >
+        Close
+      </button>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
@@ -7,6 +7,7 @@ import { CycleScheduleForm, CycleParamsForm } from "./cycle-config-form";
 import ParticipantsTable from "./participants-table";
 import FinalizeVotingButton from "./finalize-voting-button";
 import RevocationsSection from "./revocations-section";
+import AssignModeratorButton from "./assign-moderator-button";
 
 export type ParticipantRow = {
   participant_id: number;
@@ -81,6 +82,26 @@ export default async function AdminCycleDetailPage({
     (podsByParticipant[m.participant_id] ??= []).push(m.pod_id);
   }
 
+  // Fetch moderator assignments for all pods in this cycle
+  const { data: modAssignments } = podIds.length
+    ? await serviceClient
+        .from("moderator_assignments")
+        .select("participant_id, pod_id, assigned_at, participants (first_name, last_name, preferred_name)")
+        .in("pod_id", podIds)
+        .is("removed_at", null)
+    : { data: [] as { participant_id: number; pod_id: number; assigned_at: string; participants: unknown }[] };
+
+  const moderatorsByPod: Record<number, { participant_id: number; name: string; assigned_at: string }[]> = {};
+  for (const ma of modAssignments ?? []) {
+    const p = (ma.participants as unknown) as { first_name: string; last_name: string; preferred_name: string | null } | null;
+    const name = p ? `${p.preferred_name || p.first_name} ${p.last_name}`.trim() : "";
+    (moderatorsByPod[ma.pod_id] ??= []).push({
+      participant_id: ma.participant_id,
+      name,
+      assigned_at: ma.assigned_at,
+    });
+  }
+
   const participantIds = enrollments?.map((e) => e.participant_id) ?? [];
   const { data: elevatedRoles } = participantIds.length
     ? await serviceClient
@@ -122,6 +143,14 @@ export default async function AdminCycleDetailPage({
     .order("revoked_at", { ascending: false });
 
   const activeCount = participants.filter((p) => p.status === "active").length;
+
+  // Participant list for moderator assignment dropdown
+  const participantOptions = participants.map((p) => ({
+    participant_id: p.participant_id,
+    name: p.preferred_name
+      ? `${p.preferred_name} ${p.last_name}`
+      : `${p.first_name} ${p.last_name}`,
+  }));
 
   return (
     <div>
@@ -232,6 +261,9 @@ export default async function AdminCycleDetailPage({
                       <th className="px-4 py-3 text-left font-medium text-cloud/60">
                         Members
                       </th>
+                      <th className="px-4 py-3 text-left font-medium text-cloud/60">
+                        Moderators
+                      </th>
                       <th className="px-4 py-3 text-right font-medium text-cloud/60" />
                     </tr>
                   </thead>
@@ -261,6 +293,14 @@ export default async function AdminCycleDetailPage({
                           <td className="px-4 py-3 text-cloud/60">
                             {memberCount}
                           </td>
+                          <td className="px-4 py-3">
+                            <AssignModeratorButton
+                              podId={pod.id}
+                              cycleId={cycle.id}
+                              participants={participantOptions}
+                              initialModerators={moderatorsByPod[pod.id] ?? []}
+                            />
+                          </td>
                           <td className="px-4 py-3 text-right">
                             <Link
                               href={`/pods/${pod.id}`}
@@ -286,7 +326,7 @@ export default async function AdminCycleDetailPage({
           <h2 className="mb-4 text-lg font-semibold text-white">
             Participants ({participants.length})
           </h2>
-          <ParticipantsTable participants={participants} />
+          <ParticipantsTable participants={participants} isOwnerUser={userRoles.roles.includes("owner")} />
         </section>
 
         <hr className="border-whisper" />

--- a/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
@@ -5,10 +5,13 @@ import type { ParticipantRow } from "./page";
 
 export default function ParticipantsTable({
   participants,
+  isOwnerUser,
 }: {
   participants: ParticipantRow[];
+  isOwnerUser: boolean;
 }) {
   const [grantedIds, setGrantedIds] = useState<Set<number>>(new Set());
+  const [grantedAdminIds, setGrantedAdminIds] = useState<Set<number>>(new Set());
   const [loadingIds, setLoadingIds] = useState<Set<number>>(new Set());
   const [errors, setErrors] = useState<Record<number, string>>({});
 
@@ -34,6 +37,37 @@ export default function ParticipantsTable({
 
     if (res.ok) {
       setGrantedIds((prev) => new Set(prev).add(participantId));
+    } else {
+      const data = await res.json();
+      setErrors((prev) => ({
+        ...prev,
+        [participantId]: data.error ?? "Failed",
+      }));
+    }
+  }
+
+  async function grantAdmin(participantId: number) {
+    setLoadingIds((prev) => new Set(prev).add(participantId));
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next[participantId];
+      return next;
+    });
+
+    const res = await fetch("/api/roles/admin", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ participant_id: participantId }),
+    });
+
+    setLoadingIds((prev) => {
+      const next = new Set(prev);
+      next.delete(participantId);
+      return next;
+    });
+
+    if (res.ok) {
+      setGrantedAdminIds((prev) => new Set(prev).add(participantId));
     } else {
       const data = await res.json();
       setErrors((prev) => ({
@@ -79,15 +113,18 @@ export default function ParticipantsTable({
             const alreadyElevated = p.roles.some((r) =>
               ["owner", "admin", "observer"].includes(r)
             );
-            const justGranted = grantedIds.has(p.participant_id);
+            const justGrantedObserver = grantedIds.has(p.participant_id);
+            const justGrantedAdmin = grantedAdminIds.has(p.participant_id);
 
-            const topRole = p.roles.includes("owner")
-              ? "owner"
-              : p.roles.includes("admin")
-                ? "admin"
-                : p.roles.includes("observer")
-                  ? "observer"
-                  : null;
+            const topRole = justGrantedAdmin
+              ? "admin"
+              : p.roles.includes("owner")
+                ? "owner"
+                : p.roles.includes("admin")
+                  ? "admin"
+                  : p.roles.includes("observer")
+                    ? "observer"
+                    : null;
 
             return (
               <tr key={p.participant_id}>
@@ -110,9 +147,9 @@ export default function ParticipantsTable({
                 </td>
                 <td className="px-4 py-3 text-cloud/60">{p.pods.length}</td>
                 <td className="px-4 py-3">
-                  {(topRole ?? justGranted) && (
+                  {(topRole ?? justGrantedObserver) && (
                     <span className="rounded-full bg-teal/15 px-2 py-0.5 text-xs font-medium text-aqua">
-                      {justGranted && !topRole ? "observer" : topRole}
+                      {justGrantedObserver && !topRole ? "observer" : topRole}
                     </span>
                   )}
                 </td>
@@ -122,17 +159,30 @@ export default function ParticipantsTable({
                       {errors[p.participant_id]}
                     </span>
                   )}
-                  {!alreadyElevated && !justGranted && (
-                    <button
-                      onClick={() => grantObserver(p.participant_id)}
-                      disabled={loadingIds.has(p.participant_id)}
-                      className="rounded px-2.5 py-1 text-xs font-medium text-cloud/60 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud disabled:opacity-50"
-                    >
-                      {loadingIds.has(p.participant_id)
-                        ? "…"
-                        : "Grant Observer"}
-                    </button>
-                  )}
+                  <div className="flex items-center justify-end gap-2">
+                    {!alreadyElevated && !justGrantedObserver && !justGrantedAdmin && (
+                      <button
+                        onClick={() => grantObserver(p.participant_id)}
+                        disabled={loadingIds.has(p.participant_id)}
+                        className="rounded px-2.5 py-1 text-xs font-medium text-cloud/60 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud disabled:opacity-50"
+                      >
+                        {loadingIds.has(p.participant_id)
+                          ? "…"
+                          : "Grant Observer"}
+                      </button>
+                    )}
+                    {isOwnerUser && !p.roles.includes("owner") && !p.roles.includes("admin") && !justGrantedAdmin && (
+                      <button
+                        onClick={() => grantAdmin(p.participant_id)}
+                        disabled={loadingIds.has(p.participant_id)}
+                        className="rounded px-2.5 py-1 text-xs font-medium text-aqua ring-1 ring-teal/40 hover:bg-teal/10 hover:text-white disabled:opacity-50"
+                      >
+                        {loadingIds.has(p.participant_id)
+                          ? "…"
+                          : "Grant Admin"}
+                      </button>
+                    )}
+                  </div>
                 </td>
               </tr>
             );

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
+import { resolveUserRoles, isAdmin, isModerator } from "@/lib/auth/roles";
 import LogoutButton from "./components/logout-button";
 
 export default async function DashboardLayout({
@@ -28,6 +28,7 @@ export default async function DashboardLayout({
 
   const userRoles = await resolveUserRoles(serviceClient, user.id);
   const adminUser = isAdmin(userRoles);
+  const moderatorUser = isModerator(userRoles) && !adminUser;
 
   const displayName =
     participant?.preferred_name ||
@@ -65,6 +66,14 @@ export default async function DashboardLayout({
               <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-yellow-400" />
               Pulse Check
             </Link>
+            {moderatorUser && (
+              <Link
+                href="/moderator"
+                className="text-sm text-cloud transition-colors hover:text-aqua"
+              >
+                My Pods
+              </Link>
+            )}
             {adminUser && (
               <Link
                 href="/admin"

--- a/app/(dashboard)/moderator/page.tsx
+++ b/app/(dashboard)/moderator/page.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { resolveUserRoles, isModerator } from "@/lib/auth/roles";
+
+export default async function ModeratorPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const serviceClient = createServiceClient();
+  const userRoles = await resolveUserRoles(serviceClient, user.id);
+
+  if (!isModerator(userRoles)) redirect("/cycles");
+
+  // Fetch assigned pods with details
+  const { data: assignments } = await serviceClient
+    .from("moderator_assignments")
+    .select(
+      "pod_id, assigned_at, pods (id, name, status, cycle_id, cycles (name))"
+    )
+    .eq("participant_id", userRoles.participantId!)
+    .is("removed_at", null)
+    .order("assigned_at", { ascending: false });
+
+  const pods = (assignments ?? []).map((a) => {
+    const pod = (a.pods as unknown) as {
+      id: number;
+      name: string | null;
+      status: string;
+      cycle_id: number;
+      cycles: { name: string } | null;
+    } | null;
+    return {
+      pod_id: a.pod_id,
+      pod_name: pod?.name ?? `Pod ${a.pod_id}`,
+      status: pod?.status ?? "unknown",
+      cycle_name: pod?.cycles?.name ?? "",
+      assigned_at: a.assigned_at,
+    };
+  });
+
+  return (
+    <div>
+      <h1 className="mb-6 text-2xl font-bold text-white">My Pods</h1>
+      <p className="mb-8 text-sm text-cloud/60">
+        Pods you are assigned to moderate. View pulse check responses and member
+        activity.
+      </p>
+
+      {pods.length === 0 ? (
+        <p className="text-sm text-cloud/40">
+          You are not currently assigned to moderate any pods.
+        </p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {pods.map((pod) => (
+            <Link
+              key={pod.pod_id}
+              href={`/pods/${pod.pod_id}`}
+              className="rounded-md border border-whisper bg-white/[0.02] p-4 transition-colors hover:border-teal/40 hover:bg-white/[0.04]"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium text-white">{pod.pod_name}</span>
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                    pod.status === "active"
+                      ? "bg-teal/20 text-aqua"
+                      : pod.status === "forming"
+                        ? "bg-teal/10 text-teal"
+                        : "bg-white/10 text-cloud/60"
+                  }`}
+                >
+                  {pod.status}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-cloud/60">{pod.cycle_name}</p>
+              <p className="mt-2 text-xs text-cloud/40">
+                Assigned {new Date(pod.assigned_at).toLocaleDateString()}
+              </p>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/pods/[pod_id]/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
+import { resolveUserRoles, isAdmin, isModeratorForPod } from "@/lib/auth/roles";
+import PulseCheckDashboard from "./pulse-check-dashboard";
 
 export default async function PodDetailPage({
   params,
@@ -9,6 +11,11 @@ export default async function PodDetailPage({
 }) {
   const { pod_id } = await params;
   const supabase = await createClient();
+  const serviceClient = createServiceClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   const { data: pod } = await supabase
     .from("pods")
@@ -35,6 +42,56 @@ export default async function PodDetailPage({
     .order("created_at");
 
   const ps = (pod.problem_statements as unknown) as Record<string, string> | null;
+
+  // Check if viewer is admin or moderator for this pod
+  const userRoles = user
+    ? await resolveUserRoles(serviceClient, user.id)
+    : null;
+  const canViewDashboard =
+    userRoles && (isAdmin(userRoles) || isModeratorForPod(userRoles, pod.id));
+
+  // Fetch pulse check data for dashboard (using service client to bypass RLS)
+  let pulseCheckData: {
+    participant_id: number;
+    name: string;
+    checks: {
+      scheduled_date: string;
+      completed_at: string | null;
+      survey_responses: Record<string, unknown> | null;
+    }[];
+  }[] = [];
+
+  if (canViewDashboard && members && members.length > 0) {
+    const memberIds = members.map((m) => m.participant_id);
+
+    const { data: pulseChecks } = await serviceClient
+      .from("pulse_checks")
+      .select("participant_id, scheduled_date, completed_at, survey_responses")
+      .in("participant_id", memberIds)
+      .eq("cycle_id", pod.cycle_id)
+      .order("scheduled_date", { ascending: false });
+
+    const checksByParticipant: Record<
+      number,
+      { scheduled_date: string; completed_at: string | null; survey_responses: Record<string, unknown> | null }[]
+    > = {};
+    for (const pc of pulseChecks ?? []) {
+      (checksByParticipant[pc.participant_id] ??= []).push({
+        scheduled_date: pc.scheduled_date,
+        completed_at: pc.completed_at,
+        survey_responses: pc.survey_responses as Record<string, unknown> | null,
+      });
+    }
+
+    pulseCheckData = members.map((m) => {
+      const p = (m.participants as unknown) as Record<string, string> | null;
+      return {
+        participant_id: m.participant_id,
+        name: `${p?.preferred_name || p?.first_name || ""} ${p?.last_name || ""}`.trim(),
+        checks: checksByParticipant[m.participant_id] ?? [],
+      };
+    });
+  }
 
   return (
     <div>
@@ -125,15 +182,16 @@ export default async function PodDetailPage({
       </div>
 
       {projects && projects.length > 0 && (
-        <div>
+        <div className="mb-8">
           <h2 className="mb-3 text-lg font-semibold text-white">
             Projects
           </h2>
           <div className="grid gap-3 sm:grid-cols-2">
             {projects.map((project) => (
-              <div
+              <Link
                 key={project.id}
-                className="rounded-md border border-whisper bg-white/[0.02] p-4"
+                href={`/projects/${project.id}`}
+                className="rounded-md border border-whisper bg-white/[0.02] p-4 transition-colors hover:border-teal/40 hover:bg-white/[0.04]"
               >
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-white">
@@ -151,10 +209,14 @@ export default async function PodDetailPage({
                     {project.status}
                   </span>
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
         </div>
+      )}
+
+      {canViewDashboard && (
+        <PulseCheckDashboard members={pulseCheckData} />
       )}
     </div>
   );

--- a/app/(dashboard)/pods/[pod_id]/pulse-check-dashboard.tsx
+++ b/app/(dashboard)/pods/[pod_id]/pulse-check-dashboard.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+
+type PulseCheck = {
+  scheduled_date: string;
+  completed_at: string | null;
+  survey_responses: Record<string, unknown> | null;
+};
+
+type MemberPulseData = {
+  participant_id: number;
+  name: string;
+  checks: PulseCheck[];
+};
+
+export default function PulseCheckDashboard({
+  members,
+}: {
+  members: MemberPulseData[];
+}) {
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  // Summary stats
+  const totalChecks = members.reduce((sum, m) => sum + m.checks.length, 0);
+  const completedChecks = members.reduce(
+    (sum, m) => sum + m.checks.filter((c) => c.completed_at).length,
+    0
+  );
+  const completionRate =
+    totalChecks > 0 ? Math.round((completedChecks / totalChecks) * 100) : 0;
+
+  const energyValues = members.flatMap((m) =>
+    m.checks
+      .filter((c) => c.survey_responses?.energy_level != null)
+      .map((c) => Number(c.survey_responses!.energy_level))
+  );
+  const avgEnergy =
+    energyValues.length > 0
+      ? (energyValues.reduce((a, b) => a + b, 0) / energyValues.length).toFixed(
+          1
+        )
+      : "—";
+
+  return (
+    <div>
+      <hr className="mb-8 border-whisper" />
+      <h2 className="mb-4 text-lg font-semibold text-white">
+        Pulse Checks
+      </h2>
+
+      {/* Summary stats */}
+      <div className="mb-6 grid grid-cols-3 gap-4">
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-4">
+          <p className="text-sm text-cloud/60">Completion Rate</p>
+          <p className="text-2xl font-bold text-white">{completionRate}%</p>
+          <p className="text-xs text-cloud/40">
+            {completedChecks} / {totalChecks}
+          </p>
+        </div>
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-4">
+          <p className="text-sm text-cloud/60">Avg Energy</p>
+          <p className="text-2xl font-bold text-aqua">{avgEnergy}</p>
+          <p className="text-xs text-cloud/40">out of 5</p>
+        </div>
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-4">
+          <p className="text-sm text-cloud/60">Members</p>
+          <p className="text-2xl font-bold text-white">{members.length}</p>
+        </div>
+      </div>
+
+      {/* Per-member table */}
+      <div className="overflow-hidden rounded-md border border-whisper">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-white/[0.04]">
+            <tr>
+              <th className="px-4 py-3 font-medium text-cloud/60">Name</th>
+              <th className="px-4 py-3 font-medium text-cloud/60">
+                Completed
+              </th>
+              <th className="px-4 py-3 font-medium text-cloud/60">
+                Last Check
+              </th>
+              <th className="px-4 py-3 font-medium text-cloud/60">
+                Avg Energy
+              </th>
+              <th className="px-4 py-3 text-right font-medium text-cloud/60" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-whisper">
+            {members.map((m) => {
+              const completed = m.checks.filter((c) => c.completed_at).length;
+              const lastCompleted = m.checks.find((c) => c.completed_at);
+              const memberEnergy = m.checks
+                .filter((c) => c.survey_responses?.energy_level != null)
+                .map((c) => Number(c.survey_responses!.energy_level));
+              const memberAvgEnergy =
+                memberEnergy.length > 0
+                  ? (
+                      memberEnergy.reduce((a, b) => a + b, 0) /
+                      memberEnergy.length
+                    ).toFixed(1)
+                  : "—";
+              const isExpanded = expandedId === m.participant_id;
+
+              return (
+                <tr key={m.participant_id} className="group">
+                  <td colSpan={5} className="p-0">
+                    <div
+                      className="flex cursor-pointer items-center px-4 py-3 hover:bg-white/[0.02]"
+                      onClick={() =>
+                        setExpandedId(isExpanded ? null : m.participant_id)
+                      }
+                    >
+                      <span className="flex-1 font-medium text-white">
+                        {m.name}
+                      </span>
+                      <span className="w-24 text-cloud/60">
+                        {completed} / {m.checks.length}
+                      </span>
+                      <span className="w-32 text-cloud/60">
+                        {lastCompleted
+                          ? new Date(
+                              lastCompleted.completed_at!
+                            ).toLocaleDateString()
+                          : "—"}
+                      </span>
+                      <span className="w-24 text-cloud/60">
+                        {memberAvgEnergy}
+                      </span>
+                      <span className="w-8 text-right text-cloud/40">
+                        {isExpanded ? "−" : "+"}
+                      </span>
+                    </div>
+                    {isExpanded && (
+                      <div className="border-t border-whisper/50 bg-white/[0.01] px-4 py-3">
+                        {m.checks.filter((c) => c.completed_at).length === 0 ? (
+                          <p className="text-sm text-cloud/40">
+                            No completed pulse checks yet.
+                          </p>
+                        ) : (
+                          <div className="space-y-3">
+                            {m.checks
+                              .filter((c) => c.completed_at)
+                              .map((c, i) => {
+                                const r = c.survey_responses;
+                                return (
+                                  <div
+                                    key={i}
+                                    className="rounded border border-whisper/50 bg-white/[0.01] p-3"
+                                  >
+                                    <div className="mb-2 flex items-center justify-between">
+                                      <span className="text-xs font-medium text-aqua">
+                                        {new Date(
+                                          c.scheduled_date
+                                        ).toLocaleDateString()}
+                                      </span>
+                                      {r?.energy_level != null && (
+                                        <span className="rounded-full bg-teal/15 px-2 py-0.5 text-xs text-aqua">
+                                          Energy: {String(r.energy_level)}/5
+                                        </span>
+                                      )}
+                                    </div>
+                                    {r?.accomplishment != null && (
+                                      <div className="mb-1">
+                                        <span className="text-xs font-medium text-cloud/60">
+                                          Accomplishment:{" "}
+                                        </span>
+                                        <span className="text-sm text-white">
+                                          {String(r.accomplishment)}
+                                        </span>
+                                      </div>
+                                    )}
+                                    {r?.highlight != null && (
+                                      <div className="mb-1">
+                                        <span className="text-xs font-medium text-cloud/60">
+                                          Highlight:{" "}
+                                        </span>
+                                        <span className="text-sm text-white">
+                                          {String(r.highlight)}
+                                        </span>
+                                      </div>
+                                    )}
+                                    {r?.challenge != null && (
+                                      <div className="mb-1">
+                                        <span className="text-xs font-medium text-cloud/60">
+                                          Challenge:{" "}
+                                        </span>
+                                        <span className="text-sm text-white">
+                                          {String(r.challenge)}
+                                        </span>
+                                      </div>
+                                    )}
+                                    {r?.help_needed != null && (
+                                      <div>
+                                        <span className="text-xs font-medium text-cloud/60">
+                                          Help Needed:{" "}
+                                        </span>
+                                        <span className="text-sm text-white">
+                                          {String(r.help_needed)}
+                                        </span>
+                                      </div>
+                                    )}
+                                  </div>
+                                );
+                              })}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/projects/[project_id]/page.tsx
+++ b/app/(dashboard)/projects/[project_id]/page.tsx
@@ -1,0 +1,188 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { notFound } from "next/navigation";
+import { resolveUserRoles, isAdmin, isModeratorForPod } from "@/lib/auth/roles";
+import PulseCheckDashboard from "../../pods/[pod_id]/pulse-check-dashboard";
+
+export default async function ProjectDetailPage({
+  params,
+}: {
+  params: Promise<{ project_id: string }>;
+}) {
+  const { project_id } = await params;
+  const supabase = await createClient();
+  const serviceClient = createServiceClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const projectId = parseInt(project_id);
+
+  const { data: project } = await supabase
+    .from("projects")
+    .select("id, name, status, pod_id, cycle_id, solution_proposal_id")
+    .eq("id", projectId)
+    .single();
+
+  if (!project) notFound();
+
+  // Get pod info for breadcrumb
+  const { data: pod } = await supabase
+    .from("pods")
+    .select("id, name")
+    .eq("id", project.pod_id)
+    .single();
+
+  // Get project members
+  const { data: memberships } = await supabase
+    .from("project_memberships")
+    .select(
+      "participant_id, registered_at, left_at, participants(first_name, last_name, preferred_name)"
+    )
+    .eq("project_id", projectId)
+    .order("registered_at");
+
+  const activeMembers = (memberships ?? []).filter((m) => !m.left_at);
+
+  // Check if viewer is admin or moderator for the parent pod
+  const userRoles = user
+    ? await resolveUserRoles(serviceClient, user.id)
+    : null;
+  const canViewDashboard =
+    userRoles &&
+    (isAdmin(userRoles) || isModeratorForPod(userRoles, project.pod_id));
+
+  // Fetch pulse check data for project members
+  let pulseCheckData: {
+    participant_id: number;
+    name: string;
+    checks: {
+      scheduled_date: string;
+      completed_at: string | null;
+      survey_responses: Record<string, unknown> | null;
+    }[];
+  }[] = [];
+
+  if (canViewDashboard && activeMembers.length > 0) {
+    const memberIds = activeMembers.map((m) => m.participant_id);
+
+    const { data: pulseChecks } = await serviceClient
+      .from("pulse_checks")
+      .select("participant_id, scheduled_date, completed_at, survey_responses")
+      .in("participant_id", memberIds)
+      .eq("cycle_id", project.cycle_id)
+      .order("scheduled_date", { ascending: false });
+
+    const checksByParticipant: Record<
+      number,
+      {
+        scheduled_date: string;
+        completed_at: string | null;
+        survey_responses: Record<string, unknown> | null;
+      }[]
+    > = {};
+    for (const pc of pulseChecks ?? []) {
+      (checksByParticipant[pc.participant_id] ??= []).push({
+        scheduled_date: pc.scheduled_date,
+        completed_at: pc.completed_at,
+        survey_responses: pc.survey_responses as Record<string, unknown> | null,
+      });
+    }
+
+    pulseCheckData = activeMembers.map((m) => {
+      const p = (m.participants as unknown) as Record<string, string> | null;
+      return {
+        participant_id: m.participant_id,
+        name: `${p?.preferred_name || p?.first_name || ""} ${p?.last_name || ""}`.trim(),
+        checks: checksByParticipant[m.participant_id] ?? [],
+      };
+    });
+  }
+
+  return (
+    <div>
+      <div className="mb-8">
+        <div className="flex items-center gap-2 text-sm text-cloud/60">
+          <Link href={`/cycles/${project.cycle_id}`} className="hover:text-aqua">
+            Cycle
+          </Link>
+          <span>/</span>
+          <Link href={`/pods/${project.pod_id}`} className="hover:text-aqua">
+            {pod?.name || `Pod ${project.pod_id}`}
+          </Link>
+        </div>
+        <h1 className="mt-2 text-2xl font-bold text-white">
+          {project.name || `Project ${project.id}`}
+        </h1>
+        <span
+          className={`mt-1 inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${
+            project.status === "active"
+              ? "bg-teal/20 text-aqua"
+              : project.status === "forming"
+                ? "bg-teal/10 text-teal"
+                : "bg-white/10 text-cloud/60"
+          }`}
+        >
+          {project.status}
+        </span>
+      </div>
+
+      <div className="mb-8">
+        <h2 className="mb-3 text-lg font-semibold text-white">
+          Members ({activeMembers.length})
+        </h2>
+        <div className="overflow-hidden rounded-md border border-whisper">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-teal/[0.08]">
+              <tr>
+                <th className="px-4 py-2 text-xs font-semibold text-aqua">
+                  Name
+                </th>
+                <th className="px-4 py-2 text-xs font-semibold text-aqua">
+                  Status
+                </th>
+                <th className="px-4 py-2 text-xs font-semibold text-aqua">
+                  Registered
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-whisper">
+              {(memberships ?? []).map((m) => {
+                const p = (m.participants as unknown) as Record<
+                  string,
+                  string
+                > | null;
+                return (
+                  <tr key={m.participant_id} className="bg-white/[0.01]">
+                    <td className="px-4 py-2 text-white">
+                      {p?.preferred_name || p?.first_name} {p?.last_name}
+                    </td>
+                    <td className="px-4 py-2">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs ${
+                          m.left_at
+                            ? "bg-red/20 text-red-300"
+                            : "bg-teal/20 text-aqua"
+                        }`}
+                      >
+                        {m.left_at ? "left" : "active"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-cloud/60">
+                      {new Date(m.registered_at).toLocaleDateString()}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {canViewDashboard && (
+        <PulseCheckDashboard members={pulseCheckData} />
+      )}
+    </div>
+  );
+}

--- a/app/api/pods/[pod_id]/moderators/remove/route.ts
+++ b/app/api/pods/[pod_id]/moderators/remove/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { dbError } from "@/lib/api/errors";
+import { parseIntParam } from "@/lib/api/params";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { moderatorAssignmentSchema } from "@/lib/validations/pods";
+
+export const POST = withAdminAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest, params: Record<string, string>) => {
+    const podId = parseIntParam(params.pod_id, "pod_id");
+    if (podId instanceof NextResponse) return podId;
+
+    const body = await parseBody(request, moderatorAssignmentSchema);
+    if (isErrorResponse(body)) return body;
+    const { participant_id, cycle_id } = body;
+
+    const { data, error } = await auth.supabase
+      .from("moderator_assignments")
+      .update({ removed_at: new Date().toISOString() })
+      .eq("pod_id", podId)
+      .eq("participant_id", participant_id)
+      .eq("cycle_id", cycle_id)
+      .is("removed_at", null)
+      .select("id, removed_at")
+      .single();
+
+    if (error) {
+      return dbError(error);
+    }
+
+    return NextResponse.json(data);
+  }
+);

--- a/app/api/roles/admin/route.ts
+++ b/app/api/roles/admin/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withOwnerAuth } from "@/lib/auth/middleware";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { dbError } from "@/lib/api/errors";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { observerRoleSchema } from "@/lib/validations/pods";
+
+export const POST = withOwnerAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest) => {
+    const body = await parseBody(request, observerRoleSchema);
+    if (isErrorResponse(body)) return body;
+    const { participant_id } = body;
+
+    const { data, error } = await auth.supabase
+      .from("user_roles")
+      .insert({
+        participant_id,
+        role: "admin",
+        granted_by: auth.user.participantId,
+      })
+      .select("id, granted_at")
+      .single();
+
+    if (error) {
+      return dbError(error);
+    }
+
+    return NextResponse.json(data, { status: 201 });
+  }
+);

--- a/lib/auth/middleware.ts
+++ b/lib/auth/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { resolveUserRoles, UserRoles, isAdmin } from "./roles";
+import { resolveUserRoles, UserRoles, isAdmin, isOwner } from "./roles";
 
 export interface AuthenticatedRequest {
   user: UserRoles;
@@ -33,6 +33,15 @@ export function withAuth(handler: RouteHandler) {
 export function withAdminAuth(handler: RouteHandler) {
   return withAuth(async (request, auth, params) => {
     if (!isAdmin(auth.user)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    return handler(request, auth, params);
+  });
+}
+
+export function withOwnerAuth(handler: RouteHandler) {
+  return withAuth(async (request, auth, params) => {
+    if (!isOwner(auth.user)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
     return handler(request, auth, params);

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -79,6 +79,10 @@ export async function resolveUserRoles(
   return { userId: authUserId, participantId, roles, moderatorPodIds, cycleEnrollments };
 }
 
+export function isOwner(roles: UserRoles): boolean {
+  return roles.roles.includes("owner");
+}
+
 export function isAdmin(roles: UserRoles): boolean {
   return roles.roles.includes("admin") || roles.roles.includes("owner");
 }


### PR DESCRIPTION
- Owners can grant admin roles from the participants table
- Owners/admins can assign and remove moderators for pods
- Pod detail page shows pulse check responses for admins/moderators
- New project detail page with pulse check dashboard
- Moderator landing page with assigned pods navigation

https://claude.ai/code/session_014Z5dNKZJwviv39PoGfLKwv