### PR TITLE
revert CTA to dark button with aqua glow on hover

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -95,7 +95,7 @@ function LoginContent() {
           <div className="mt-10 flex flex-col gap-5 sm:flex-row sm:items-center lg:mt-12">
             <button
               onClick={handleLogin}
-              className="inline-flex items-center justify-center gap-3 rounded-full bg-teal px-8 py-4 text-sm font-semibold text-midnight transition-colors hover:bg-aqua"
+              className="inline-flex items-center justify-center gap-3 rounded-full border border-white/[0.12] bg-white/[0.04] px-8 py-4 text-sm font-semibold text-white shadow-[0_0_0_0_rgba(77,187,194,0)] transition-all duration-300 hover:border-aqua/40 hover:bg-white/[0.07] hover:shadow-[0_0_24px_rgba(77,187,194,0.18)]"
             >
               <GoogleLogo />
               {invited
@@ -164,7 +164,7 @@ function LoginContent() {
 
           <button
             onClick={handleLogin}
-            className="inline-flex items-center justify-center gap-3 rounded-full bg-teal px-8 py-4 text-sm font-semibold text-midnight transition-colors hover:bg-aqua"
+            className="inline-flex items-center justify-center gap-3 rounded-full border border-white/[0.12] bg-white/[0.04] px-8 py-4 text-sm font-semibold text-white shadow-[0_0_0_0_rgba(77,187,194,0)] transition-all duration-300 hover:border-aqua/40 hover:bg-white/[0.07] hover:shadow-[0_0_24px_rgba(77,187,194,0.18)]"
           >
             <GoogleLogo />
             {invited


### PR DESCRIPTION
Teal filled pill doesn't suit the Google logo well. Back to the dark ghost-style button (bg-white/[0.04], border-white/[0.12]) with the aqua shadow glow on hover. Shadow starts at 0 and expands to shadow-[0_0_24px_rgba(77,187,194,0.18)] for a smooth transition.

https://claude.ai/code/session_01D6wDW2WuCsxS1FLDN5Wj52