### PR TITLE
feat(ops): bulk magic-link script for cycle onboarding

### DIFF
--- a/lib/auth/CLAUDE.md
+++ b/lib/auth/CLAUDE.md
@@ -409,7 +409,10 @@ Sequenced — each step depends on the previous:
    secret from step 1.
 3. **Supabase Studio → Auth → URL Configuration** — set `Site URL` and
    add the prod app domain to Redirect URLs
-   (`https://app.theupskillinglabs.org/api/auth/callback`).
+   (`https://olos.theupskillinglabs.org/api/auth/callback`). The
+   `app.theupskillinglabs.org` subdomain referenced in earlier drafts was
+   never DNS'd; production lives on `olos.theupskillinglabs.org` per the
+   Vercel project's domain configuration.
 4. ✅ **Resend** — verified `enroll.theupskillinglabs.org` (subdomain mode);
    SPF + DKIM + DMARC passing on the 2026-05-08 first prod send. Approved
    sender is `noreply@enroll.theupskillinglabs.org` (in-code default

--- a/scripts/ops/CLAUDE.md
+++ b/scripts/ops/CLAUDE.md
@@ -1,0 +1,212 @@
+# scripts/ops/ — operational scripts
+
+Scope: this file applies to anything under [scripts/ops/](.) — one-shot or
+ad-hoc Node/TypeScript scripts that run against a live Supabase project.
+Distinct from [scripts/migration/](../migration/) (Python, legacy spreadsheet
+→ Postgres) and [supabase/migrations/](../../supabase/migrations/) (DDL).
+
+Roadmap anchor: [§1.8](../../docs/OLOS-roadmap.md). The first script in this
+folder — `send-bulk-invites.ts` — closes Issue #46.
+
+---
+
+## Stack: Node + TypeScript via tsx
+
+These scripts call the same Resend HTTP API and the same `invitations` /
+`cycle_enrollments` shapes as the Next.js app, so they share the app's
+TypeScript code and dependencies. Reusing the app's
+[`lib/email/invitation-template.ts`](../../lib/email/invitation-template.ts)
+keeps the bulk path and the per-row admin send (POST
+`/api/invitations/{id}/send`) from drifting on subject line, layout, or
+copy.
+
+Run with [`tsx`](https://tsx.is) — no compile step, respects the repo
+`tsconfig.json` paths (`@/*`), and forwards Node's `--env-file` flag so
+`.env.local` loads without a bespoke parser.
+
+```bash
+npx tsx --env-file=.env.local scripts/ops/send-bulk-invites.ts --help
+```
+
+`tsx` is not in `package.json` — `npx` fetches it on first run. That's
+intentional: ops scripts are infrequent operator runs, not part of CI.
+
+---
+
+## Safety contract
+
+Mirrors [scripts/migration/CLAUDE.md §"Looking ahead: ISSUE-W1-004"](../migration/CLAUDE.md).
+Items marked **[required]** are non-negotiable; everything else is style
+guidance for future scripts in this folder.
+
+### [required] Dry-run by default
+
+Default mode prints the plan with no side effects. `--commit` is required to
+write or send. The flag asymmetry is deliberate — accidentally typing
+`--commit` is harder than accidentally omitting `--dry-run`.
+
+### [required] Connection-string guard
+
+Inspect `NEXT_PUBLIC_SUPABASE_URL` before any work. If the host contains the
+production project ref (`cethihabtddiujzayaxe`), require `--prod` to proceed
+*and* — for `--commit` — a typed cycle-name confirmation read from stdin.
+The interactive prompt is the last line of defence against a misfired batch
+on prod. Do not delegate this to operator discipline.
+
+The reverse also holds: passing `--prod` against a non-prod URL aborts. The
+two flags must agree.
+
+### [required] Never log PII
+
+Logs go to terminals, terminals go to screenshots, screenshots leak. Log
+indices (`[3/19]`), IDs (`participant_id=14 invitation_id=22`), counts, and
+outcomes. **Never** log full email addresses, names, free-text fields, or
+row dumps. The participant join is needed to *do* the work; the log is for
+operators to follow progress, not for auditing identities.
+
+If you genuinely need a per-recipient debug trail, write it to a file with
+explicit operator opt-in (e.g. `--debug-log path.jsonl`) — never to stdout.
+
+### [required] Idempotency
+
+Re-running with the same arguments must not double-send. For the invitation
+flow, the duplicate key follows `app/api/invitations/route.ts:54-81` —
+`(email, cycle_id, role_preset=null)` for non-expired pending invites. The
+bulk script defaults to skipping rows that match; `--include-pending`
+overrides for the rare re-send case.
+
+Idempotency is keyed on **pending bulk invites only**. Already-accepted
+invites do not block a new bulk send — accepting an extra bulk invite for an
+already-enrolled participant is materially a no-op (`fulfillInvitation()`
+with all NULL grant fields just marks the invitation accepted).
+
+### [required] Fail-loud, log-soft
+
+Per-row failures append to an outcomes array and the run continues. The
+final summary names every failed row by `participant_id` + phase
+(`insert` / `send` / `update`) + error message. Process exits non-zero if
+any failure occurred so CI / shell pipelines notice.
+
+### Rate limit awareness
+
+Resend free tier: 100 emails/day, 3000/month, 1 verified domain. For the
+~30-row Wave 1 cohort, no throttle is needed; the script still inserts a
+200ms per-row delay so a future 500-row batch stays polite. If the cohort
+grows past the daily cap, the script needs to learn `--resume-from`; for
+now, that's deferred (operator can re-run with `--limit` + an offset).
+
+---
+
+## Stack reality vs. roadmap wording
+
+[Issue #46](https://github.com/TheUpskillingLabs/OLOS/issues/46) says
+"script at `/scripts/ops/send_magic_links.py`" — Python, snake_case. The
+shipped script is `send-bulk-invites.ts` — Node/TypeScript, kebab-case. Two
+reasons:
+
+1. **Reusing the email template.** The Resend dispatch path is in
+   TypeScript at [`lib/email/`](../../lib/email/). A Python script would
+   either re-implement the template (drift risk on subject + body) or shell
+   out to Node (worse). TypeScript here keeps the bulk path and the admin
+   per-row path on one template.
+2. **Python in this repo is a one-shot escape hatch.** The
+   [scripts/migration/CLAUDE.md](../migration/CLAUDE.md) folder uses
+   Python because `pandas` + `openpyxl` read `.xlsx`; ops work against
+   Postgres + Resend HTTP is exactly what the app stack does.
+
+The issue's other architectural pointer — "Supabase Admin API: POST
+`/auth/v1/admin/generate_link`" — is also wrong. That's the Supabase
+magic-link OTP path that [#64](https://github.com/TheUpskillingLabs/OLOS/issues/64)
+ratified the codebase off (free-tier auth-email throttle would block bulk
+fan-out). The bulk script reuses the custom-invitation flow described in
+[`lib/auth/CLAUDE.md §Invitation flow`](../../lib/auth/CLAUDE.md).
+
+---
+
+## Active script: `send-bulk-invites.ts` (#46)
+
+### Behavior summary
+
+1. Validate args + env. Detect prod via the `NEXT_PUBLIC_SUPABASE_URL`
+   host; require `--prod` if it's prod.
+2. Verify the cycle exists. Print the plan (PII-free).
+3. Fetch active `cycle_enrollments` for the cycle, joined with
+   `participants`. Filter by `--only-email` if set.
+4. Annotate each row with `has_auth_user`, `has_live_pending_invite`,
+   `has_accepted_invite` for that cycle.
+5. Apply `--limit`.
+6. Print plan summary by `participant_id` (no emails).
+7. If `--commit`: prompt for cycle-name confirmation on prod; then per row:
+   insert `invitations` row (bulk shape — `cycle_id` set, everything else
+   NULL/empty), dispatch via Resend, update `email_sent_at`, append to
+   outcomes. 200ms delay between sends.
+8. Print run summary. Exit non-zero on any failure.
+
+The "bulk shape" — `pod_id` / `permissions` / `role_preset` NULL/empty —
+matters because `fulfillInvitation()` in
+[`/api/auth/callback`](../../app/api/auth/callback/route.ts) will upsert
+*nothing material* for those fields. The bulk invite is a click-tracked
+"sign in" entry point, not a permission grant. Participants are already
+enrolled.
+
+### CLI
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--cycle-id <n>` | required | positive integer; must exist in `cycles` |
+| `--dry-run` | on | no DB writes, no emails |
+| `--commit` | off | required to fire |
+| `--prod` | off | required when SUPABASE_URL is prod |
+| `--limit <n>` | none | cap rows processed (after `--only-email` filter) |
+| `--only-email <addr>` | none | restrict to one address (sanity tests) |
+| `--include-pending` | off | do not skip rows with live pending bulk invite |
+| `--app-url <url>` | env / `https://olos.theupskillinglabs.org` | magic-link host |
+
+### Test plan (executed for #46)
+
+1. **Dry-run on prod** — `--cycle-id 1 --dry-run --prod`. Verify counts
+   match `select count(*) from cycle_enrollments where cycle_id = 1 and
+   status = 'active'`.
+2. **Single-recipient sanity send** — `--cycle-id 1 --commit --prod
+   --only-email <addr>`. Confirm: invitation row inserted, `email_sent_at`
+   populated, email arrives in inbox, link works, `fulfillInvitation()`
+   no-ops gracefully (participant already enrolled).
+3. **Re-run idempotency** — same command. Should be skipped as "live
+   pending bulk invite already exists".
+4. **Full run** — held pending operator decision (see Open question below).
+
+### Open question: full-cohort fan-out timing
+
+The 19 active enrollments on `cycle_id=1` ("Spring 2026 Build Cycle") are
+pre-existing rows (early adopters + manual seeds), not the migrated cohort
+the issue text assumes. `§1.5` (production migration) hasn't run yet, so
+the "migrated participant list" doesn't exist. Three options:
+
+- (a) Run the full batch against the 19 rows now and treat #46 as done.
+- (b) Hold the full batch until `§1.5` finishes and the real cohort lands.
+- (c) Ship the script + dry-run verification; defer the full batch to a
+  separate operator-triggered run.
+
+**Status:** (c) — script shipped + verified via prod dry-run + single-recipient
+sanity send. Full cohort fan-out is deferred until the §1.5 migration
+produces the real population. Re-run against `cycle_id=1` (or whichever
+cycle holds the migrated cohort) when that lands.
+
+---
+
+## Looking ahead
+
+Other ops scripts that may grow this folder. Linked here so future sessions
+can plan ahead, not act ahead.
+
+- **Bulk pod assignment** (post-§2.x): assign participants to pods based on
+  ranked-choice resolution (pending D1).
+- **Pulse-check reminder send**: re-engage participants who haven't filed
+  the current cycle's pulse. Same Resend path, different template.
+- **Data export to operator dashboards**: CSV / Sheets dumps of cycle
+  activity — read-only, but PII-heavy, so the same `[required] Never log
+  PII` rule applies (write to file, never stdout).
+
+If any of these grow past a one-off, consider whether they belong as a
+worker / cron route in [`app/api/`](../../app/api/) instead. The folder is
+for *operator-triggered* scripts, not background jobs.

--- a/scripts/ops/send-bulk-invites.ts
+++ b/scripts/ops/send-bulk-invites.ts
@@ -1,0 +1,534 @@
+/**
+ * Bulk magic-link invite generator (ROADMAP §1.8 / ISSUE-W1-008).
+ *
+ * Inserts an `invitations` row per active enrollment in a target cycle and
+ * dispatches the branded magic-link email via Resend. Invitations are
+ * "bulk-flavored": cycle_id is set; pod_id, role_preset, permissions are NULL.
+ * That makes acceptance idempotent — `fulfillInvitation()` no-ops materially
+ * for already-enrolled participants and just marks the invitation accepted.
+ *
+ * Safety contract (mirrors scripts/migration/CLAUDE.md):
+ *   - dry-run by default; --commit required to write or send
+ *   - prod-host guard requires --prod + typed cycle-name confirmation
+ *   - idempotent: skips rows with a non-expired pending bulk invite already
+ *   - PII-safe logs: indices, IDs, counts, outcomes — never emails or names
+ *   - per-row failures append to summary; run continues
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/ops/send-bulk-invites.ts \
+ *     --cycle-id 1 --dry-run
+ *
+ *   npx tsx --env-file=.env.local scripts/ops/send-bulk-invites.ts \
+ *     --cycle-id 1 --commit --prod --limit 1 --only-email someone@example.com
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { Resend } from "resend";
+import {
+  invitationEmailHtml,
+  invitationEmailText,
+} from "@/lib/email/invitation-template";
+import { createInterface } from "node:readline/promises";
+
+const PROD_PROJECT_REF = "cethihabtddiujzayaxe";
+const DEFAULT_APP_URL = "https://olos.theupskillinglabs.org";
+const EMAIL_SUBJECT = "You're invited to The Upskilling Labs";
+const PER_ROW_DELAY_MS = 200;
+
+type Args = {
+  cycleId: number;
+  dryRun: boolean;
+  commit: boolean;
+  prod: boolean;
+  limit: number | null;
+  onlyEmail: string | null;
+  includePending: boolean;
+  appUrl: string | null;
+  invitedBy: number | null;
+};
+
+type TargetRow = {
+  participantId: number;
+  email: string;
+  hasAuthUser: boolean;
+  hasLivePending: boolean;
+  hasAcceptedInvite: boolean;
+};
+
+type RowOutcome =
+  | { kind: "sent"; participantId: number; invitationId: number }
+  | { kind: "skipped"; participantId: number; reason: string }
+  | { kind: "failed"; participantId: number; phase: string; error: string };
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    cycleId: 0,
+    dryRun: true,
+    commit: false,
+    prod: false,
+    limit: null,
+    onlyEmail: null,
+    includePending: false,
+    appUrl: null,
+    invitedBy: null,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--cycle-id":
+        args.cycleId = Number(argv[++i]);
+        break;
+      case "--dry-run":
+        args.dryRun = true;
+        args.commit = false;
+        break;
+      case "--commit":
+        args.commit = true;
+        args.dryRun = false;
+        break;
+      case "--prod":
+        args.prod = true;
+        break;
+      case "--limit":
+        args.limit = Number(argv[++i]);
+        break;
+      case "--only-email":
+        args.onlyEmail = argv[++i].toLowerCase();
+        break;
+      case "--include-pending":
+        args.includePending = true;
+        break;
+      case "--app-url":
+        args.appUrl = argv[++i];
+        break;
+      case "--invited-by":
+        args.invitedBy = Number(argv[++i]);
+        break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        die(`Unknown flag: ${a}. Use --help for usage.`);
+    }
+  }
+
+  if (!Number.isInteger(args.cycleId) || args.cycleId <= 0) {
+    die("--cycle-id <n> is required (positive integer).");
+  }
+  if (args.limit !== null && (!Number.isInteger(args.limit) || args.limit <= 0)) {
+    die("--limit must be a positive integer when set.");
+  }
+  if (args.invitedBy !== null && (!Number.isInteger(args.invitedBy) || args.invitedBy <= 0)) {
+    die("--invited-by must be a positive integer when set.");
+  }
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write(`Bulk magic-link invite generator (#46 / §1.8)
+
+Required:
+  --cycle-id <n>          Target cycle id
+
+Mode:
+  --dry-run               (default) plan only — no DB writes, no Resend calls
+  --commit                actually insert + send
+  --prod                  required when SUPABASE_URL points at production
+
+Filtering:
+  --limit <n>             process at most N rows
+  --only-email <addr>     restrict target list to one address (sanity sends)
+  --include-pending       do not skip rows with a live pending bulk invite
+
+Actor:
+  --invited-by <pid>      participant_id to record as the inviter
+                          (default: first OWNER_EMAILS entry resolved to a participant)
+
+Other:
+  --app-url <url>         override magic-link host (default: NEXT_PUBLIC_APP_URL or ${DEFAULT_APP_URL})
+  -h, --help              show this help
+
+Run with --env-file=.env.local so env vars load:
+  npx tsx --env-file=.env.local scripts/ops/send-bulk-invites.ts --cycle-id 1 --dry-run
+`);
+}
+
+function die(msg: string): never {
+  process.stderr.write(`error: ${msg}\n`);
+  process.exit(2);
+}
+
+function isProdUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  return url.includes(PROD_PROJECT_REF);
+}
+
+async function confirmProd(cycleName: string): Promise<void> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  process.stdout.write(
+    `\nproduction guard: type the cycle name exactly to proceed.\n` +
+      `expected: ${cycleName}\n> `
+  );
+  const answer = (await rl.question("")).trim();
+  rl.close();
+  if (answer !== cycleName) {
+    die("cycle-name confirmation did not match. aborting.");
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const resendKey = process.env.RESEND_API_KEY;
+  const envAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  const appUrl = args.appUrl ?? envAppUrl ?? DEFAULT_APP_URL;
+
+  if (!supabaseUrl) {
+    die(
+      "NEXT_PUBLIC_SUPABASE_URL is not set. Did you forget --env-file=.env.local?"
+    );
+  }
+  if (!serviceKey) die("SUPABASE_SERVICE_ROLE_KEY is not set.");
+  if (args.commit && !resendKey) die("RESEND_API_KEY is not set (required for --commit).");
+
+  const targetingProd = isProdUrl(supabaseUrl);
+  if (targetingProd && !args.prod) {
+    die(
+      "SUPABASE_URL targets production but --prod was not passed. " +
+        "Re-run with --prod (and a typed cycle-name confirmation will be required for --commit)."
+    );
+  }
+  if (!targetingProd && args.prod) {
+    die("--prod was passed but SUPABASE_URL does not target the production project.");
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  // 0. Resolve the inviter participant_id. invitations.invited_by is NOT NULL.
+  let invitedBy: number;
+  if (args.invitedBy !== null) {
+    const { data: pRow, error: pErr } = await supabase
+      .from("participants")
+      .select("id")
+      .eq("id", args.invitedBy)
+      .maybeSingle();
+    if (pErr) die(`--invited-by lookup failed: ${pErr.message}`);
+    if (!pRow) die(`--invited-by participant ${args.invitedBy} not found.`);
+    invitedBy = args.invitedBy;
+  } else {
+    const ownerEmailsRaw = process.env.OWNER_EMAILS;
+    if (!ownerEmailsRaw) {
+      die(
+        "no --invited-by passed and OWNER_EMAILS env var is unset. " +
+          "set OWNER_EMAILS or pass --invited-by <participant_id>."
+      );
+    }
+    const ownerEmails = ownerEmailsRaw
+      .split(",")
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean);
+    if (ownerEmails.length === 0) {
+      die("OWNER_EMAILS is set but contains no addresses.");
+    }
+    const { data: ownerRow, error: ownerErr } = await supabase
+      .from("participants")
+      .select("id, email")
+      .in("email", ownerEmails)
+      .order("id", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    if (ownerErr) die(`OWNER_EMAILS participant lookup failed: ${ownerErr.message}`);
+    if (!ownerRow) {
+      die(
+        "no participants row matches any OWNER_EMAILS entry. " +
+          "an owner must have signed in once before bulk runs."
+      );
+    }
+    invitedBy = ownerRow.id as number;
+  }
+
+  // 1. Verify cycle exists.
+  const { data: cycle, error: cycleErr } = await supabase
+    .from("cycles")
+    .select("id, name")
+    .eq("id", args.cycleId)
+    .maybeSingle();
+  if (cycleErr) die(`cycle lookup failed: ${cycleErr.message}`);
+  if (!cycle) die(`cycle ${args.cycleId} not found.`);
+  const cycleName = cycle.name as string;
+
+  process.stdout.write(
+    `\nbulk-invite plan\n` +
+      `  cycle_id:        ${args.cycleId}\n` +
+      `  cycle_name:      ${cycleName}\n` +
+      `  mode:            ${args.commit ? "COMMIT" : "dry-run"}\n` +
+      `  targeting_prod:  ${targetingProd}\n` +
+      `  app_url:         ${appUrl}\n` +
+      `  invited_by:      participant_id=${invitedBy}${args.invitedBy === null ? " (resolved from OWNER_EMAILS)" : ""}\n` +
+      `  limit:           ${args.limit ?? "(none)"}\n` +
+      `  only_email:      ${args.onlyEmail ? "(set)" : "(none)"}\n` +
+      `  include_pending: ${args.includePending}\n`
+  );
+
+  // 2. Fetch active enrollments + participant rows.
+  const { data: enrollRows, error: enrollErr } = await supabase
+    .from("cycle_enrollments")
+    .select("participant_id, status, participants!inner(id, email, auth_user_id)")
+    .eq("cycle_id", args.cycleId)
+    .eq("status", "active")
+    .order("participant_id", { ascending: true });
+  if (enrollErr) die(`enrollment query failed: ${enrollErr.message}`);
+  if (!enrollRows || enrollRows.length === 0) {
+    process.stdout.write("\nno active enrollments for this cycle. nothing to do.\n");
+    return;
+  }
+
+  type EnrollmentJoin = {
+    participant_id: number;
+    participants: { id: number; email: string; auth_user_id: string | null };
+  };
+
+  let rowsRaw: EnrollmentJoin[] = (enrollRows as unknown as EnrollmentJoin[]).map(
+    (r) => ({
+      participant_id: r.participant_id,
+      participants: r.participants,
+    })
+  );
+
+  if (args.onlyEmail) {
+    const target = args.onlyEmail;
+    rowsRaw = rowsRaw.filter((r) => r.participants.email.toLowerCase() === target);
+    if (rowsRaw.length === 0) {
+      die(`--only-email did not match any active enrollment in cycle ${args.cycleId}.`);
+    }
+  }
+
+  // 3. Annotate with idempotency facts: live pending bulk invite + accepted invite.
+  const emails = rowsRaw.map((r) => r.participants.email.toLowerCase());
+  const nowIso = new Date().toISOString();
+  const { data: priorInvites, error: priorErr } = await supabase
+    .from("invitations")
+    .select("email, cycle_id, role_preset, status, expires_at")
+    .in("email", emails)
+    .eq("cycle_id", args.cycleId);
+  if (priorErr) die(`prior-invite query failed: ${priorErr.message}`);
+
+  const livePendingByEmail = new Set<string>();
+  const acceptedByEmail = new Set<string>();
+  for (const inv of priorInvites ?? []) {
+    const email = (inv.email as string).toLowerCase();
+    const isBulkShape = inv.role_preset === null;
+    if (
+      inv.status === "pending" &&
+      isBulkShape &&
+      new Date(inv.expires_at as string) > new Date(nowIso)
+    ) {
+      livePendingByEmail.add(email);
+    }
+    if (inv.status === "accepted") {
+      acceptedByEmail.add(email);
+    }
+  }
+
+  const annotated: TargetRow[] = rowsRaw.map((r) => ({
+    participantId: r.participant_id,
+    email: r.participants.email.toLowerCase(),
+    hasAuthUser: r.participants.auth_user_id !== null,
+    hasLivePending: livePendingByEmail.has(r.participants.email.toLowerCase()),
+    hasAcceptedInvite: acceptedByEmail.has(r.participants.email.toLowerCase()),
+  }));
+
+  // 4. Apply limit.
+  const limited = args.limit ? annotated.slice(0, args.limit) : annotated;
+
+  // 5. Plan summary (no PII).
+  const planSent: number[] = [];
+  const planSkippedPending: number[] = [];
+  for (const row of limited) {
+    if (row.hasLivePending && !args.includePending) {
+      planSkippedPending.push(row.participantId);
+    } else {
+      planSent.push(row.participantId);
+    }
+  }
+
+  process.stdout.write(
+    `\ntarget summary (no PII):\n` +
+      `  active_enrollments_total: ${annotated.length}\n` +
+      `  after_limit:              ${limited.length}\n` +
+      `  would_send:               ${planSent.length}\n` +
+      `  would_skip_live_pending:  ${planSkippedPending.length}\n` +
+      `  among would_send:\n` +
+      `    already_has_auth_user:  ${
+        limited.filter((r) => planSent.includes(r.participantId) && r.hasAuthUser).length
+      }\n` +
+      `    has_prior_accepted:     ${
+        limited.filter(
+          (r) => planSent.includes(r.participantId) && r.hasAcceptedInvite
+        ).length
+      }\n`
+  );
+
+  if (planSent.length > 0) {
+    process.stdout.write(
+      `  participant_ids to send: ${planSent.join(", ")}\n`
+    );
+  }
+  if (planSkippedPending.length > 0) {
+    process.stdout.write(
+      `  participant_ids skipped (live pending bulk invite): ${planSkippedPending.join(", ")}\n`
+    );
+  }
+
+  if (!args.commit) {
+    process.stdout.write(
+      `\ndry-run: no DB writes, no emails sent. re-run with --commit to fire.\n`
+    );
+    return;
+  }
+
+  // 6. Production confirmation prompt before any side effects.
+  if (targetingProd) {
+    await confirmProd(cycleName);
+  }
+
+  // 7. Execute.
+  const resend = new Resend(resendKey!);
+  const outcomes: RowOutcome[] = [];
+
+  for (let i = 0; i < limited.length; i++) {
+    const row = limited[i];
+    const idx = i + 1;
+    const total = limited.length;
+
+    if (row.hasLivePending && !args.includePending) {
+      outcomes.push({
+        kind: "skipped",
+        participantId: row.participantId,
+        reason: "live pending bulk invite already exists",
+      });
+      process.stdout.write(`  [${idx}/${total}] participant_id=${row.participantId} → skipped (pending)\n`);
+      continue;
+    }
+
+    // Build notes.
+    const noteParts: string[] = [`Bulk magic link for cycle: ${cycleName}`];
+    if (row.hasAuthUser) noteParts.push("participant already authenticated");
+    if (row.hasAcceptedInvite) noteParts.push("had prior accepted invite for this cycle");
+    const notes = noteParts.join("; ");
+
+    // Insert invitation row.
+    const { data: insertRow, error: insertErr } = await supabase
+      .from("invitations")
+      .insert({
+        email: row.email,
+        permissions: [],
+        role_preset: null,
+        cycle_id: args.cycleId,
+        pod_id: null,
+        invited_by: invitedBy,
+        notes,
+      })
+      .select("id, token")
+      .single();
+    if (insertErr || !insertRow) {
+      outcomes.push({
+        kind: "failed",
+        participantId: row.participantId,
+        phase: "insert",
+        error: insertErr?.message ?? "no row returned",
+      });
+      process.stdout.write(`  [${idx}/${total}] participant_id=${row.participantId} → FAILED (insert): ${insertErr?.message}\n`);
+      continue;
+    }
+
+    const invitationId = insertRow.id as number;
+    const token = insertRow.token as string;
+    const magicLink = `${appUrl.replace(/\/$/, "")}/login?invite=${token}`;
+
+    // Send email via Resend.
+    try {
+      const { error: sendErr } = await resend.emails.send({
+        from: `Upskilling Labs <${process.env.RESEND_FROM_EMAIL ?? "noreply@enroll.theupskillinglabs.org"}>`,
+        to: row.email,
+        subject: EMAIL_SUBJECT,
+        html: invitationEmailHtml({ magicLink, rolePreset: null, cycleName }),
+        text: invitationEmailText({ magicLink, rolePreset: null, cycleName }),
+      });
+      if (sendErr) {
+        outcomes.push({
+          kind: "failed",
+          participantId: row.participantId,
+          phase: "send",
+          error: sendErr.message ?? String(sendErr),
+        });
+        process.stdout.write(`  [${idx}/${total}] participant_id=${row.participantId} invitation_id=${invitationId} → FAILED (send): ${sendErr.message}\n`);
+        // continue to next row; the invitation row stays without email_sent_at
+        continue;
+      }
+    } catch (e) {
+      outcomes.push({
+        kind: "failed",
+        participantId: row.participantId,
+        phase: "send",
+        error: e instanceof Error ? e.message : String(e),
+      });
+      process.stdout.write(`  [${idx}/${total}] participant_id=${row.participantId} invitation_id=${invitationId} → FAILED (send exception)\n`);
+      continue;
+    }
+
+    // Record email_sent_at (non-fatal on failure — email did land).
+    const sentAt = new Date().toISOString();
+    const { error: updateErr } = await supabase
+      .from("invitations")
+      .update({ email_sent_at: sentAt })
+      .eq("id", invitationId);
+    if (updateErr) {
+      process.stdout.write(`  [${idx}/${total}] participant_id=${row.participantId} invitation_id=${invitationId} → sent (email_sent_at update failed: ${updateErr.message})\n`);
+    } else {
+      process.stdout.write(`  [${idx}/${total}] participant_id=${row.participantId} invitation_id=${invitationId} → sent\n`);
+    }
+    outcomes.push({ kind: "sent", participantId: row.participantId, invitationId });
+
+    if (i < limited.length - 1) await sleep(PER_ROW_DELAY_MS);
+  }
+
+  // 8. Final summary.
+  const sentCount = outcomes.filter((o) => o.kind === "sent").length;
+  const skippedCount = outcomes.filter((o) => o.kind === "skipped").length;
+  const failedCount = outcomes.filter((o) => o.kind === "failed").length;
+
+  process.stdout.write(
+    `\nrun summary\n` +
+      `  total processed: ${outcomes.length}\n` +
+      `  sent:            ${sentCount}\n` +
+      `  skipped:         ${skippedCount}\n` +
+      `  failed:          ${failedCount}\n`
+  );
+
+  if (failedCount > 0) {
+    process.stdout.write(`\nfailures:\n`);
+    for (const o of outcomes) {
+      if (o.kind === "failed") {
+        process.stdout.write(`  participant_id=${o.participantId} phase=${o.phase} error=${o.error}\n`);
+      }
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  process.stderr.write(`unhandled error: ${e instanceof Error ? e.stack ?? e.message : String(e)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/ops/send-bulk-invites.ts` (#46 / §1.8) — fans out branded magic-link emails to every active `cycle_enrollments` row for a target cycle, reusing #45's custom-invitation path.
- Adds `scripts/ops/CLAUDE.md` — folder safety contract mirroring `scripts/migration/CLAUDE.md`.
- Fixes a verified doc bug in `lib/auth/CLAUDE.md` §Open ops tasks: production lives on `olos.theupskillinglabs.org`, not the never-DNS'd `app.theupskillinglabs.org` referenced in earlier drafts.

Refs #46 (does **not** close — see *What's still open* below).

## Architectural translation

The issue text was authored before the #63/#64 ratifications and points at the wrong APIs in two places. The shipped script translates as follows:

| Issue text | Shipped |
|---|---|
| Python at `scripts/ops/send_magic_links.py` | TypeScript at `scripts/ops/send-bulk-invites.ts`, run via `npx tsx --env-file=.env.local ...` |
| Supabase Admin API `POST /auth/v1/admin/generate_link` | Custom invitation rows + Resend HTTP, per [#64](https://github.com/TheUpskillingLabs/OLOS/issues/64) |
| "Rate limit: 10/sec to stay under Resend's free-tier cap" | Resend free tier is 100/day, 3000/month — daily quota dominates for our cohort sizes; 200ms per-row delay only |
| "For ~84 participants" | Actual active enrollments on `cycle_id=1` today: **19** (pre-migration cohort) |

Rationale lives in [scripts/ops/CLAUDE.md §Stack reality vs. roadmap wording](../blob/46-issue-w1-008-ops-bulk-magic-link-generator-script/scripts/ops/CLAUDE.md).

## Safety contract

- **Dry-run by default.** `--commit` required to write or send. Flag asymmetry is deliberate.
- **Prod-host guard.** If `NEXT_PUBLIC_SUPABASE_URL` contains the prod project ref, `--prod` is required. On `--commit --prod`, the script prompts for a typed cycle-name confirmation from stdin.
- **PII-free logs.** Indices, IDs, counts, outcomes — never emails or names. Run transcripts can be screenshotted and shared.
- **Idempotent.** Skips rows with a non-expired pending bulk invite (same `(email, cycle_id, role_preset=null)` key as `app/api/invitations/route.ts:54-81`). `--include-pending` overrides.
- **Fail-loud, log-soft.** Per-row failures append to outcomes; run continues; non-zero exit if any failed.
- **Actor record.** `invitations.invited_by` is `NOT NULL` — script defaults to looking up the first `OWNER_EMAILS` entry resolved to a participant; `--invited-by <pid>` overrides.

## Verification on prod

| Test | Outcome |
|---|---|
| Dry-run `--cycle-id 1 --dry-run --prod` | 19 active enrollments; 19 would-send; 0 would-skip; counts match SQL ✓ |
| Sanity send `--commit --prod --only-email <addr>` | invitation_id=18 inserted, email dispatched, `email_sent_at` set ✓ |
| Idempotency re-run | `would_send=0`, `would_skip_live_pending=1`, exit 0 ✓ |
| User clicks magic link → Google sign-in | `invitations.status='accepted'`, `accepted_at` populated; no spurious permission grants (bulk shape has no grants to fulfill) ✓ |

Sample dry-run transcript (PII-free — safe to share with the team):

```
bulk-invite plan
  cycle_id:        1
  cycle_name:      Spring 2026 Build Cycle
  mode:            dry-run
  targeting_prod:  true
  app_url:         https://olos.theupskillinglabs.org
  invited_by:      participant_id=21 (resolved from OWNER_EMAILS)
  limit:           (none)
  only_email:      (none)
  include_pending: false

target summary (no PII):
  active_enrollments_total: 19
  after_limit:              19
  would_send:               19
  would_skip_live_pending:  0
  among would_send:
    already_has_auth_user:  2
    has_prior_accepted:     2
  participant_ids to send: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 26, 31

dry-run: no DB writes, no emails sent. re-run with --commit to fire.
```

`tsc --noEmit` clean. `npm run lint` 0 errors (7 pre-existing warnings on unrelated files).

## What's still open

Option **(c)** in the handoff decision: script ships and is verified, but the **full-cohort fan-out is deferred**. The 19 active enrollments on `cycle_id=1` are early adopters + manual seeds — not the migrated cohort #46's issue text assumes. Issue stays open until §1.5 produces the real population and an operator runs the full batch.

Also noticed but **out of scope** for this PR:
- `invitation-template.ts` says "expires in 7 days" but the DB row's `expires_at` is 30 days out. Pre-existing copy mismatch from #45.
- `lib/auth/CLAUDE.md §Status snapshot` does not yet have a row for #46; I'm leaving that for the close-out PR when the full batch actually runs.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint` 0 errors
- [x] Prod dry-run on `cycle_id=1` — counts match SQL
- [x] Single-recipient prod commit — row inserted, email arrives, link works
- [x] Idempotency re-run — skipped as expected
- [x] Acceptance flow — invitation marked accepted, no spurious permission grants
- [ ] Full-cohort fan-out — held pending §1.5 (Sheets → Postgres migration)