### PR TITLE
Add granular permissions model and invitation system

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,8 +1,23 @@
 "use client";
 
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 
-export default function LoginPage() {
+function LoginContent() {
+  const searchParams = useSearchParams();
+  const inviteToken = searchParams.get("invite");
+  const [invited, setInvited] = useState(false);
+
+  useEffect(() => {
+    if (inviteToken) {
+      // Store invite token in a cookie so it survives the OAuth redirect
+      document.cookie = `invite_token=${inviteToken}; path=/; max-age=3600; SameSite=Lax`;
+      setInvited(true);
+    }
+  }, [inviteToken]);
+
   const handleLogin = async () => {
     const supabase = createClient();
     await supabase.auth.signInWithOAuth({
@@ -20,9 +35,15 @@ export default function LoginPage() {
           <h1 className="text-2xl font-bold tracking-tight text-white">
             The Upskilling Labs
           </h1>
-          <p className="mt-2 text-sm text-cloud/80">
-            Sign in to continue
-          </p>
+          {invited ? (
+            <p className="mt-2 text-sm text-aqua">
+              You&apos;ve been invited to join The Upskilling Labs
+            </p>
+          ) : (
+            <p className="mt-2 text-sm text-cloud/80">
+              Sign in to continue
+            </p>
+          )}
         </div>
         <button
           onClick={handleLogin}
@@ -46,9 +67,17 @@ export default function LoginPage() {
               fill="#EA4335"
             />
           </svg>
-          Sign in with Google
+          {invited ? "Sign in to accept invitation" : "Sign in with Google"}
         </button>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
   );
 }

--- a/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
@@ -345,7 +345,7 @@ export default async function AdminCycleDetailPage({
           <h2 className="mb-4 text-lg font-semibold text-white">
             Participants ({participants.length})
           </h2>
-          <ParticipantsTable participants={participants} isOwnerUser={userRoles.roles.includes("owner")} />
+          <ParticipantsTable participants={participants} />
         </section>
 
         <hr className="border-whisper" />

--- a/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
@@ -1,114 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import Link from "next/link";
 import type { ParticipantRow } from "./page";
+
+const ROLE_COLORS: Record<string, string> = {
+  owner: "bg-yellow-500/15 text-yellow-300",
+  admin: "bg-teal/15 text-aqua",
+  developer: "bg-purple-500/15 text-purple-300",
+  moderator: "bg-blue-500/15 text-blue-300",
+  observer: "bg-white/10 text-cloud/60",
+};
 
 export default function ParticipantsTable({
   participants,
-  isOwnerUser,
 }: {
   participants: ParticipantRow[];
-  isOwnerUser: boolean;
 }) {
-  const [grantedIds, setGrantedIds] = useState<Set<number>>(new Set());
-  const [grantedAdminIds, setGrantedAdminIds] = useState<Set<number>>(new Set());
-  const [grantedDeveloperIds, setGrantedDeveloperIds] = useState<Set<number>>(new Set());
-  const [loadingIds, setLoadingIds] = useState<Set<number>>(new Set());
-  const [errors, setErrors] = useState<Record<number, string>>({});
-
-  async function grantObserver(participantId: number) {
-    setLoadingIds((prev) => new Set(prev).add(participantId));
-    setErrors((prev) => {
-      const next = { ...prev };
-      delete next[participantId];
-      return next;
-    });
-
-    const res = await fetch("/api/roles/observer", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ participant_id: participantId }),
-    });
-
-    setLoadingIds((prev) => {
-      const next = new Set(prev);
-      next.delete(participantId);
-      return next;
-    });
-
-    if (res.ok) {
-      setGrantedIds((prev) => new Set(prev).add(participantId));
-    } else {
-      const data = await res.json();
-      setErrors((prev) => ({
-        ...prev,
-        [participantId]: data.error ?? "Failed",
-      }));
-    }
-  }
-
-  async function grantAdmin(participantId: number) {
-    setLoadingIds((prev) => new Set(prev).add(participantId));
-    setErrors((prev) => {
-      const next = { ...prev };
-      delete next[participantId];
-      return next;
-    });
-
-    const res = await fetch("/api/roles/admin", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ participant_id: participantId }),
-    });
-
-    setLoadingIds((prev) => {
-      const next = new Set(prev);
-      next.delete(participantId);
-      return next;
-    });
-
-    if (res.ok) {
-      setGrantedAdminIds((prev) => new Set(prev).add(participantId));
-    } else {
-      const data = await res.json();
-      setErrors((prev) => ({
-        ...prev,
-        [participantId]: data.error ?? "Failed",
-      }));
-    }
-  }
-
-  async function grantDeveloper(participantId: number) {
-    setLoadingIds((prev) => new Set(prev).add(participantId));
-    setErrors((prev) => {
-      const next = { ...prev };
-      delete next[participantId];
-      return next;
-    });
-
-    const res = await fetch("/api/roles/developer", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ participant_id: participantId }),
-    });
-
-    setLoadingIds((prev) => {
-      const next = new Set(prev);
-      next.delete(participantId);
-      return next;
-    });
-
-    if (res.ok) {
-      setGrantedDeveloperIds((prev) => new Set(prev).add(participantId));
-    } else {
-      const data = await res.json();
-      setErrors((prev) => ({
-        ...prev,
-        [participantId]: data.error ?? "Failed",
-      }));
-    }
-  }
-
   if (participants.length === 0) {
     return <p className="text-sm text-cloud/60">No participants enrolled.</p>;
   }
