### PR TITLE
fix(email): align default sender with verified Resend subdomain

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -11,7 +11,7 @@ OWNER_EMAILS=hq@theupskillinglabs.org,brendan@withlevy.com
 
 # Resend (email delivery for magic link invitations)
 RESEND_API_KEY=re_your_api_key_here
-RESEND_FROM_EMAIL=noreply@theupskillinglabs.org
+RESEND_FROM_EMAIL=noreply@enroll.theupskillinglabs.org
 
 # Public app URL (used to build magic links in emails)
 NEXT_PUBLIC_APP_URL=https://app.theupskillinglabs.org

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 .env*.local
 !.env.local.example
 
+# MCP server config — may contain credentials
+.mcp.json
+
 # supabase
 supabase/.temp/
 supabase/.branches/

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -8,6 +8,6 @@ export function getResendClient(): Resend {
 }
 
 const fromAddress =
-  process.env.RESEND_FROM_EMAIL ?? "noreply@theupskillinglabs.org";
+  process.env.RESEND_FROM_EMAIL ?? "noreply@enroll.theupskillinglabs.org";
 
 export const FROM_EMAIL = `Upskilling Labs <${fromAddress}>`;


### PR DESCRIPTION
## Summary

- Switch in-code `RESEND_FROM_EMAIL` fallback in [`lib/email/index.ts`](lib/email/index.ts#L11) and [`.env.local.example`](.env.local.example#L14) from `noreply@theupskillinglabs.org` (apex) → `noreply@enroll.theupskillinglabs.org` (verified subdomain). Without this, a contributor running locally with no env var set would build a `From:` address Resend rejects.
- Add `.mcp.json` to [`.gitignore`](.gitignore) — the file holds MCP server credentials and was previously uncovered, so a future `git add -A` could accidentally commit it.

## Why

Resend domain verification for OLOS landed on **subdomain mode** (`enroll.theupskillinglabs.org`), confirmed via SPF/DKIM/DMARC pass on the first production send (2026-05-08). PR #67 set the default to the apex; this corrects it to match the actually-verified domain. Audit context in [`lib/auth/CLAUDE.md`](lib/auth/CLAUDE.md) §Issue #45.

## Action required after merge

Update Vercel Production env: `RESEND_FROM_EMAIL=noreply@enroll.theupskillinglabs.org`, then redeploy. (Was previously `hq@enroll.theupskillinglabs.org` per ops notes.)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (7 pre-existing warnings on unrelated files; 0 errors)
- [ ] After merge + Vercel env update: send a test invitation via `/admin/invitations`, confirm `From:` shows `Upskilling Labs <noreply@enroll.theupskillinglabs.org>`

## Related

- Closes the local-default half of #45
- Follow-up to #67