### PR TITLE
Fix permission audit findings: role bypass, RLS tightening, legacy en…

### DIFF
--- a/app/api/cycles/route.ts
+++ b/app/api/cycles/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, NextRequest } from "next/server";
 import { withAuth, withAdminAuth } from "@/lib/auth/middleware";
-import { isAdmin } from "@/lib/auth/roles";
+import { isAdmin, can } from "@/lib/auth/roles";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 import { dbError } from "@/lib/api/errors";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
@@ -13,8 +13,8 @@ export const GET = withAuth(
       .select("id, name, slug, start_date, end_date, status")
       .order("start_date", { ascending: false });
 
-    // Non-admin users only see cycles they're enrolled in
-    if (!isAdmin(auth.user) && !auth.user.roles.includes("observer")) {
+    // Non-admin users only see cycles they're enrolled in (cycles:read grants full visibility)
+    if (!isAdmin(auth.user) && !can(auth.user, "cycles:read")) {
       const enrolledCycleIds = auth.user.cycleEnrollments.map((e) => e.cycleId);
       if (enrolledCycleIds.length === 0) {
         return NextResponse.json([]);

--- a/app/api/roles/admin/route.ts
+++ b/app/api/roles/admin/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse, NextRequest } from "next/server";
 import { withOwnerAuth } from "@/lib/auth/middleware";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { createServiceClient } from "@/lib/supabase/server";
 import { dbError } from "@/lib/api/errors";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { observerRoleSchema } from "@/lib/validations/pods";
+import { ROLE_PRESETS } from "@/lib/auth/permissions";
 
 export const POST = withOwnerAuth(
   async (request: NextRequest, auth: AuthenticatedRequest) => {
@@ -23,6 +25,23 @@ export const POST = withOwnerAuth(
 
     if (error) {
       return dbError(error);
+    }
+
+    // Also grant corresponding permissions
+    const serviceClient = createServiceClient();
+    const permissions = ROLE_PRESETS["admin"] ?? [];
+    for (const permission of permissions) {
+      await serviceClient
+        .from("participant_permissions")
+        .upsert(
+          {
+            participant_id,
+            permission,
+            granted_by: auth.user.participantId,
+            revoked_at: null,
+          },
+          { onConflict: "participant_id,permission" }
+        );
     }
 
     return NextResponse.json(data, { status: 201 });

--- a/app/api/roles/developer/route.ts
+++ b/app/api/roles/developer/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse, NextRequest } from "next/server";
 import { withOwnerAuth } from "@/lib/auth/middleware";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { createServiceClient } from "@/lib/supabase/server";
 import { dbError } from "@/lib/api/errors";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { observerRoleSchema } from "@/lib/validations/pods";
+import { ROLE_PRESETS } from "@/lib/auth/permissions";
 
 export const POST = withOwnerAuth(
   async (request: NextRequest, auth: AuthenticatedRequest) => {
@@ -23,6 +25,23 @@ export const POST = withOwnerAuth(
 
     if (error) {
       return dbError(error);
+    }
+
+    // Also grant corresponding permissions
+    const serviceClient = createServiceClient();
+    const permissions = ROLE_PRESETS["developer"] ?? [];
+    for (const permission of permissions) {
+      await serviceClient
+        .from("participant_permissions")
+        .upsert(
+          {
+            participant_id,
+            permission,
+            granted_by: auth.user.participantId,
+            revoked_at: null,
+          },
+          { onConflict: "participant_id,permission" }
+        );
     }
 
     return NextResponse.json(data, { status: 201 });

--- a/app/api/roles/observer/route.ts
+++ b/app/api/roles/observer/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse, NextRequest } from "next/server";
 import { withAdminAuth } from "@/lib/auth/middleware";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { createServiceClient } from "@/lib/supabase/server";
 import { dbError } from "@/lib/api/errors";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { observerRoleSchema } from "@/lib/validations/pods";
+import { ROLE_PRESETS } from "@/lib/auth/permissions";
 
 export const POST = withAdminAuth(
   async (request: NextRequest, auth: AuthenticatedRequest) => {
@@ -23,6 +25,23 @@ export const POST = withAdminAuth(
 
     if (error) {
       return dbError(error);
+    }
+
+    // Also grant corresponding permissions
+    const serviceClient = createServiceClient();
+    const permissions = ROLE_PRESETS["observer"] ?? [];
+    for (const permission of permissions) {
+      await serviceClient
+        .from("participant_permissions")
+        .upsert(
+          {
+            participant_id,
+            permission,
+            granted_by: auth.user.participantId,
+            revoked_at: null,
+          },
+          { onConflict: "participant_id,permission" }
+        );
     }
 
     return NextResponse.json(data, { status: 201 });

--- a/supabase/migrations/00009_permissions_model.sql
+++ b/supabase/migrations/00009_permissions_model.sql
@@ -84,7 +84,23 @@ RETURNS BOOLEAN AS $$
   SELECT has_permission('cycles:write');
 $$ LANGUAGE sql SECURITY DEFINER STABLE;
 
--- 6. Invitations table
+-- 6. Tighten RLS on user_roles and participant_permissions:
+--    write operations require roles:write, not just cycles:write
+DROP POLICY IF EXISTS "user_roles_insert" ON user_roles;
+DROP POLICY IF EXISTS "user_roles_update" ON user_roles;
+CREATE POLICY "user_roles_insert" ON user_roles FOR INSERT TO authenticated
+  WITH CHECK (has_permission('roles:write'));
+CREATE POLICY "user_roles_update" ON user_roles FOR UPDATE TO authenticated
+  USING (has_permission('roles:write'));
+
+DROP POLICY IF EXISTS "permissions_insert" ON participant_permissions;
+DROP POLICY IF EXISTS "permissions_update" ON participant_permissions;
+CREATE POLICY "permissions_insert" ON participant_permissions FOR INSERT TO authenticated
+  WITH CHECK (has_permission('roles:write'));
+CREATE POLICY "permissions_update" ON participant_permissions FOR UPDATE TO authenticated
+  USING (has_permission('roles:write'));
+
+-- 7. Invitations table
 CREATE TABLE invitations (
   id SERIAL PRIMARY KEY,
   email VARCHAR(255) NOT NULL,


### PR DESCRIPTION
…dpoints

- Fix cycles API: replace roles.includes("observer") with can(user, "cycles:read") so permission-based observers see all cycles correctly
- Tighten RLS on user_roles and participant_permissions tables to require roles:write instead of cycles:write for write operations
- Update legacy role-granting endpoints (/api/roles/admin, developer, observer) to also create participant_permissions rows, keeping both tables in sync

https://claude.ai/code/session_014Z5dNKZJwviv39PoGfLKwv