@@ -131,7 +38,7 @@ export default function ParticipantsTable({
               Pods
             </th>
             <th className="px-4 py-3 text-left font-medium text-cloud/60">
-              Role
+              Roles
             </th>
             <th className="px-4 py-3 text-right font-medium text-cloud/60" />
           </tr>
@@ -141,27 +48,6 @@ export default function ParticipantsTable({
             const displayName = p.preferred_name
               ? `${p.preferred_name} ${p.last_name}`
               : `${p.first_name} ${p.last_name}`;
-
-            const alreadyElevated = p.roles.some((r) =>
-              ["owner", "admin", "developer", "observer"].includes(r)
-            );
-            const justGrantedObserver = grantedIds.has(p.participant_id);
-            const justGrantedAdmin = grantedAdminIds.has(p.participant_id);
-            const justGrantedDeveloper = grantedDeveloperIds.has(p.participant_id);
-
-            const topRole = justGrantedAdmin
-              ? "admin"
-              : p.roles.includes("owner")
-                ? "owner"
-                : p.roles.includes("admin")
-                  ? "admin"
-                  : justGrantedDeveloper
-                    ? "developer"
-                    : p.roles.includes("developer")
-                      ? "developer"
-                      : p.roles.includes("observer")
-                        ? "observer"
-                        : null;
 
             return (
               <tr key={p.participant_id}>
@@ -184,61 +70,29 @@ export default function ParticipantsTable({
                 </td>
                 <td className="px-4 py-3 text-cloud/60">{p.pods.length}</td>
                 <td className="px-4 py-3">
-                  {(topRole ?? justGrantedObserver) && (
-                    <span
-                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                        topRole === "owner"
-                          ? "bg-yellow-500/15 text-yellow-300"
-                          : topRole === "developer"
-                            ? "bg-purple-500/15 text-purple-300"
-                            : "bg-teal/15 text-aqua"
-                      }`}
-                    >
-                      {justGrantedObserver && !topRole ? "observer" : topRole}
-                    </span>
-                  )}
-                </td>
-                <td className="px-4 py-3 text-right">
-                  {errors[p.participant_id] && (
-                    <span className="mr-2 text-xs text-red">
-                      {errors[p.participant_id]}
-                    </span>
-                  )}
-                  <div className="flex items-center justify-end gap-2">
-                    {!alreadyElevated && !justGrantedObserver && !justGrantedAdmin && !justGrantedDeveloper && (
-                      <button
-                        onClick={() => grantObserver(p.participant_id)}
-                        disabled={loadingIds.has(p.participant_id)}
-                        className="rounded px-2.5 py-1 text-xs font-medium text-cloud/60 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud disabled:opacity-50"
+                  <div className="flex flex-wrap gap-1">
+                    {p.roles.map((role) => (
+                      <span
+                        key={role}
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                          ROLE_COLORS[role] ?? "bg-white/10 text-cloud/60"
+                        }`}
                       >
-                        {loadingIds.has(p.participant_id)
-                          ? "…"
-                          : "Grant Observer"}
-                      </button>
-                    )}
-                    {isOwnerUser && !p.roles.includes("owner") && !p.roles.includes("admin") && !p.roles.includes("developer") && !justGrantedAdmin && !justGrantedDeveloper && (
-                      <>
-                        <button
-                          onClick={() => grantDeveloper(p.participant_id)}
-                          disabled={loadingIds.has(p.participant_id)}
-                          className="rounded px-2.5 py-1 text-xs font-medium text-purple-300 ring-1 ring-purple-500/40 hover:bg-purple-500/10 hover:text-white disabled:opacity-50"
-                        >
-                          {loadingIds.has(p.participant_id)
-                            ? "…"
-                            : "Grant Developer"}
-                        </button>
-                        <button
-                          onClick={() => grantAdmin(p.participant_id)}
-                          disabled={loadingIds.has(p.participant_id)}
-                          className="rounded px-2.5 py-1 text-xs font-medium text-aqua ring-1 ring-teal/40 hover:bg-teal/10 hover:text-white disabled:opacity-50"
-                        >
-                          {loadingIds.has(p.participant_id)
-                            ? "…"
-                            : "Grant Admin"}
-                        </button>
-                      </>
+                        {role}
+                      </span>
+                    ))}
+                    {p.roles.length === 0 && (
+                      <span className="text-xs text-cloud/30">—</span>
                     )}
                   </div>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <Link
+                    href={`/admin/participants/${p.participant_id}/permissions`}
+                    className="rounded px-2.5 py-1 text-xs font-medium text-aqua ring-1 ring-teal/40 hover:bg-teal/10"
+                  >
+                    Permissions
+                  </Link>
                 </td>
               </tr>
             );

--- a/app/(dashboard)/admin/invitations/invitations-table.tsx
+++ b/app/(dashboard)/admin/invitations/invitations-table.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useState } from "react";
+
+type Invitation = {
+  id: number;
+  email: string;
+  token: string;
+  permissions: string[];
+  role_preset: string | null;
+  cycle_id: number | null;
+  cycle_name: string | null;
+  pod_id: number | null;
+  status: string;
+  created_at: string;
+  expires_at: string;
+  accepted_at: string | null;
+};
+
+export default function InvitationsTable({
+  invitations: initialInvitations,
+  cycles,
+  pods,
+  canManageRoles,
+}: {
+  invitations: Invitation[];
+  cycles: { id: number; name: string }[];
+  pods: { id: number; name: string; cycle_name: string }[];
+  canManageRoles: boolean;
+}) {
+  const [invitations, setInvitations] = useState(initialInvitations);
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<number | null>(null);
+
+  // Create form state
+  const [email, setEmail] = useState("");
+  const [rolePreset, setRolePreset] = useState<string>("");
+  const [cycleId, setCycleId] = useState<string>("");
+  const [podId, setPodId] = useState<string>("");
+
+  const filtered = invitations.filter(
+    (i) => statusFilter === "all" || i.status === statusFilter
+  );
+
+  async function createInvitation(e: React.FormEvent) {
+    e.preventDefault();
+    setCreating(true);
+    setError(null);
+
+    const body: Record<string, unknown> = { email };
+    if (rolePreset) body.role_preset = rolePreset;
+    if (cycleId) body.cycle_id = parseInt(cycleId);
+    if (podId) body.pod_id = parseInt(podId);
+
+    const res = await fetch("/api/invitations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    setCreating(false);
+
+    if (res.ok) {
+      const data = await res.json();
+      const cycleName = cycleId
+        ? cycles.find((c) => c.id === parseInt(cycleId))?.name ?? null
+        : null;
+      setInvitations((prev) => [
+        {
+          ...data,
+          permissions: data.permissions ?? [],
+          cycle_name: cycleName,
+        },
+        ...prev,
+      ]);
+      setEmail("");
+      setRolePreset("");
+      setCycleId("");
+      setPodId("");
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to create invitation");
+    }
+  }
+
+  async function revokeInvitation(id: number) {
+    const res = await fetch(`/api/invitations/${id}`, { method: "PATCH" });
+    if (res.ok) {
+      setInvitations((prev) =>
+        prev.map((i) => (i.id === id ? { ...i, status: "revoked" } : i))
+      );
+    }
+  }
+
+  function copyLink(invitation: Invitation) {
+    const link = `${window.location.origin}/login?invite=${invitation.token}`;
+    navigator.clipboard.writeText(link);
+    setCopied(invitation.id);
+    setTimeout(() => setCopied(null), 2000);
+  }
+
+  const availablePresets = canManageRoles
+    ? ["", "observer", "moderator", "admin", "developer", "owner"]
+    : ["", "observer", "moderator"];
+
+  return (
+    <div className="space-y-6">
+      {/* Create form */}
+      <div className="rounded-md border border-whisper bg-white/[0.02] p-4">
+        <h3 className="mb-3 text-sm font-semibold text-white">
+          Create Invitation
+        </h3>
+        <form onSubmit={createInvitation} className="flex flex-wrap items-end gap-3">
+          <label className="block flex-1 min-w-[200px]">
+            <span className="text-xs text-cloud/60">Email *</span>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              placeholder="name@example.com"
+              className="mt-1 block w-full rounded-md border border-whisper bg-transparent px-3 py-2 text-sm text-white placeholder:text-cloud/30 focus:border-teal/50 focus:outline-none"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs text-cloud/60">Role Preset</span>
+            <select
+              value={rolePreset}
+              onChange={(e) => setRolePreset(e.target.value)}
+              className="mt-1 block rounded-md border border-whisper bg-transparent px-3 py-2 text-sm text-white focus:border-teal/50 focus:outline-none"
+            >
+              <option value="">No preset</option>
+              {availablePresets
+                .filter((p) => p !== "")
+                .map((p) => (
+                  <option key={p} value={p}>
+                    {p.charAt(0).toUpperCase() + p.slice(1)}
+                  </option>
+                ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-xs text-cloud/60">Cycle</span>
+            <select
+              value={cycleId}
+              onChange={(e) => setCycleId(e.target.value)}
+              className="mt-1 block rounded-md border border-whisper bg-transparent px-3 py-2 text-sm text-white focus:border-teal/50 focus:outline-none"
+            >
+              <option value="">None</option>
+              {cycles.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {rolePreset === "moderator" && (
+            <label className="block">
+              <span className="text-xs text-cloud/60">Pod</span>
+              <select
+                value={podId}
+                onChange={(e) => setPodId(e.target.value)}
+                className="mt-1 block rounded-md border border-whisper bg-transparent px-3 py-2 text-sm text-white focus:border-teal/50 focus:outline-none"
+              >
+                <option value="">Select pod...</option>
+                {pods.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} ({p.cycle_name})
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          <button
+            type="submit"
+            disabled={creating}
+            className="rounded-md bg-aqua px-4 py-2 text-sm font-medium text-midnight hover:bg-teal disabled:opacity-50"
+          >
+            {creating ? "Creating..." : "Create Invite"}
+          </button>
+        </form>
+        {error && (
+          <p className="mt-2 text-sm text-red-300">{error}</p>
+        )}
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-3">
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="rounded-md border border-whisper bg-transparent px-3 py-2 text-sm text-white focus:border-teal/50 focus:outline-none"
+        >
+          <option value="all">All</option>
+          <option value="pending">Pending</option>
+          <option value="accepted">Accepted</option>
+          <option value="expired">Expired</option>
+          <option value="revoked">Revoked</option>
+        </select>
+        <span className="text-sm text-cloud/40">
+          {filtered.length} invitation{filtered.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-md border border-whisper">
+        <table className="w-full text-sm">
+          <thead className="bg-white/[0.04]">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-cloud/60">
+                Email
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-cloud/60">
+                Preset
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-cloud/60">
+                Cycle
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-cloud/60">
+                Status
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-cloud/60">
+                Created
+              </th>
+              <th className="px-4 py-3 text-right font-medium text-cloud/60" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-whisper">
+            {filtered.map((inv) => {
+              const isExpired =
+                inv.status === "pending" &&
+                new Date(inv.expires_at) < new Date();
+
+              return (
+                <tr key={inv.id}>
+                  <td className="px-4 py-3 font-medium text-white">
+                    {inv.email}
+                  </td>
+                  <td className="px-4 py-3">
+                    {inv.role_preset ? (
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                          inv.role_preset === "owner"
+                            ? "bg-yellow-500/15 text-yellow-300"
+                            : inv.role_preset === "admin"
+                              ? "bg-teal/15 text-aqua"
+                              : inv.role_preset === "developer"
+                                ? "bg-purple-500/15 text-purple-300"
+                                : inv.role_preset === "moderator"
+                                  ? "bg-blue-500/15 text-blue-300"
+                                  : "bg-white/10 text-cloud/60"
+                        }`}
+                      >
+                        {inv.role_preset}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-cloud/30">
+                        {inv.permissions.length} perm
+                        {inv.permissions.length !== 1 ? "s" : ""}
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-cloud/60">
+                    {inv.cycle_name ?? "—"}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                        inv.status === "accepted"
+                          ? "bg-teal/20 text-aqua"
+                          : inv.status === "pending" && !isExpired
+                            ? "bg-yellow-500/20 text-yellow-300"
+                            : "bg-white/10 text-cloud/40"
+                      }`}
+                    >
+                      {isExpired ? "expired" : inv.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-cloud/60">
+                    {new Date(inv.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      {inv.status === "pending" && !isExpired && (
+                        <>
+                          <button
+                            onClick={() => copyLink(inv)}
+                            className="rounded px-2.5 py-1 text-xs font-medium text-aqua ring-1 ring-teal/40 hover:bg-teal/10"
+                          >
+                            {copied === inv.id ? "Copied!" : "Copy Link"}
+                          </button>
+                          <button
+                            onClick={() => revokeInvitation(inv.id)}
+                            className="rounded px-2.5 py-1 text-xs font-medium text-cloud/40 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-red-300"
+                          >
+                            Revoke
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+            {filtered.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 py-8 text-center text-cloud/40"
+                >
+                  No invitations match your filter.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/invitations/page.tsx
+++ b/app/(dashboard)/admin/invitations/page.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { resolveUserRoles, isAdmin, can } from "@/lib/auth/roles";
+import InvitationsTable from "./invitations-table";
+
+export default async function AdminInvitationsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const serviceClient = createServiceClient();
+  const userRoles = await resolveUserRoles(serviceClient, user.id);
+  if (!isAdmin(userRoles)) redirect("/cycles");
+
+  // Fetch invitations
+  const { data: invitations } = await serviceClient
+    .from("invitations")
+    .select("id, email, token, permissions, role_preset, cycle_id, pod_id, status, created_at, expires_at, accepted_at, cycles (name)")
+    .order("created_at", { ascending: false });
+
+  // Fetch cycles for the create form dropdown
+  const { data: cycles } = await serviceClient
+    .from("cycles")
+    .select("id, name, status")
+    .order("start_date", { ascending: false });
+
+  // Fetch pods for moderator invite
+  const { data: pods } = await serviceClient
+    .from("pods")
+    .select("id, name, cycle_id, cycles (name)")
+    .order("created_at", { ascending: false });
+
+  const podOptions = (pods ?? []).map((p) => {
+    const cycle = (p.cycles as unknown) as { name: string } | null;
+    return {
+      id: p.id,
+      name: p.name ?? `Pod ${p.id}`,
+      cycle_name: cycle?.name ?? "",
+    };
+  });
+
+  const canManageRoles = can(userRoles, "roles:write");
+
+  const pendingCount = (invitations ?? []).filter((i) => i.status === "pending").length;
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href="/admin"
+          className="text-sm text-cloud/60 hover:text-aqua"
+        >
+          &larr; Admin
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-white">Invitations</h1>
+        <p className="mt-1 text-sm text-cloud/60">
+          {pendingCount} pending invitation{pendingCount !== 1 ? "s" : ""} &middot;{" "}
+          {(invitations ?? []).length} total
+        </p>
+      </div>
+
+      <InvitationsTable
+        invitations={(invitations ?? []).map((inv) => {
+          const cycle = (inv.cycles as unknown) as { name: string } | null;
+          return {
+            id: inv.id,
+            email: inv.email,
+            token: inv.token,
+            permissions: inv.permissions as string[],
+            role_preset: inv.role_preset,
+            cycle_id: inv.cycle_id,
+            cycle_name: cycle?.name ?? null,
+            pod_id: inv.pod_id,
+            status: inv.status,
+            created_at: inv.created_at,
+            expires_at: inv.expires_at,
+            accepted_at: inv.accepted_at,
+          };
+        })}
+        cycles={(cycles ?? []).map((c) => ({ id: c.id, name: c.name }))}
+        pods={podOptions}
+        canManageRoles={canManageRoles}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -44,6 +44,12 @@ export default async function AdminPage() {
         </div>
         <div className="flex items-center gap-3">
           <Link
+            href="/admin/invitations"
+            className="rounded-md px-4 py-2 text-sm font-medium text-cloud/60 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud"
+          >
+            Invitations
+          </Link>
+          <Link
             href="/admin/participants"
             className="rounded-md px-4 py-2 text-sm font-medium text-cloud/60 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud"
           >

--- a/app/(dashboard)/admin/participants/[participant_id]/permissions/page.tsx
+++ b/app/(dashboard)/admin/participants/[participant_id]/permissions/page.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { redirect, notFound } from "next/navigation";
+import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
+import type { Permission } from "@/lib/auth/permissions";
+import PermissionsEditor from "./permissions-editor";
+
+export default async function ParticipantPermissionsPage({
+  params,
+}: {
+  params: Promise<{ participant_id: string }>;
+}) {
+  const { participant_id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const serviceClient = createServiceClient();
+  const userRoles = await resolveUserRoles(serviceClient, user.id);
+  if (!isAdmin(userRoles)) redirect("/cycles");
+
+  const participantId = parseInt(participant_id);
+  if (isNaN(participantId)) notFound();
+
+  // Fetch participant info
+  const { data: participant } = await serviceClient
+    .from("participants")
+    .select("id, first_name, last_name, preferred_name, email")
+    .eq("id", participantId)
+    .single();
+
+  if (!participant) notFound();
+
+  // Fetch current permissions
+  const { data: permRows } = await serviceClient
+    .from("participant_permissions")
+    .select("permission")
+    .eq("participant_id", participantId)
+    .is("revoked_at", null);
+
+  const currentPermissions = (permRows ?? []).map((r) => r.permission as Permission);
+
+  // Fetch current roles (for display)
+  const { data: roleRows } = await serviceClient
+    .from("user_roles")
+    .select("role")
+    .eq("participant_id", participantId)
+    .is("revoked_at", null);
+
+  const currentRoles = (roleRows ?? []).map((r) => r.role as string);
+
+  // Fetch moderator pod assignments
+  const { data: modAssignments } = await serviceClient
+    .from("moderator_assignments")
+    .select("pod_id, pods (name, cycle_id, cycles (name))")
+    .eq("participant_id", participantId)
+    .is("removed_at", null);
+
+  const podAssignments = (modAssignments ?? []).map((ma) => {
+    const pod = (ma.pods as unknown) as { name: string | null; cycle_id: number; cycles: { name: string } | null } | null;
+    return {
+      pod_id: ma.pod_id,
+      pod_name: pod?.name ?? `Pod ${ma.pod_id}`,
+      cycle_name: pod?.cycles?.name ?? "",
+    };
+  });
+
+  const displayName = participant.preferred_name
+    ? `${participant.preferred_name} ${participant.last_name}`
+    : `${participant.first_name} ${participant.last_name}`;
+
+  const canManageRoles = userRoles.permissions.includes("roles:write");
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href="/admin/participants"
+          className="text-sm text-cloud/60 hover:text-aqua"
+        >
+          &larr; All Participants
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-white">{displayName}</h1>
+        <p className="mt-1 text-sm text-cloud/60">{participant.email}</p>
+        {currentRoles.length > 0 && (
+          <div className="mt-2 flex gap-2">
+            {currentRoles.map((role) => (
+              <span
+                key={role}
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                  role === "owner"
+                    ? "bg-yellow-500/15 text-yellow-300"
+                    : role === "admin"
+                      ? "bg-teal/15 text-aqua"
+                      : role === "developer"
+                        ? "bg-purple-500/15 text-purple-300"
+                        : "bg-white/10 text-cloud/60"
+                }`}
+              >
+                {role}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <PermissionsEditor
+        participantId={participantId}
+        initialPermissions={currentPermissions}
+        canManageRoles={canManageRoles}
+        podAssignments={podAssignments}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/participants/[participant_id]/permissions/permissions-editor.tsx
+++ b/app/(dashboard)/admin/participants/[participant_id]/permissions/permissions-editor.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import {
+  PERMISSION_GROUPS,
+  ROLE_PRESETS,
+  permissionLabel,
+  activePresets,
+  type Permission,
+} from "@/lib/auth/permissions";
+
+const PRESET_COLORS: Record<string, string> = {
+  owner: "bg-yellow-500/15 text-yellow-300 ring-yellow-500/30",
+  admin: "bg-teal/15 text-aqua ring-teal/30",
+  developer: "bg-purple-500/15 text-purple-300 ring-purple-500/30",
+  moderator: "bg-blue-500/15 text-blue-300 ring-blue-500/30",
+  observer: "bg-white/10 text-cloud/60 ring-whisper",
+};
+
+export default function PermissionsEditor({
+  participantId,
+  initialPermissions,
+  canManageRoles,
+  podAssignments,
+}: {
+  participantId: number;
+  initialPermissions: Permission[];
+  canManageRoles: boolean;
+  podAssignments: { pod_id: number; pod_name: string; cycle_name: string }[];
+}) {
+  const [permissions, setPermissions] = useState<Set<Permission>>(
+    new Set(initialPermissions)
+  );
+  const [loading, setLoading] = useState<Set<string>>(new Set());
+  const [presetLoading, setPresetLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const currentPresets = activePresets([...permissions]);
+
+  async function togglePermission(permission: Permission) {
+    const action = permissions.has(permission) ? "revoke" : "grant";
+    setLoading((prev) => new Set(prev).add(permission));
+    setError(null);
+
+    const res = await fetch("/api/permissions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        participant_id: participantId,
+        permissions: [permission],
+        action,
+      }),
+    });
+
+    setLoading((prev) => {
+      const next = new Set(prev);
+      next.delete(permission);
+      return next;
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      setPermissions(new Set(data.permissions as Permission[]));
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to update permission");
+    }
+  }
+
+  async function applyPreset(preset: string) {
+    setPresetLoading(preset);
+    setError(null);
+
+    const res = await fetch("/api/permissions/preset", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        participant_id: participantId,
+        preset,
+      }),
+    });
+
+    setPresetLoading(null);
+
+    if (res.ok) {
+      const data = await res.json();
+      setPermissions(new Set(data.permissions as Permission[]));
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to apply preset");
+    }
+  }
+
+  const restrictedPerms = canManageRoles ? [] : ["roles:write", "roles:read"];
+
+  return (
+    <div className="space-y-8">
+      {/* Role Presets */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold text-cloud/60 uppercase tracking-wider">
+          Quick Assign — Role Presets
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {Object.keys(ROLE_PRESETS).map((preset) => {
+            const isActive = currentPresets.includes(preset);
+            const isRestricted =
+              !canManageRoles && (preset === "owner" || preset === "admin" || preset === "developer");
+
+            return (
+              <button
+                key={preset}
+                onClick={() => applyPreset(preset)}
+                disabled={
+                  presetLoading !== null || isRestricted
+                }
+                className={`rounded-md px-4 py-2 text-sm font-medium ring-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                  isActive
+                    ? PRESET_COLORS[preset]
+                    : "text-cloud/60 ring-whisper hover:bg-white/[0.04] hover:text-cloud"
+                }`}
+              >
+                {presetLoading === preset
+                  ? "Applying..."
+                  : `${preset.charAt(0).toUpperCase() + preset.slice(1)}${isActive ? " \u2713" : ""}`}
+              </button>
+            );
+          })}
+        </div>
+        {currentPresets.length > 0 && (
+          <p className="mt-2 text-xs text-cloud/40">
+            Active presets: {currentPresets.join(", ")}
+          </p>
+        )}
+      </section>
+
+      {error && (
+        <div className="rounded-md border border-red/20 bg-red/10 p-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* Individual Permissions */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold text-cloud/60 uppercase tracking-wider">
+          Individual Permissions
+        </h2>
+        <div className="space-y-6">
+          {PERMISSION_GROUPS.map((group) => (
+            <div key={group.label}>
+              <h3 className="mb-2 text-sm font-medium text-cloud/80">
+                {group.label}
+              </h3>
+              <div className="space-y-1">
+                {group.permissions.map((perm) => {
+                  const enabled = permissions.has(perm);
+                  const isLoading = loading.has(perm);
+                  const isRestricted = restrictedPerms.includes(perm);
+
+                  return (
+                    <div
+                      key={perm}
+                      className="flex items-center justify-between rounded-md px-3 py-2 hover:bg-white/[0.02]"
+                    >
+                      <div>
+                        <span className="text-sm text-white">
+                          {permissionLabel(perm)}
+                        </span>
+                        <span className="ml-2 text-xs text-cloud/30">
+                          {perm}
+                        </span>
+                      </div>
+                      <button
+                        onClick={() => togglePermission(perm)}
+                        disabled={isLoading || isRestricted}
+                        className={`relative h-6 w-11 rounded-full transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                          enabled ? "bg-teal" : "bg-white/10"
+                        }`}
+                      >
+                        <span
+                          className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                            enabled ? "translate-x-5" : "translate-x-0.5"
+                          }`}
+                        />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Pod Assignments (informational) */}
+      {podAssignments.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold text-cloud/60 uppercase tracking-wider">
+            Moderator Pod Assignments
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {podAssignments.map((pa) => (
+              <span
+                key={pa.pod_id}
+                className="rounded-full bg-blue-500/10 px-3 py-1 text-xs text-blue-300"
+              >
+                {pa.pod_name}
+                {pa.cycle_name && (
+                  <span className="text-blue-300/50"> ({pa.cycle_name})</span>
+                )}
+              </span>
+            ))}
+          </div>
+          <p className="mt-2 text-xs text-cloud/30">
+            Pod assignments are managed from the cycle admin page.
+          </p>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/participants/page.tsx
+++ b/app/(dashboard)/admin/participants/page.tsx
@@ -97,8 +97,6 @@ export default async function AdminParticipantsPage() {
     moderator_pods: modPodsByParticipant[p.id] ?? [],
   }));
 
-  const isOwnerUser = userRoles.roles.includes("owner");
-
   return (
     <div>
       <div className="mb-8">
@@ -119,7 +117,6 @@ export default async function AdminParticipantsPage() {
 
       <ParticipantsGlobalTable
         participants={globalParticipants}
-        isOwnerUser={isOwnerUser}
       />
     </div>
   );

--- a/app/(dashboard)/admin/participants/participants-global-table.tsx
+++ b/app/(dashboard)/admin/participants/participants-global-table.tsx
@@ -1,28 +1,24 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import type { GlobalParticipant } from "./page";
+
+const ROLE_COLORS: Record<string, string> = {
+  owner: "bg-yellow-500/15 text-yellow-300",
+  admin: "bg-teal/15 text-aqua",
+  developer: "bg-purple-500/15 text-purple-300",
+  moderator: "bg-blue-500/15 text-blue-300",
+  observer: "bg-white/10 text-cloud/60",
+};
 
 export default function ParticipantsGlobalTable({
   participants,
-  isOwnerUser,
 }: {
   participants: GlobalParticipant[];
-  isOwnerUser: boolean;
 }) {
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState<string>("all");
-  const [loadingIds, setLoadingIds] = useState<Set<number>>(new Set());
-  const [grantedAdminIds, setGrantedAdminIds] = useState<Set<number>>(
-    new Set()
-  );
-  const [grantedObserverIds, setGrantedObserverIds] = useState<Set<number>>(
-    new Set()
-  );
-  const [grantedDeveloperIds, setGrantedDeveloperIds] = useState<Set<number>>(
-    new Set()
-  );
-  const [errors, setErrors] = useState<Record<number, string>>({});
 
   const filtered = participants.filter((p) => {
     const name = p.preferred_name
@@ -33,76 +29,16 @@ export default function ParticipantsGlobalTable({
       name.toLowerCase().includes(search.toLowerCase()) ||
       p.email.toLowerCase().includes(search.toLowerCase());
 
-    const effectiveRoles = [...p.roles];
-    if (grantedAdminIds.has(p.id) && !effectiveRoles.includes("admin"))
-      effectiveRoles.push("admin");
-    if (grantedDeveloperIds.has(p.id) && !effectiveRoles.includes("developer"))
-      effectiveRoles.push("developer");
-    if (grantedObserverIds.has(p.id) && !effectiveRoles.includes("observer"))
-      effectiveRoles.push("observer");
-
     const matchesRole =
       roleFilter === "all" ||
       (roleFilter === "moderator" && p.moderator_pods.length > 0) ||
       (roleFilter === "none" &&
-        effectiveRoles.length === 0 &&
+        p.roles.length === 0 &&
         p.moderator_pods.length === 0) ||
-      effectiveRoles.includes(roleFilter);
+      p.roles.includes(roleFilter);
 
     return matchesSearch && matchesRole;
   });
-
-  async function grantRole(
-    participantId: number,
-    role: "admin" | "observer" | "developer"
-  ) {
-    setLoadingIds((prev) => new Set(prev).add(participantId));
-    setErrors((prev) => {
-      const next = { ...prev };
-      delete next[participantId];
-      return next;
-    });
-
-    const res = await fetch(`/api/roles/${role}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ participant_id: participantId }),
-    });
-
-    setLoadingIds((prev) => {
-      const next = new Set(prev);
-      next.delete(participantId);
-      return next;
-    });
-
-    if (res.ok) {
-      if (role === "admin") {
-        setGrantedAdminIds((prev) => new Set(prev).add(participantId));
-      } else if (role === "developer") {
-        setGrantedDeveloperIds((prev) => new Set(prev).add(participantId));
-      } else {
-        setGrantedObserverIds((prev) => new Set(prev).add(participantId));
-      }
-    } else {
-      const data = await res.json();
-      setErrors((prev) => ({
-        ...prev,
-        [participantId]: data.error ?? "Failed",
-      }));
-    }
-  }
-
-  function getTopRole(p: GlobalParticipant): string | null {
-    if (grantedAdminIds.has(p.id)) return "admin";
-    if (p.roles.includes("owner")) return "owner";
-    if (p.roles.includes("admin")) return "admin";
-    if (grantedDeveloperIds.has(p.id)) return "developer";
-    if (p.roles.includes("developer")) return "developer";
-    if (grantedObserverIds.has(p.id)) return "observer";
-    if (p.roles.includes("observer")) return "observer";
-    if (p.moderator_pods.length > 0) return "moderator";
-    return null;
-  }
 
   return (
     <div>
@@ -145,7 +81,7 @@ export default function ParticipantsGlobalTable({
                 Email
               </th>
               <th className="px-4 py-3 text-left font-medium text-cloud/60">
-                Role
+                Roles
               </th>
               <th className="px-4 py-3 text-left font-medium text-cloud/60">
                 Cycles
@@ -164,13 +100,15 @@ export default function ParticipantsGlobalTable({
               const displayName = p.preferred_name
                 ? `${p.preferred_name} ${p.last_name}`
                 : `${p.first_name} ${p.last_name}`;
-              const topRole = getTopRole(p);
-              const hasElevated =
-                p.roles.includes("owner") ||
-                p.roles.includes("admin") ||
-                p.roles.includes("developer") ||
-                grantedAdminIds.has(p.id) ||
-                grantedDeveloperIds.has(p.id);
+
+              // Show all roles as badges
+              const displayRoles = [...p.roles];
+              if (
+                p.moderator_pods.length > 0 &&
+                !displayRoles.includes("moderator")
+              ) {
+                displayRoles.push("moderator");
+              }
 
               return (
                 <tr key={p.id}>
@@ -179,23 +117,21 @@ export default function ParticipantsGlobalTable({
                   </td>
                   <td className="px-4 py-3 text-cloud/60">{p.email}</td>
                   <td className="px-4 py-3">
-                    {topRole && (
-                      <span
-                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                          topRole === "owner"
-                            ? "bg-yellow-500/15 text-yellow-300"
-                            : topRole === "admin"
-                              ? "bg-teal/15 text-aqua"
-                              : topRole === "developer"
-                                ? "bg-purple-500/15 text-purple-300"
-                                : topRole === "moderator"
-                                  ? "bg-blue-500/15 text-blue-300"
-                                  : "bg-white/10 text-cloud/60"
-                        }`}
-                      >
-                        {topRole}
-                      </span>
-                    )}
+                    <div className="flex flex-wrap gap-1">
+                      {displayRoles.map((role) => (
+                        <span
+                          key={role}
+                          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                            ROLE_COLORS[role] ?? "bg-white/10 text-cloud/60"
+                          }`}
+                        >
+                          {role}
+                        </span>
+                      ))}
+                      {displayRoles.length === 0 && (
+                        <span className="text-xs text-cloud/30">—</span>
+                      )}
+                    </div>
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex flex-wrap gap-1">
@@ -237,42 +173,12 @@ export default function ParticipantsGlobalTable({
                     {new Date(p.created_at).toLocaleDateString()}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    {errors[p.id] && (
-                      <span className="mr-2 text-xs text-red">
-                        {errors[p.id]}
-                      </span>
-                    )}
-                    <div className="flex items-center justify-end gap-2">
-                      {!hasElevated &&
-                        !p.roles.includes("observer") &&
-                        !grantedObserverIds.has(p.id) && (
-                          <button
-                            onClick={() => grantRole(p.id, "observer")}
-                            disabled={loadingIds.has(p.id)}
-                            className="rounded px-2.5 py-1 text-xs font-medium text-cloud/60 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud disabled:opacity-50"
-                          >
-                            {loadingIds.has(p.id) ? "…" : "Observer"}
-                          </button>
-                        )}
-                      {isOwnerUser && !hasElevated && (
-                        <>
-                          <button
-                            onClick={() => grantRole(p.id, "developer")}
-                            disabled={loadingIds.has(p.id)}
-                            className="rounded px-2.5 py-1 text-xs font-medium text-purple-300 ring-1 ring-purple-500/40 hover:bg-purple-500/10 hover:text-white disabled:opacity-50"
-                          >
-                            {loadingIds.has(p.id) ? "…" : "Developer"}
-                          </button>
-                          <button
-                            onClick={() => grantRole(p.id, "admin")}
-                            disabled={loadingIds.has(p.id)}
-                            className="rounded px-2.5 py-1 text-xs font-medium text-aqua ring-1 ring-teal/40 hover:bg-teal/10 hover:text-white disabled:opacity-50"
-                          >
-                            {loadingIds.has(p.id) ? "…" : "Admin"}
-                          </button>
-                        </>
-                      )}
-                    </div>
+                    <Link
+                      href={`/admin/participants/${p.id}/permissions`}
+                      className="rounded px-2.5 py-1 text-xs font-medium text-aqua ring-1 ring-teal/40 hover:bg-teal/10"
+                    >
+                      Permissions
+                    </Link>
                   </td>
                 </tr>
               );

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import { resolveUserRoles, isAdmin, isModerator } from "@/lib/auth/roles";
+import { resolveUserRoles, isAdmin, isModerator, can } from "@/lib/auth/roles";
 import LogoutButton from "./components/logout-button";
 
 export default async function DashboardLayout({
@@ -29,6 +29,7 @@ export default async function DashboardLayout({
   const userRoles = await resolveUserRoles(serviceClient, user.id);
   const adminUser = isAdmin(userRoles);
   const moderatorUser = isModerator(userRoles);
+  const showPods = can(userRoles, "pods:read") || moderatorUser;
 
   const displayName =
     participant?.preferred_name ||
@@ -66,7 +67,7 @@ export default async function DashboardLayout({
               <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-yellow-400" />
               Pulse Check
             </Link>
-            {(adminUser || moderatorUser) && (
+            {showPods && (
               <Link
                 href="/moderator"
                 className="text-sm text-cloud transition-colors hover:text-aqua"

--- a/app/(dashboard)/moderator/page.tsx
+++ b/app/(dashboard)/moderator/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import { resolveUserRoles, isAdmin, isModerator } from "@/lib/auth/roles";
+import { resolveUserRoles, isAdmin, isModerator, can } from "@/lib/auth/roles";
 
 export default async function ModeratorPage() {
   const supabase = await createClient();
@@ -13,9 +13,10 @@ export default async function ModeratorPage() {
   const serviceClient = createServiceClient();
   const userRoles = await resolveUserRoles(serviceClient, user.id);
 
-  if (!isAdmin(userRoles) && !isModerator(userRoles)) redirect("/cycles");
+  const hasPodAccess = can(userRoles, "pods:read") || isModerator(userRoles);
+  if (!hasPodAccess) redirect("/cycles");
 
-  const admin = isAdmin(userRoles);
+  const admin = isAdmin(userRoles) || can(userRoles, "pods:read");
 
   // Admins see all pods; moderators see only their assigned pods
   let pods: {

--- a/app/(dashboard)/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/pods/[pod_id]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
-import { resolveUserRoles, isAdmin, isModeratorForPod } from "@/lib/auth/roles";
+import { resolveUserRoles, isAdmin, isModeratorForPod, can } from "@/lib/auth/roles";
 import PulseCheckDashboard from "./pulse-check-dashboard";
 
 export default async function PodDetailPage({
@@ -48,7 +48,10 @@ export default async function PodDetailPage({
     ? await resolveUserRoles(serviceClient, user.id)
     : null;
   const canViewDashboard =
-    userRoles && (isAdmin(userRoles) || isModeratorForPod(userRoles, pod.id));
+    userRoles &&
+    (isAdmin(userRoles) ||
+      isModeratorForPod(userRoles, pod.id) ||
+      can(userRoles, "pulse_checks:read"));
 
   // Fetch pulse check data for dashboard (using service client to bypass RLS)
   let pulseCheckData: {

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,6 +1,96 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { isOwnerEmail, ensureOwnerRole } from "@/lib/auth/owner-emails";
+
+async function fulfillInvitation(
+  serviceClient: ReturnType<typeof createServiceClient>,
+  participantId: number,
+  email: string
+) {
+  // Read invite token from cookie
+  const cookieStore = await cookies();
+  const inviteToken = cookieStore.get("invite_token")?.value;
+  if (!inviteToken) return;
+
+  // Clear the cookie
+  cookieStore.set("invite_token", "", { maxAge: 0, path: "/" });
+
+  // Look up the invitation
+  const { data: invitation } = await serviceClient
+    .from("invitations")
+    .select("id, email, permissions, role_preset, cycle_id, pod_id")
+    .eq("token", inviteToken)
+    .eq("status", "pending")
+    .gt("expires_at", new Date().toISOString())
+    .maybeSingle();
+
+  if (!invitation) return;
+
+  // Verify email matches
+  if (invitation.email.toLowerCase() !== email.toLowerCase()) return;
+
+  // Grant permissions
+  const permissions = (invitation.permissions as string[]) ?? [];
+  if (permissions.length > 0) {
+    const rows = permissions.map((perm) => ({
+      participant_id: participantId,
+      permission: perm,
+    }));
+    await serviceClient
+      .from("participant_permissions")
+      .upsert(rows, { onConflict: "participant_id,permission", ignoreDuplicates: true });
+  }
+
+  // Record role preset in user_roles for audit
+  if (invitation.role_preset && ["owner", "admin", "developer", "observer"].includes(invitation.role_preset)) {
+    await serviceClient
+      .from("user_roles")
+      .upsert(
+        { participant_id: participantId, role: invitation.role_preset, granted_by: null },
+        { onConflict: "participant_id,role", ignoreDuplicates: true }
+      );
+  }
+
+  // Enroll in cycle if specified
+  if (invitation.cycle_id) {
+    await serviceClient
+      .from("cycle_enrollments")
+      .upsert(
+        { participant_id: participantId, cycle_id: invitation.cycle_id, status: "active" },
+        { onConflict: "participant_id,cycle_id", ignoreDuplicates: true }
+      );
+  }
+
+  // Create moderator assignment if pod specified
+  if (invitation.pod_id) {
+    // Need cycle_id for moderator_assignments — get it from the pod
+    const { data: pod } = await serviceClient
+      .from("pods")
+      .select("cycle_id")
+      .eq("id", invitation.pod_id)
+      .single();
+
+    if (pod) {
+      await serviceClient
+        .from("moderator_assignments")
+        .upsert(
+          {
+            participant_id: participantId,
+            pod_id: invitation.pod_id,
+            cycle_id: pod.cycle_id,
+          },
+          { onConflict: "participant_id,pod_id,cycle_id", ignoreDuplicates: true }
+        );
+    }
+  }
+
+  // Mark invitation as accepted
+  await serviceClient
+    .from("invitations")
+    .update({ status: "accepted", accepted_at: new Date().toISOString() })
+    .eq("id", invitation.id);
+}
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -36,6 +126,12 @@ export async function GET(request: Request) {
           if (email && isOwnerEmail(email)) {
             await ensureOwnerRole(serviceClient, participant.id);
           }
+
+          // Fulfill any pending invitation
+          if (email) {
+            await fulfillInvitation(serviceClient, participant.id, email);
+          }
+
           return NextResponse.redirect(`${origin}/`);
         } else {
           // No participant record — redirect to registration

--- a/app/api/invitations/[invitation_id]/route.ts
+++ b/app/api/invitations/[invitation_id]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { dbError } from "@/lib/api/errors";
+import { parseIntParam } from "@/lib/api/params";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export const PATCH = withAdminAuth(
+  async (_request: NextRequest, _auth: AuthenticatedRequest, params: Record<string, string>) => {
+    const invitationId = parseIntParam(params.invitation_id, "invitation_id");
+    if (invitationId instanceof NextResponse) return invitationId;
+
+    const serviceClient = createServiceClient();
+
+    const { data, error } = await serviceClient
+      .from("invitations")
+      .update({ status: "revoked" })
+      .eq("id", invitationId)
+      .eq("status", "pending")
+      .select("id, status")
+      .single();
+
+    if (error) return dbError(error);
+    if (!data) {
+      return NextResponse.json({ error: "Invitation not found or already processed" }, { status: 404 });
+    }
+
+    return NextResponse.json(data);
+  }
+);

--- a/app/api/invitations/route.ts
+++ b/app/api/invitations/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { can } from "@/lib/auth/roles";
+import { dbError } from "@/lib/api/errors";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { createInvitationSchema } from "@/lib/validations/invitations";
+import { ROLE_PRESETS } from "@/lib/auth/permissions";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export const GET = withAdminAuth(
+  async (_request: NextRequest, _auth: AuthenticatedRequest) => {
+    const serviceClient = createServiceClient();
+
+    const { data, error } = await serviceClient
+      .from("invitations")
+      .select("*, cycles (name), participants!invitations_invited_by_fkey (preferred_name, first_name, last_name)")
+      .order("created_at", { ascending: false });
+
+    if (error) return dbError(error);
+
+    return NextResponse.json(data ?? []);
+  }
+);
+
+export const POST = withAdminAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest) => {
+    const body = await parseBody(request, createInvitationSchema);
+    if (isErrorResponse(body)) return body;
+
+    const { email, role_preset, permissions: extraPerms, cycle_id, pod_id } = body;
+
+    // Build final permissions list
+    let finalPerms: string[] = [];
+    if (role_preset && ROLE_PRESETS[role_preset]) {
+      finalPerms = [...ROLE_PRESETS[role_preset]];
+    }
+    if (extraPerms) {
+      for (const p of extraPerms) {
+        if (!finalPerms.includes(p)) finalPerms.push(p);
+      }
+    }
+
+    // If granting roles:write, caller must have it
+    if (finalPerms.includes("roles:write") && !can(auth.user, "roles:write")) {
+      return NextResponse.json(
+        { error: "Only users with roles:write can invite with that permission" },
+        { status: 403 }
+      );
+    }
+
+    const serviceClient = createServiceClient();
+
+    // Check for existing pending invitation for this email
+    const { data: existing } = await serviceClient
+      .from("invitations")
+      .select("id")
+      .eq("email", email.toLowerCase())
+      .eq("status", "pending")
+      .maybeSingle();
+
+    if (existing) {
+      return NextResponse.json(
+        { error: "A pending invitation already exists for this email" },
+        { status: 409 }
+      );
+    }
+
+    const { data, error } = await serviceClient
+      .from("invitations")
+      .insert({
+        email: email.toLowerCase(),
+        permissions: finalPerms,
+        role_preset: role_preset ?? null,
+        cycle_id: cycle_id ?? null,
+        pod_id: pod_id ?? null,
+        invited_by: auth.user.participantId,
+      })
+      .select("id, email, token, permissions, role_preset, cycle_id, pod_id, status, created_at, expires_at")
+      .single();
+
+    if (error) return dbError(error);
+
+    return NextResponse.json(data, { status: 201 });
+  }
+);

--- a/app/api/permissions/preset/route.ts
+++ b/app/api/permissions/preset/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { can } from "@/lib/auth/roles";
+import { dbError } from "@/lib/api/errors";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { applyPresetSchema } from "@/lib/validations/invitations";
+import { ROLE_PRESETS } from "@/lib/auth/permissions";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export const POST = withAdminAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest) => {
+    const body = await parseBody(request, applyPresetSchema);
+    if (isErrorResponse(body)) return body;
+
+    const { participant_id, preset } = body;
+    const permissions = ROLE_PRESETS[preset];
+
+    if (!permissions) {
+      return NextResponse.json({ error: "Unknown preset" }, { status: 400 });
+    }
+
+    // If preset includes roles:write, caller must have roles:write
+    if (permissions.includes("roles:write") && !can(auth.user, "roles:write")) {
+      return NextResponse.json(
+        { error: "Only users with roles:write can apply this preset" },
+        { status: 403 }
+      );
+    }
+
+    const serviceClient = createServiceClient();
+
+    // Insert all permissions for the preset
+    const rows = permissions.map((perm) => ({
+      participant_id,
+      permission: perm,
+      granted_by: auth.user.participantId,
+    }));
+
+    const { error } = await serviceClient
+      .from("participant_permissions")
+      .upsert(rows, { onConflict: "participant_id,permission", ignoreDuplicates: false });
+
+    if (error) return dbError(error);
+
+    // Clear revoked_at for any previously revoked
+    await serviceClient
+      .from("participant_permissions")
+      .update({ revoked_at: null, granted_by: auth.user.participantId, granted_at: new Date().toISOString() })
+      .eq("participant_id", participant_id)
+      .in("permission", permissions)
+      .not("revoked_at", "is", null);
+
+    // Also record in user_roles for audit trail (if applicable preset)
+    if (["owner", "admin", "developer", "observer"].includes(preset)) {
+      await serviceClient
+        .from("user_roles")
+        .upsert(
+          { participant_id, role: preset, granted_by: auth.user.participantId },
+          { onConflict: "participant_id,role", ignoreDuplicates: true }
+        );
+    }
+
+    // Return updated permissions
+    const { data: updated } = await serviceClient
+      .from("participant_permissions")
+      .select("permission")
+      .eq("participant_id", participant_id)
+      .is("revoked_at", null);
+
+    return NextResponse.json({
+      participant_id,
+      preset,
+      permissions: (updated ?? []).map((r) => r.permission),
+    });
+  }
+);

--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAuth, withAdminAuth } from "@/lib/auth/middleware";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { isAdmin, can } from "@/lib/auth/roles";
+import { dbError } from "@/lib/api/errors";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { togglePermissionsSchema } from "@/lib/validations/invitations";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export const GET = withAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest) => {
+    const url = new URL(request.url);
+    const participantId = url.searchParams.get("participant_id");
+
+    if (!participantId) {
+      // Return own permissions
+      return NextResponse.json({ permissions: auth.user.permissions });
+    }
+
+    const pid = parseInt(participantId);
+    if (isNaN(pid)) {
+      return NextResponse.json({ error: "Invalid participant_id" }, { status: 400 });
+    }
+
+    // Must be admin to view others' permissions
+    if (pid !== auth.user.participantId && !isAdmin(auth.user)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const serviceClient = createServiceClient();
+    const { data, error } = await serviceClient
+      .from("participant_permissions")
+      .select("permission, granted_at, revoked_at")
+      .eq("participant_id", pid)
+      .is("revoked_at", null);
+
+    if (error) return dbError(error);
+
+    return NextResponse.json({
+      participant_id: pid,
+      permissions: (data ?? []).map((r) => r.permission),
+    });
+  }
+);
+
+export const POST = withAdminAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest) => {
+    const body = await parseBody(request, togglePermissionsSchema);
+    if (isErrorResponse(body)) return body;
+
+    const { participant_id, permissions, action } = body;
+
+    // If toggling roles:write, caller must have roles:write
+    if (permissions.includes("roles:write") && !can(auth.user, "roles:write")) {
+      return NextResponse.json(
+        { error: "Only users with roles:write can grant that permission" },
+        { status: 403 }
+      );
+    }
+
+    const serviceClient = createServiceClient();
+
+    if (action === "grant") {
+      const rows = permissions.map((perm) => ({
+        participant_id,
+        permission: perm,
+        granted_by: auth.user.participantId,
+      }));
+
+      const { error } = await serviceClient
+        .from("participant_permissions")
+        .upsert(rows, { onConflict: "participant_id,permission", ignoreDuplicates: false })
+        .select();
+
+      // Also clear revoked_at for any that were previously revoked
+      await serviceClient
+        .from("participant_permissions")
+        .update({ revoked_at: null, granted_by: auth.user.participantId, granted_at: new Date().toISOString() })
+        .eq("participant_id", participant_id)
+        .in("permission", permissions)
+        .not("revoked_at", "is", null);
+
+      if (error) return dbError(error);
+    } else {
+      const { error } = await serviceClient
+        .from("participant_permissions")
+        .update({ revoked_at: new Date().toISOString() })
+        .eq("participant_id", participant_id)
+        .in("permission", permissions)
+        .is("revoked_at", null);
+
+      if (error) return dbError(error);
+    }
+
+    // Return updated permissions
+    const { data: updated } = await serviceClient
+      .from("participant_permissions")
+      .select("permission")
+      .eq("participant_id", participant_id)
+      .is("revoked_at", null);
+
+    return NextResponse.json({
+      participant_id,
+      permissions: (updated ?? []).map((r) => r.permission),
+    });
+  }
+);

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -1,0 +1,88 @@
+export const PERMISSIONS = [
+  "cycles:read",
+  "cycles:write",
+  "participants:read",
+  "participants:write",
+  "pods:read",
+  "pods:write",
+  "pulse_checks:read",
+  "roles:read",
+  "roles:write",
+  "invitations:read",
+  "invitations:write",
+  "testing:use",
+  "moderate:assigned_pods",
+] as const;
+
+export type Permission = (typeof PERMISSIONS)[number];
+
+export const PERMISSION_GROUPS: { label: string; permissions: Permission[] }[] = [
+  { label: "Cycles", permissions: ["cycles:read", "cycles:write"] },
+  { label: "Participants", permissions: ["participants:read", "participants:write"] },
+  { label: "Pods", permissions: ["pods:read", "pods:write"] },
+  { label: "Pulse Checks", permissions: ["pulse_checks:read"] },
+  { label: "Roles & Invitations", permissions: ["roles:read", "roles:write", "invitations:read", "invitations:write"] },
+  { label: "Tools", permissions: ["testing:use"] },
+  { label: "Moderator", permissions: ["moderate:assigned_pods"] },
+];
+
+export const ROLE_PRESETS: Record<string, Permission[]> = {
+  owner: [...PERMISSIONS],
+  admin: [
+    "cycles:read", "cycles:write",
+    "participants:read", "participants:write",
+    "pods:read", "pods:write",
+    "pulse_checks:read",
+    "roles:read", "roles:write",
+    "invitations:read", "invitations:write",
+  ],
+  developer: [
+    "cycles:read", "cycles:write",
+    "participants:read", "participants:write",
+    "pods:read", "pods:write",
+    "pulse_checks:read",
+    "roles:read", "roles:write",
+    "invitations:read", "invitations:write",
+    "testing:use",
+  ],
+  moderator: [
+    "pods:read",
+    "pulse_checks:read",
+    "moderate:assigned_pods",
+  ],
+  observer: [
+    "cycles:read",
+    "participants:read",
+    "pods:read",
+    "pulse_checks:read",
+  ],
+};
+
+export const ROLE_PRESET_NAMES = Object.keys(ROLE_PRESETS) as (keyof typeof ROLE_PRESETS)[];
+
+export function permissionLabel(permission: Permission): string {
+  const labels: Record<Permission, string> = {
+    "cycles:read": "View Cycles",
+    "cycles:write": "Manage Cycles",
+    "participants:read": "View Participants",
+    "participants:write": "Manage Participants",
+    "pods:read": "View All Pods",
+    "pods:write": "Manage Pods",
+    "pulse_checks:read": "View Pulse Checks",
+    "roles:read": "View Roles",
+    "roles:write": "Manage Roles",
+    "invitations:read": "View Invitations",
+    "invitations:write": "Manage Invitations",
+    "testing:use": "Testing Tools",
+    "moderate:assigned_pods": "Moderate Assigned Pods",
+  };
+  return labels[permission];
+}
+
+/** Determine which role presets are fully covered by a set of permissions */
+export function activePresets(permissions: Permission[]): string[] {
+  const set = new Set(permissions);
+  return Object.entries(ROLE_PRESETS)
+    .filter(([, perms]) => perms.every((p) => set.has(p)))
+    .map(([name]) => name);
+}

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -1,4 +1,5 @@
 import { SupabaseClient } from "@supabase/supabase-js";
+import type { Permission } from "./permissions";
 
 export type Role = "owner" | "admin" | "observer" | "developer" | "moderator" | "participant";
 export type ParticipantStatus = "active" | "inactive" | "revoked";
@@ -7,6 +8,7 @@ export interface UserRoles {
   userId: string;
   participantId: number | null;
   roles: Role[];
+  permissions: Permission[];
   moderatorPodIds: number[];
   cycleEnrollments: {
     cycleId: number;
@@ -27,14 +29,15 @@ export async function resolveUserRoles(
 
   const participantId = participant?.id ?? null;
   const roles: Role[] = [];
+  const permissions: Permission[] = [];
   const moderatorPodIds: number[] = [];
   const cycleEnrollments: UserRoles["cycleEnrollments"] = [];
 
   if (!participantId) {
-    return { userId: authUserId, participantId, roles, moderatorPodIds, cycleEnrollments };
+    return { userId: authUserId, participantId, roles, permissions, moderatorPodIds, cycleEnrollments };
   }
 
-  // Get elevated roles (owner, admin, observer)
+  // Get elevated roles (owner, admin, observer, developer) — kept for audit/display
   const { data: userRoles } = await supabase
     .from("user_roles")
     .select("role")
@@ -47,6 +50,19 @@ export async function resolveUserRoles(
     }
   }
 
+  // Get granular permissions
+  const { data: permRows } = await supabase
+    .from("participant_permissions")
+    .select("permission")
+    .eq("participant_id", participantId)
+    .is("revoked_at", null);
+
+  if (permRows) {
+    for (const p of permRows) {
+      permissions.push(p.permission as Permission);
+    }
+  }
+
   // Get moderator assignments
   const { data: modAssignments } = await supabase
     .from("moderator_assignments")
@@ -55,7 +71,7 @@ export async function resolveUserRoles(
     .is("removed_at", null);
 
   if (modAssignments && modAssignments.length > 0) {
-    roles.push("moderator");
+    if (!roles.includes("moderator")) roles.push("moderator");
     for (const a of modAssignments) {
       moderatorPodIds.push(a.pod_id);
     }
@@ -76,19 +92,27 @@ export async function resolveUserRoles(
     }
   }
 
-  return { userId: authUserId, participantId, roles, moderatorPodIds, cycleEnrollments };
+  return { userId: authUserId, participantId, roles, permissions, moderatorPodIds, cycleEnrollments };
 }
 
-export function isOwner(roles: UserRoles): boolean {
-  return roles.roles.includes("owner");
+/** Check if user has a specific permission */
+export function can(roles: UserRoles, permission: Permission): boolean {
+  return roles.permissions.includes(permission);
 }
 
+/** Backward-compatible: true if user can manage cycles (admin-level write access) */
 export function isAdmin(roles: UserRoles): boolean {
-  return roles.roles.includes("admin") || roles.roles.includes("owner") || roles.roles.includes("developer");
+  return can(roles, "cycles:write");
 }
 
+/** True if user can manage roles/permissions (owner-level) */
+export function isOwner(roles: UserRoles): boolean {
+  return can(roles, "roles:write");
+}
+
+/** True if user has moderator assignments */
 export function isModerator(roles: UserRoles): boolean {
-  return roles.roles.includes("moderator");
+  return roles.moderatorPodIds.length > 0 || can(roles, "moderate:assigned_pods");
 }
 
 export function isModeratorForPod(roles: UserRoles, podId: number): boolean {

--- a/lib/validations/invitations.ts
+++ b/lib/validations/invitations.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { PERMISSIONS, ROLE_PRESETS } from "@/lib/auth/permissions";
+
+export const createInvitationSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  role_preset: z
+    .enum(Object.keys(ROLE_PRESETS) as [string, ...string[]])
+    .nullable()
+    .optional(),
+  permissions: z
+    .array(z.enum(PERMISSIONS as unknown as [string, ...string[]]))
+    .optional(),
+  cycle_id: z.number().int().positive().nullable().optional(),
+  pod_id: z.number().int().positive().nullable().optional(),
+});
+
+export const revokeInvitationSchema = z.object({
+  status: z.literal("revoked"),
+});
+
+export const togglePermissionsSchema = z.object({
+  participant_id: z.number().int({ message: "participant_id must be a number" }),
+  permissions: z.array(z.string().min(1)).min(1, "At least one permission required"),
+  action: z.enum(["grant", "revoke"]),
+});
+
+export const applyPresetSchema = z.object({
+  participant_id: z.number().int({ message: "participant_id must be a number" }),
+  preset: z.enum(Object.keys(ROLE_PRESETS) as [string, ...string[]]),
+});

--- a/supabase/migrations/00009_permissions_model.sql
+++ b/supabase/migrations/00009_permissions_model.sql
@@ -1,0 +1,113 @@
+-- Granular Permissions Model + Invitations
+-- Replaces role-only access with individual permission toggles.
+-- Roles become presets that batch-assign groups of permissions.
+
+-- 1. participant_permissions table
+CREATE TABLE participant_permissions (
+  id SERIAL PRIMARY KEY,
+  participant_id INT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+  permission VARCHAR(50) NOT NULL,
+  granted_by INT REFERENCES participants(id),
+  granted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  revoked_at TIMESTAMP,
+  UNIQUE(participant_id, permission)
+);
+
+CREATE INDEX idx_participant_permissions_participant ON participant_permissions(participant_id);
+CREATE INDEX idx_participant_permissions_permission ON participant_permissions(permission);
+
+-- RLS for participant_permissions
+ALTER TABLE participant_permissions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "permissions_select_own" ON participant_permissions FOR SELECT TO authenticated
+  USING (participant_id = current_participant_id() OR is_admin_or_owner());
+CREATE POLICY "permissions_insert" ON participant_permissions FOR INSERT TO authenticated
+  WITH CHECK (is_admin_or_owner());
+CREATE POLICY "permissions_update" ON participant_permissions FOR UPDATE TO authenticated
+  USING (is_admin_or_owner());
+
+-- 2. Migrate existing user_roles → participant_permissions
+INSERT INTO participant_permissions (participant_id, permission, granted_by, granted_at)
+SELECT ur.participant_id, p.permission, ur.granted_by, ur.granted_at
+FROM user_roles ur
+CROSS JOIN LATERAL (
+  SELECT unnest(CASE ur.role
+    WHEN 'owner' THEN ARRAY[
+      'cycles:read','cycles:write','participants:read','participants:write',
+      'pods:read','pods:write','pulse_checks:read',
+      'roles:read','roles:write','invitations:read','invitations:write','testing:use',
+      'moderate:assigned_pods'
+    ]
+    WHEN 'admin' THEN ARRAY[
+      'cycles:read','cycles:write','participants:read','participants:write',
+      'pods:read','pods:write','pulse_checks:read',
+      'roles:read','roles:write','invitations:read','invitations:write'
+    ]
+    WHEN 'developer' THEN ARRAY[
+      'cycles:read','cycles:write','participants:read','participants:write',
+      'pods:read','pods:write','pulse_checks:read',
+      'roles:read','roles:write','invitations:read','invitations:write','testing:use'
+    ]
+    WHEN 'observer' THEN ARRAY[
+      'cycles:read','participants:read','pods:read','pulse_checks:read'
+    ]
+  END) AS permission
+) p
+WHERE ur.revoked_at IS NULL
+ON CONFLICT (participant_id, permission) DO NOTHING;
+
+-- 3. Migrate moderator_assignments → permissions
+INSERT INTO participant_permissions (participant_id, permission, granted_at)
+SELECT DISTINCT ma.participant_id, p.permission, ma.assigned_at
+FROM moderator_assignments ma
+CROSS JOIN LATERAL (
+  SELECT unnest(ARRAY['moderate:assigned_pods', 'pods:read', 'pulse_checks:read']) AS permission
+) p
+WHERE ma.removed_at IS NULL
+ON CONFLICT (participant_id, permission) DO NOTHING;
+
+-- 4. RLS helper: check if current user has a specific permission
+CREATE OR REPLACE FUNCTION has_permission(perm TEXT)
+RETURNS BOOLEAN AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM participant_permissions pp
+    JOIN participants p ON p.id = pp.participant_id
+    WHERE p.auth_user_id = auth.uid()
+      AND pp.permission = perm
+      AND pp.revoked_at IS NULL
+  );
+$$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- 5. Redefine is_admin_or_owner() to use permissions (keeps all existing RLS policies working)
+CREATE OR REPLACE FUNCTION is_admin_or_owner()
+RETURNS BOOLEAN AS $$
+  SELECT has_permission('cycles:write');
+$$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- 6. Invitations table
+CREATE TABLE invitations (
+  id SERIAL PRIMARY KEY,
+  email VARCHAR(255) NOT NULL,
+  token UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  permissions TEXT[] DEFAULT ARRAY[]::TEXT[],
+  role_preset VARCHAR(50),
+  cycle_id INT REFERENCES cycles(id),
+  pod_id INT REFERENCES pods(id),
+  invited_by INT NOT NULL REFERENCES participants(id),
+  status VARCHAR(20) NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'accepted', 'expired', 'revoked')),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  accepted_at TIMESTAMP,
+  expires_at TIMESTAMP DEFAULT (CURRENT_TIMESTAMP + INTERVAL '30 days')
+);
+
+CREATE INDEX idx_invitations_email ON invitations(email);
+CREATE INDEX idx_invitations_token ON invitations(token);
+
+ALTER TABLE invitations ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "invitations_select" ON invitations FOR SELECT TO authenticated
+  USING (has_permission('invitations:read'));
+CREATE POLICY "invitations_insert" ON invitations FOR INSERT TO authenticated
+  WITH CHECK (has_permission('invitations:write'));
+CREATE POLICY "invitations_update" ON invitations FOR UPDATE TO authenticated
+  USING (has_permission('invitations:write'));


### PR DESCRIPTION
Replace role-only access control with granular permissions where each capability is an independent toggle. Roles (owner, admin, developer, moderator, observer) become presets that batch-assign permissions. Adds invitation system with token-based links that auto-apply permissions on OAuth callback.

- New participant_permissions table as source of truth for access checks
- New invitations table with token generation, status tracking, expiry
- Permission management API (toggle individual perms, apply presets)
- Admin UI: per-participant permission editor with toggle switches
- Admin UI: invitation management with create form, copy-link, revoke
- Auth callback fulfills pending invitations on login
- Updated all access checks to use granular permissions via can() helper
- Replaced inline grant buttons with Permissions link in participant tables

https://claude.ai/code/session_014Z5dNKZJwviv39PoGfLKwv