### PR TITLE
fix(email): set noreply@ as default sender, restore on-brand subject

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -11,7 +11,7 @@ OWNER_EMAILS=hq@theupskillinglabs.org,brendan@withlevy.com
 
 # Resend (email delivery for magic link invitations)
 RESEND_API_KEY=re_your_api_key_here
-RESEND_FROM_EMAIL=invites@theupskillinglabs.org
+RESEND_FROM_EMAIL=noreply@theupskillinglabs.org
 
 # Public app URL (used to build magic links in emails)
 NEXT_PUBLIC_APP_URL=https://app.theupskillinglabs.org

--- a/app/api/invitations/[invitation_id]/send/route.ts
+++ b/app/api/invitations/[invitation_id]/send/route.ts
@@ -59,7 +59,7 @@ export const POST = withAdminAuth(
     const { error: sendError } = await resend.emails.send({
       from: FROM_EMAIL,
       to: invitation.email,
-      subject: "Invitation to Open Labs Operating System",
+      subject: "You're invited to The Upskilling Labs",
       html: invitationEmailHtml({
         magicLink,
         rolePreset: invitation.role_preset,

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -8,6 +8,6 @@ export function getResendClient(): Resend {
 }
 
 const fromAddress =
-  process.env.RESEND_FROM_EMAIL ?? "invites@theupskillinglabs.org";
+  process.env.RESEND_FROM_EMAIL ?? "noreply@theupskillinglabs.org";
 
 export const FROM_EMAIL = `Upskilling Labs <${fromAddress}>`;


### PR DESCRIPTION
## Summary

Two small polish items for #45 (configure Resend), both team-confirmed:

- **Sender:** switch `RESEND_FROM_EMAIL` default from `invites@theupskillinglabs.org` → `noreply@theupskillinglabs.org`. Matches the sender named in #45's spec text. Reads correctly for any future Supabase-Auth-side emails (password recovery, email-change) if those are ever routed through the same domain. Updated in both \`.env.local.example\` and the in-code fallback in [lib/email/index.ts](lib/email/index.ts) so a contributor running locally without the env var set hits a sensible default.
- **Subject:** revert to \`\"You're invited to The Upskilling Labs\"\`. The post-merge change to \`\"Invitation to Open Labs Operating System\"\` (commit 7ff5492 by @inferno-gh) expanded the OLOS acronym to a name that doesn't appear on the login page, in the email body H1, or anywhere else user-facing — recipients would see brand drift between the inbox preview and the email body.

Both changes are surfaced from the audit in [\`docs/branch-vs-main-2026-05-08.md\`](docs/branch-vs-main-2026-05-08.md) §Findings.

## Test plan

- [ ] Update \`RESEND_FROM_EMAIL=noreply@theupskillinglabs.org\` in Vercel Production env, redeploy
- [ ] After Resend domain is verified (#45 ops step), create a test invitation via \`/admin/invitations\` to a personal Gmail
- [ ] Inbox shows sender as \`Upskilling Labs <noreply@theupskillinglabs.org>\`
- [ ] Inbox shows subject as \`You're invited to The Upskilling Labs\`
- [ ] Repeat with a non-Gmail inbox; confirm SPF + DKIM pass via \"Show original\"

## Related

- Closes a sub-task of #45
- Reverts the subject-line half of MJ's post-merge commit \`7ff5492\`; keeps the display-name half (\`Upskilling Labs <…>\`) which is correct
- Architecture context in [\`lib/auth/CLAUDE.md\`](lib/auth/CLAUDE.md) §Issue #45