### PR TITLE
42 issue w1 004 migration migration script sheets to postgres staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ yarn-error.log*
 
 # supabase
 supabase/.temp/
+supabase/.branches/
 
 # vercel
 .vercel

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -87,6 +87,7 @@ erDiagram
         varchar gender
         varchar state
         varchar neighborhood
+        varchar phone_number
         varchar dcpl_card
         boolean dcpl_info
         varchar work_situation
@@ -98,12 +99,19 @@ erDiagram
         varchar participation_commitment
         varchar primary_expertise
         varchar volunteer_interest
+        text availability_notes
+        text commitment_notes
+        text interest_areas
+        text moderator_experience
         boolean text_updates
+        boolean email_updates
+        boolean comms_consent
         boolean photo_video_consent
         varchar source
         varchar slack_username
         varchar github_username
         varchar drive_email
+        text notes
         timestamp created_at
     }
 

--- a/docs/OLOS-architecture-brief.md
+++ b/docs/OLOS-architecture-brief.md
@@ -1,0 +1,146 @@
+# OLOS — Architecture Brief
+*The 5-minute orientation for every new contributor*
+
+---
+
+## What OLOS is
+
+OLOS is **The Upskilling Labs' build-cycle operating system** — a custom application that replaces a battery of Google Forms and reconciliation spreadsheets with a single tool that walks Upskillers through ideation → pods → projects → showcase across a 13-week build cycle.
+
+It exists to free a small staff from manual coordination work so they can spend their time engaging with the community, not maintaining cross-sheet joins.
+
+---
+
+## The core abstraction: Cycle → Pod → Project
+
+A **Cycle** is a 13-week build cohort with a theme (e.g. "Health Systems," "Energy & Climate"). It's the root entity.
+
+A **Pod** belongs to a cycle and is seeded by a top-voted *problem statement*. Pods exist in `forming` status until they hit a configurable minimum registrant count, then go `active` and get external resources provisioned (Slack channel, Drive folder, GitHub repo, Google Group).
+
+A **Project** belongs to a pod and is seeded by a top-voted *solution proposal*. Same lifecycle as pods: `forming` → `active` on reaching `project_min`, with its own resource provisioning.
+
+Hierarchy is strict: **a project is always inside a pod, which is always inside a cycle.** No project lives outside a pod; no pod outside a cycle.
+
+---
+
+## The phase machine
+
+Every cycle moves through seven phases, each gated by a configurable open/close window in `cycle_config`:
+
+| Phase | What happens | API endpoint |
+|---|---|---|
+| 1 | Problem statement submission | `POST /api/problem-statements` |
+| 2 | Pod-level (stack) voting | `POST /api/votes` |
+| 3 | Pod shortlist published; participants self-register | `POST /api/pods/{id}/register` |
+| 4 | Solution proposal submission within active pods | `POST /api/pods/{id}/solution-proposals` |
+| 5 | Solution voting within pods | `POST /api/pods/{id}/project-votes` |
+| 6 | Project shortlist published per pod | `POST /api/pods/{id}/projects/finalize` |
+| 7 | Project self-registration | `POST /api/projects/{id}/register` |
+
+**Pulse checks run alongside all phases.** They have no window — they're always open during an active cycle. Missing 2+ consecutive pulse checks is one of the two triggers for inactive status (the other is being in no pod).
+
+---
+
+## Roles
+
+Five roles. Two are explicit grants (Owner/Admin/Observer in `user_roles`), one is implicit from a row in `moderator_assignments`, and Participant is *derived* from `cycle_enrollments.status`.
+
+| Role | Storage | Scope |
+|---|---|---|
+| Owner / Admin | `user_roles` | Global |
+| Moderator | `moderator_assignments` row, `removed_at IS NULL` | Assigned pod(s) for one cycle |
+| Participant (active) | `cycle_enrollments.status = 'active'` | Own pod(s) + projects within them |
+| Participant (inactive) | `cycle_enrollments.status = 'inactive'` | Read-only |
+| Observer | `user_roles` | All cycles, read-only |
+
+Roles **stack**: a Moderator who is also a Participant gets both permission sets unioned.
+
+---
+
+## Five architectural invariants
+
+These are constraints that don't change. Internalize them:
+
+### 1. Phase windows are server-enforced
+Every write endpoint validates `now()` against `cycle_config.{phase}_open / _close` and returns `403` outside the window. No admin override exists. `NULL` timestamps mean "not scheduled" and also return `403`. Pulse checks are the lone exception.
+
+### 2. Roles stack; visibility is the union
+JWT claims carry the resolved role set at token issuance. Endpoints authorize against claims; moderator pod-scope is *additionally* re-checked at endpoint level for write operations.
+
+### 3. Pod membership is multi; project membership is exclusive
+A participant may be in N pods within a cycle (N is configurable via `cycle_config.pod_limit`, default 2 long-term, higher in early cycles). A participant may be in **exactly one** active project per cycle, enforced by a partial unique index on `project_memberships`.
+
+### 4. Resources provision at activation, not formation
+A pod or project at `forming` is just a database row. Once registrant count hits `pod_min` / `project_min`, the backend provisions four external resources synchronously: Slack channel, Drive folder, GitHub repo, Google Group. Provisioning failures don't block activation — they're returned as warnings.
+
+### 5. Soft delete everywhere
+`pod_memberships.inactive_at`, `project_memberships.left_at`, `moderator_assignments.removed_at`, `user_roles.revoked_at`, `access_revocations` audit log. Rows are never hard-deleted. This makes reactivation possible and gives us an audit trail.
+
+---
+
+## The stack at a glance
+
+| Layer | Technology |
+|---|---|
+| Frontend | Next.js (App Router) |
+| Auth | Supabase Auth + Google OAuth + magic links via Resend SMTP |
+| Backend | Python / FastAPI |
+| DB | PostgreSQL (hosted on Supabase) |
+| External | Slack (`slack_sdk`), Google Drive + Groups (`google-api-python-client`), GitHub (`PyGithub`), Resend |
+| LLM | Anthropic API (`claude-haiku-4-5-20251001`) for pod/project name generation |
+
+The frontend talks to FastAPI via REST. FastAPI talks to Postgres directly via the Supabase connection string (not the Supabase client lib — performance). All authenticated calls use a FastAPI JWT, not the Supabase session token.
+
+---
+
+## What replaces what
+
+The legacy workflow is `Upskiller_Community_Manager.xlsx` — a 9-sheet workbook with manually maintained cross-sheet joins. OLOS replaces it like this:
+
+| Spreadsheet artifact | OLOS replacement |
+|---|---|
+| `Upskiller Registrations` sheet | `participants` + `cycle_enrollments` + `participant_options` |
+| `Pod Registration` sheets (Seat 1/2/3) | `pod_memberships` (one row per seat) |
+| `Problem Statement Submissions` | `problem_statements` + JSONB `context` field |
+| `Voting & Pods` (Vote 1/2/3 columns) | `votes` (with `vote_count` column) |
+| `Management Dashboard` Action lists ("Ghosts," "Backdoor," "Slack Defaulters") | Derived SQL queries — no storage needed |
+| `Pod Registration Summary` (live tally) | `SELECT COUNT(*) ... GROUP BY pod_id` |
+| `Flagged Voter` reconciliation column | Eliminated by foreign keys |
+| `Mentor Registrations` | New `mentors` table (Wave 2 — pending decision D3) |
+
+The single biggest conceptual shift: pods used to be identified by string label (`"9. Medical Record Consolidation"`) shared across sheets. In OLOS pods have integer IDs and string typos become impossible.
+
+---
+
+## Where things live in the repo
+
+*(To be filled in once the repo structure is finalized.)*
+
+```
+/app                  Next.js frontend
+  /(public)/register  Public registration form
+  /pulse-check        Authenticated pulse-check form
+  /cycles/[id]        Cycle dashboard
+  /pods/[id]          Pod detail
+  /admin              Admin views
+/api                  FastAPI backend
+  /routers            Endpoint modules per resource
+  /db                 Schema, migrations, seed data
+  /auth               JWT + Supabase token validation
+  /integrations       Slack, Drive, GitHub, Groups clients
+/scripts              Operational scripts (migration, magic-link bulk gen)
+/docs                 OLOS-architecture-brief.md, OLOS-roadmap.md, etc.
+```
+
+---
+
+## Reading order for new contributors
+
+1. This document
+2. `OLOS-roadmap.md` — what we're building, in what order
+3. `OLOS-issue-template.md` — how issues are written
+4. The specific issue you're working on
+5. `TUL_MVP_Spec.md` — full spec, reference only (don't read end-to-end)
+6. `SCHEMA.md` — database schema reference
+
+If you find yourself reading the full spec linearly, you've gone too deep. Drop back to your issue.

--- a/docs/OLOS-roadmap.md
+++ b/docs/OLOS-roadmap.md
@@ -1,0 +1,281 @@
+# OLOS — Roadmap
+*The central long-term plan. This is the source of truth; issues reference back to it.*
+
+**Status:** Living document. Update as decisions resolve and waves complete.
+**Last updated:** April 30, 2026
+
+---
+
+## How to use this document
+
+Every GitHub issue references a section anchor here (e.g. `Implements ROADMAP §1.1`). Section IDs are stable — once assigned, they don't change even if the issue is split, restructured, or reordered. This means the roadmap can be reorganized for readability without breaking issue links.
+
+If a deliverable is added, give it a new ID rather than renumbering. If a deliverable is dropped, mark it `[DROPPED]` and leave the anchor in place.
+
+---
+
+## Goal
+
+Replace the legacy spreadsheet-driven workflow (`Upskiller_Community_Manager.xlsx`) with OLOS — a custom application that walks Upskillers through ideation → pods → projects → showcase. Ship in three waves, each anchored to a phase deadline of the active Energy & Climate cycle.
+
+---
+
+## Three waves
+
+```mermaid
+gantt
+    title OLOS Build — Three Waves
+    dateFormat YYYY-MM-DD
+    axisFormat %b %d
+
+    section Wave 1 — Pulse
+    Schema migration              :w1a, 2026-04-30, 1d
+    Data migration (Sheets→SQL)   :w1b, after w1a, 2d
+    Auth + magic links            :w1c, 2026-04-30, 4d
+    Pulse check form              :w1d, after w1a, 4d
+    Moderator view                :w1e, after w1a, 4d
+    Pulse opens                   :milestone, 2026-05-07, 0d
+
+    section Wave 2 — Project Submission
+    Schema amendments             :w2a, 2026-05-08, 3d
+    Pod registration UI           :w2b, after w2a, 4d
+    Solution proposal flow        :w2c, after w2a, 5d
+    Account management UI         :w2d, 2026-05-08, 5d
+    Project submission opens      :milestone, 2026-05-25, 0d
+
+    section Wave 3 — Voting
+    Project voting UI             :w3a, 2026-05-26, 3d
+    Tally analytics               :w3b, after w3a, 2d
+    Project registration UI       :w3c, after w3a, 3d
+    Project voting opens          :milestone, 2026-06-01, 0d
+```
+
+---
+
+# §1 — Wave 1: Pulse Opens (May 7)
+
+**Goal:** participants can sign in via magic link and submit weekly pulse checks; moderators can see who has and hasn't.
+
+## §1.1 — Schema migration: extend `participants` for legacy field parity
+*Add the GAP fields surfaced by the spreadsheet comparison: `phone_number`, `email_updates`, `comms_consent`, `availability_notes`, `commitment_notes`, `interest_areas`, `moderator_experience`, `notes`. See `2026-04-30_schema_comparison.md` §3.1.*
+- Issue: `ISSUE-W1-001`
+
+## §1.2 — Seed `option_lists` per spec
+*Populate the six lists (`ai_tools`, `labs_goals`, `availability`, `work_style`, `group_strengths`, `pulse_benefits`) with the values defined in `TUL_MVP_Spec.md §option_lists Seed Data`.*
+- Issue: `ISSUE-W1-002`
+
+## §1.3 — Build legacy column mapping CSV
+*Produce a reviewable artifact mapping each spreadsheet column to its destination SQL column or junction-table option. Becomes input to the migration script.*
+- Issue: `ISSUE-W1-003`
+
+## §1.4 — Migration script: spreadsheet → Postgres (staging)
+*Python script that reads `Upskiller_Community_Manager.xlsx`, applies the column mapping from §1.3, and writes to `participants`, `cycle_enrollments`, `participant_options`, `pod_memberships`, `problem_statements`, `votes`. Runs against staging only.*
+- Issue: `ISSUE-W1-004`
+
+## §1.5 — Production migration: Energy & Climate cycle
+*Use the script from §1.4 against production. Active cycle only — historical Health Systems data stays in the workbook as test fixtures.*
+- Issue: `ISSUE-W1-005`
+
+## §1.6 — Wire Supabase Auth + Google OAuth
+*Configure Google OAuth credentials in Supabase Auth; implement `POST /auth/google` in FastAPI; resolve roles from `user_roles`, `moderator_assignments`, `cycle_enrollments` and encode into JWT.*
+- Issue: `ISSUE-W1-006`
+
+## §1.7 — Configure Supabase magic links via Resend SMTP
+*Configure Supabase Auth to deliver magic-link emails via Resend. Includes email template (subject, body, branded sender).*
+- Issue: `ISSUE-W1-007`
+
+## §1.8 — Bulk magic-link generator
+*Admin script that iterates over migrated participants and triggers Supabase magic-link emails. Run once after §1.5 completes.*
+- Issue: `ISSUE-W1-008`
+
+## §1.9 — `POST /api/pulse-checks` endpoint
+*Implement the endpoint per `TUL_MVP_Spec.md` §Pulse Checks, including JSONB validation and the `409 Conflict` rule for duplicate `scheduled_date + cycle_id`.*
+- Issue: `ISSUE-W1-009`
+
+## §1.10 — `GET /api/pulse-checks/{cycle_id}` endpoint
+*Implement the read endpoint with role-based scoping (own records / moderator's pod / admin all).*
+- Issue: `ISSUE-W1-010`
+
+## §1.11 — Pulse-check form page (Next.js)
+*Authenticated route at `/pulse-check`. Renders the survey, posts to §1.9, shows confirmation state.*
+- Issue: `ISSUE-W1-011`
+
+## §1.12 — Pulse-check form copy
+*Final microcopy for question text, helper text, validation messages, confirmation state, error states.*
+- Issue: `ISSUE-W1-012`
+
+## §1.13 — `GET /api/pods/{pod_id}/members` with pulse status
+*Per spec, but extend the response to include each member's most-recent `completed_at` for the pulse-check status indicator.*
+- Issue: `ISSUE-W1-013`
+
+## §1.14 — Moderator pod-members view
+*Authenticated route at `/pods/[id]/members`. Lists members with a pulse-completion indicator (current week complete / missed / overdue). Visible to moderators of that pod, admins, owners.*
+- Issue: `ISSUE-W1-014`
+
+---
+
+## Wave 1 dependency graph
+
+```mermaid
+graph TD
+    W101[§1.1 schema migration]
+    W102[§1.2 seed options]
+    W103[§1.3 mapping CSV]
+    W104[§1.4 migration script]
+    W105[§1.5 prod migration]
+    W106[§1.6 OAuth wiring]
+    W107[§1.7 Resend SMTP]
+    W108[§1.8 bulk magic links]
+    W109[§1.9 POST pulse-checks]
+    W110[§1.10 GET pulse-checks]
+    W111[§1.11 form UI]
+    W112[§1.12 form copy]
+    W113[§1.13 members API]
+    W114[§1.14 moderator UI]
+
+    W101 --> W103 --> W104 --> W105 --> W108
+    W102 --> W109
+    W101 --> W109 --> W110
+    W101 --> W113 --> W114
+    W106 --> W107 --> W108
+    W109 --> W111
+    W112 --> W111
+    W106 --> W111
+    W110 --> W114
+
+    classDef critical fill:#7c2d12,stroke:#fed7aa,color:#fff;
+    class W101,W104,W105,W108 critical
+```
+
+**Critical path** (highlighted): §1.1 → §1.4 → §1.5 → §1.8. If any of these slips, the May 7 deadline slips. Everything else can run in parallel.
+
+---
+
+# §2 — Wave 2: Project Submission Opens (May 25)
+
+**Goal:** pods are formed, moderators can manage them, participants can submit project proposals, and the team behind project voting can see the full data shape.
+
+## §2.1 — Schema amendments: configurable `pod_limit`
+*Move the hardcoded 2-pod cap to `cycle_config.pod_limit SMALLINT NOT NULL DEFAULT 2`. Refactor `POST /api/pods/{id}/register` validation to read from config.*
+- Issue: TBD
+
+## §2.2 — Schema amendments: problem statement context JSONB + `theme_track`
+*Per the schema comparison §3.3, add `problem_statements.context JSONB` and `problem_statements.theme_track VARCHAR(100)` with index. Existing `statement_text` becomes the one-sentence summary.*
+- Issue: TBD
+
+## §2.3 — Account management UI: cycle config editor
+*Admin form to edit `cycle_config` values: pod limit, project limit, vote thresholds, min/max members, all phase windows. Implements `PATCH /api/cycles/{id}/config` from spec.*
+- Issue: TBD
+
+## §2.4 — Pod registration: participant view
+*Authenticated route showing the pod shortlist with problem statements, members, moderators, and a register button. Implements the "See their pods" board section.*
+- Issue: TBD
+
+## §2.5 — Pod self-registration form
+*Implements `POST /api/pods/{id}/register` and `DELETE`. Includes the configurable cap check from §2.1.*
+- Issue: TBD
+
+## §2.6 — Solution proposal submission form
+*Authenticated form scoped to a pod. Posts to `POST /api/pods/{id}/solution-proposals`. Single-submitter UX (per board annotation: multi-submission is functionally allowed but not promoted).*
+- Issue: TBD
+
+## §2.7 — Pulse-check moderator view: response review
+*Extends §1.14. Moderators can read individual pulse responses for their pod members.*
+- Issue: TBD
+
+## §2.8 — Mentors table + onboarding flow
+**[Conditional on D3 — see Open Decisions]**
+- Issue: TBD
+
+---
+
+# §3 — Wave 3: Project Voting Opens (June 1)
+
+**Goal:** active pod members can vote on solution proposals within their pod, see live tallies, and self-register for the resulting projects.
+
+## §3.1 — Project voting form
+*Implements `POST /api/pods/{id}/project-votes` with budget validation (default 3 votes per active pod member, no submitter differentiation per spec).*
+- Issue: TBD
+
+## §3.2 — Voting dashboard (real-time tallies)
+*Per `TUL_MVP_Spec.md §UI Specifications`. Bar visualization with threshold line. Polling-based real-time updates.*
+- Issue: TBD
+
+## §3.3 — Project shortlist publication
+*Implements `POST /api/pods/{id}/projects/finalize`. Tallies, filters by `project_vote_threshold`, ranks, creates up to `max_projects` projects in `forming` status. Includes LLM name generation.*
+- Issue: TBD
+
+## §3.4 — Project self-registration UI
+*Implements `POST /api/projects/{id}/register` and `DELETE`. Enforces the 1-project-per-cycle exclusive constraint.*
+- Issue: TBD
+
+## §3.5 — Pulse-check response analysis
+*Per the Wave 3 board section ("see analysis of responses"). Moderator dashboard view with aggregations across the cycle's pulse data: most-cited tools, most-cited benefits, help requests trend.*
+- Issue: TBD
+
+## §3.6 — Project membership view
+*Per the Wave 3 board section ("see projects membership"). Moderator can see which of their pod's members ended up in which project.*
+- Issue: TBD
+
+---
+
+# §4 — Backlog (post-Showcase)
+
+## §4.1 — Participant-initiated pod join (NTH from board)
+## §4.2 — Auto-add to pod resources on join (NTH)
+## §4.3 — Project review workflow (NTH)
+## §4.4 — Slack message on project submit → pod channel (NTH)
+## §4.5 — Per-project Slack groups (NTH)
+## §4.6 — Onboarding flow expansion
+## §4.7 — Access revocation automation (Slack/Drive/GitHub/Groups APIs)
+## §4.8 — Email notification scheduling
+## §4.9 — Cycle closure side effects (spec Q7)
+
+---
+
+# §5 — Open decisions
+
+These block specific issues. Resolve before the affected work starts.
+
+| ID | Decision | Blocks | Owner | Status |
+|---|---|---|---|---|
+| D1 | Ranked-choice pod registration: preserve `preference_rank` column or flatten to bag-of-pods? | §1.4 (migration script — needs to know whether to write rank), §2.5 (registration form — needs to know whether to surface a rank picker) | TBD | OPEN |
+| D2 | Vote-budget historical reconciliation: how was the Health cycle voting actually run? Per-voter 3-vote budget regardless of submission, or differential? | §1.4 (test data load only — does not block production) | TBD | OPEN |
+| D3 | Mentors: separate `mentors` table, or unify into `participants` with `participant_type` enum? | §2.8 (mentor onboarding — affects entire flow) | TBD | OPEN |
+| D4 | GAP field rollout: add all 8 to `participants` now (one migration), or trickle in as forms get rebuilt? | §1.1 (single migration vs phased) | TBD | RECOMMEND: single migration |
+
+---
+
+# §6 — Wave 1 status tracker
+
+*Update this table as issues progress. Mark waves complete when all issues are merged + deployed.*
+
+| Anchor | Issue | Status | Owner | PR | Notes |
+|---|---|---|---|---|---|
+| §1.1 | ISSUE-W1-001 | not started | — | — | Critical path |
+| §1.2 | ISSUE-W1-002 | not started | — | — | |
+| §1.3 | ISSUE-W1-003 | not started | — | — | |
+| §1.4 | ISSUE-W1-004 | not started | — | — | Critical path; awaits D1 |
+| §1.5 | ISSUE-W1-005 | not started | — | — | Critical path |
+| §1.6 | ISSUE-W1-006 | not started | — | — | |
+| §1.7 | ISSUE-W1-007 | not started | — | — | |
+| §1.8 | ISSUE-W1-008 | not started | — | — | Critical path |
+| §1.9 | ISSUE-W1-009 | not started | — | — | |
+| §1.10 | ISSUE-W1-010 | not started | — | — | |
+| §1.11 | ISSUE-W1-011 | not started | — | — | |
+| §1.12 | ISSUE-W1-012 | not started | — | — | Copy work — non-engineering |
+| §1.13 | ISSUE-W1-013 | not started | — | — | |
+| §1.14 | ISSUE-W1-014 | not started | — | — | |
+
+---
+
+# §7 — Assumptions to verify
+
+These were inferred from the dashboard screenshot and earlier conversation but haven't been confirmed:
+
+1. **Cycle list + cycle detail UI is already shipped.** The April 30 dashboard screenshot showed a working cycle timeline. If this is mocked rather than wired to real data, add issues to §1 to wire it up.
+2. **Participant authentication has SOME implementation.** Aaron is shown logged in. If this is just a stub, §1.6 needs to be expanded.
+3. **The `pulse_checks` table doesn't exist yet in the production DB.** §1.1 includes creating it.
+4. **No staging environment exists.** §1.4 may need to provision one before the script can run against it.
+
+Confirm or correct each before starting Wave 1.

--- a/supabase/CLAUDE.md
+++ b/supabase/CLAUDE.md
@@ -1,0 +1,85 @@
+# supabase/ — migrations & DB conventions
+
+Scope: this file applies to anything under [supabase/](.) — migrations, seed data, RLS, helper functions.
+
+---
+
+## Stack reality vs. roadmap wording
+
+[OLOS-architecture-brief.md](../docs/OLOS-architecture-brief.md) and several issues describe a Python/FastAPI backend with Alembic migrations under `/api/db/migrations/`. **That stack does not exist in this repo.** The shipped stack is:
+
+- Next.js App Router (frontend + API routes under [app/api/](../app/api/))
+- Supabase Postgres, with raw-SQL migrations under [supabase/migrations/](migrations/)
+- No Alembic, no `/api/db/`
+
+When an issue says "Alembic migration under `/api/db/migrations/`", translate it to "raw-SQL migration under `supabase/migrations/`" using the conventions below. Do not introduce Alembic.
+
+---
+
+## Migration conventions
+
+- **Filename:** `NNNNN_short_snake_case_description.sql`. `NNNNN` is the next zero-padded integer after the highest-numbered file currently in [migrations/](migrations/). Check before naming — don't assume.
+- **Forward-only.** Supabase CLI applies files in lexical order; there is no separate down file. If a migration must be reversible, include the rollback as a commented `-- DOWN:` block at the bottom of the same file. Real rollbacks ship as a new forward migration.
+- **Additive by default.** Prefer `ADD COLUMN`, `CREATE INDEX CONCURRENTLY` (where safe), new helper functions, etc. Destructive changes (`DROP COLUMN`, type narrowing, `NOT NULL` without default on a populated table) need an explicit backfill plan in the migration's header comment.
+- **Header comment.** First lines explain *why*, not *what* — the SQL already shows what. Reference the issue or roadmap anchor (e.g. `-- ROADMAP §1.1 / ISSUE-W1-001`).
+- **Defaults for new NOT NULL columns.** Every legacy row must satisfy the constraint. If no safe default exists, split into: (1) add nullable, (2) backfill, (3) set NOT NULL — across separate migrations.
+- **RLS.** New tables need policies in the same migration or an immediate follow-up. Existing tables: confirm policies still cover new columns (column-level grants are rare here, so usually fine — but check [00002_rls_policies.sql](migrations/00002_rls_policies.sql) if in doubt).
+- **No data writes** in schema migrations except trivial seed/lookup rows. Bulk data lives in [seed.sql](seed.sql) or one-off scripts.
+
+## After writing a migration
+
+1. Update [SCHEMA.md](../SCHEMA.md) — both the Mermaid ERD block for the affected table and the table summary if relevant. Schema docs drift fast; update in the same PR.
+2. Run locally if a Supabase instance is up; otherwise call out in the PR that it has only been static-checked.
+3. Reference the migration filename in the PR body.
+
+---
+
+## Active issue: ISSUE-W1-001 (#39) — extend `participants` for legacy field parity
+
+Roadmap anchor: [§1.1](../docs/OLOS-roadmap.md). Unblocks §1.3, §1.4, §1.9, §1.13. Decision D4 is resolved: **single migration**, all eight columns at once.
+
+### Columns to add
+
+Add to `participants` (definition lives at [migrations/00001_initial_schema.sql:54-106](migrations/00001_initial_schema.sql#L54-L106)):
+
+| Column | Type | Nullable | Default | Notes |
+|---|---|---|---|---|
+| `phone_number` | `VARCHAR(50)` | yes | — | free-form; legacy rows lack format normalization |
+| `email_updates` | `BOOLEAN` | yes | — | nullable because legacy form wording shifted mid-cycle |
+| `comms_consent` | `BOOLEAN` | no | `TRUE` | every legacy row had "I agree" before submission, so backfill is safe |
+| `availability_notes` | `TEXT` | yes | — | |
+| `commitment_notes` | `TEXT` | yes | — | |
+| `interest_areas` | `TEXT` | yes | — | free-text for now; may later normalize to an `option_lists` entry |
+| `moderator_experience` | `TEXT` | yes | — | |
+| `notes` | `TEXT` | yes | — | staff-facing scratchpad |
+
+### Execution checklist
+
+- [ ] Create `supabase/migrations/00011_extend_participants_legacy_fields.sql` with all eight `ADD COLUMN` statements in one migration (per D4). (Originally drafted as `00010_*` but renumbered after `main` shipped `00010_pulse_check_v2.sql` via PR #53.)
+- [ ] Header comment cites `ROADMAP §1.1 / ISSUE-W1-001` and the rationale for `comms_consent` defaulting to `TRUE`.
+- [ ] Append a commented `-- DOWN:` block with `ALTER TABLE participants DROP COLUMN ...` for each new column.
+- [ ] Update [SCHEMA.md](../SCHEMA.md) `participants` ERD block (lines ~80–108) to list the new columns.
+- [ ] Verify no existing RLS policy in [00002_rls_policies.sql](migrations/00002_rls_policies.sql) needs to change — current policies are row-level, not column-level, so additions inherit.
+
+### Out of scope (do not pull in)
+
+- The registration form does not yet write these columns at the API/UI layer. That is downstream work in §1.4 / Wave 2.
+- `pod_limit` move to `cycle_config` — that is §2.1.
+- `mentors` table — pending decision D3.
+
+### Verification
+
+- Apply against a clean staging DB: should run with no errors.
+- Apply against a DB with existing `participants` rows: `comms_consent` defaults to `TRUE`, all other new columns are `NULL`. Confirm with `\d participants`.
+- Rollback test: copy the `-- DOWN:` block into a scratch query, run, confirm columns gone, then re-apply the up migration.
+
+---
+
+## Upcoming migrations on the roadmap
+
+These will live in this folder when their issues open. Linked here so future sessions can plan ahead, not act ahead.
+
+- §1.2 — seed `option_lists` (six lists). Lives in [seed.sql](seed.sql) or a dedicated migration; decide based on whether values should be re-seedable.
+- §2.1 — move `pod_limit` from hardcoded constant into `cycle_config`. Will require coordinated API change in [app/api/pods/](../app/api/pods/).
+- §2.2 — add `problem_statements.context JSONB` and `problem_statements.theme_track VARCHAR(100)` (with index).
+- §2.8 — `mentors` table, conditional on D3.

--- a/supabase/migrations/00011_extend_participants_legacy_fields.sql
+++ b/supabase/migrations/00011_extend_participants_legacy_fields.sql
@@ -1,0 +1,40 @@
+-- ROADMAP §1.1 / ISSUE-W1-001
+-- Extend participants for legacy field parity.
+--
+-- Adds the eight fields the legacy registration form collects but the current
+-- schema discards, so the W1-004 migration script can write all spreadsheet
+-- columns without dropping data.
+--
+-- comms_consent defaults TRUE because every legacy row agreed to comms before
+-- submission was accepted; backfill is safe.
+-- email_updates is nullable because the legacy form's question wording shifted
+-- mid-cycle and "no answer" is a meaningful state.
+--
+-- IF NOT EXISTS guards make the migration idempotent against partial application.
+-- Single ALTER TABLE batches the eight column adds into one catalog rewrite.
+-- Postgres 11+ treats ADD COLUMN ... DEFAULT as metadata-only (no full table
+-- rewrite), so this is safe to run on a populated participants table.
+
+ALTER TABLE participants
+  ADD COLUMN IF NOT EXISTS phone_number         VARCHAR(50),
+  ADD COLUMN IF NOT EXISTS email_updates        BOOLEAN,
+  ADD COLUMN IF NOT EXISTS comms_consent        BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN IF NOT EXISTS availability_notes   TEXT,
+  ADD COLUMN IF NOT EXISTS commitment_notes     TEXT,
+  ADD COLUMN IF NOT EXISTS interest_areas       TEXT,
+  ADD COLUMN IF NOT EXISTS moderator_experience TEXT,
+  ADD COLUMN IF NOT EXISTS notes                TEXT;
+
+-- DOWN: rollback block. Copy into a scratch query to revert in dev.
+-- Not auto-applied; Supabase migrations are forward-only. A real rollback
+-- ships as a new forward migration so the history stays linear.
+--
+-- ALTER TABLE participants
+--   DROP COLUMN IF EXISTS phone_number,
+--   DROP COLUMN IF EXISTS email_updates,
+--   DROP COLUMN IF EXISTS comms_consent,
+--   DROP COLUMN IF EXISTS availability_notes,
+--   DROP COLUMN IF EXISTS commitment_notes,
+--   DROP COLUMN IF EXISTS interest_areas,
+--   DROP COLUMN IF EXISTS moderator_experience,
+--   DROP COLUMN IF EXISTS notes;


### PR DESCRIPTION
## Summary
- Implements W1-001 (#39): adds 8 legacy-parity columns to `participants` (`phone_number`, `email_updates`, `comms_consent NOT NULL DEFAULT TRUE`, `availability_notes`, `commitment_notes`, `interest_areas`, `moderator_experience`, `notes`) via `00011_extend_participants_legacy_fields.sql`. Idempotent additive ALTER with a commented `-- DOWN:` rollback.
- Adds `supabase/CLAUDE.md` (migration-lane conventions + W1-001 execution plan), updates `SCHEMA.md`, and ignores `supabase/.branches/`.
- Separate commit ships `docs/OLOS-architecture-brief.md` + `docs/OLOS-roadmap.md` — reference docs the migration work cites.

Renumbered `00010 → 00011` after `00010_pulse_check_v2.sql` (#53) landed on main. Branch is named for W1-004; that issue depends on W1-001 and ships next.

## Test plan
- [x] `supabase db reset` applies the full chain cleanly locally.
- [x] `\d participants` shows all 8 new columns; `comms_consent` is `NOT NULL DEFAULT TRUE`.
- [x] Synthetic INSERT round-trip works; default applies when `comms_consent` is omitted.
- [x] DOWN→UP roundtrip clean.
- [ ] Staging: `supabase db push` + `NOTIFY pgrst, 'reload schema';`
- [ ] Production: manual snapshot, apply, verify, reload PostgREST cache.

Closes #39.
