### PR TITLE
fix(permissions): symmetric knob gutter on permission toggles

### DIFF
--- a/app/(dashboard)/admin/participants/[participant_id]/permissions/permissions-editor.tsx
+++ b/app/(dashboard)/admin/participants/[participant_id]/permissions/permissions-editor.tsx
@@ -184,7 +184,7 @@ export default function PermissionsEditor({
                       >
                         <span
                           className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform duration-150 ease-spring ${
-                            enabled ? "translate-x-5" : "translate-x-0.5"
+                            enabled ? "translate-x-[1.375rem]" : "translate-x-0.5"
                           }`}
                         />
                       </button>


### PR DESCRIPTION
Knob slid to translate-x-5 (20px) inside a 44px container with a 20px knob, leaving 4px on the right vs 2px on the left in the off state. Bump to 22px for matching 2px gutters on both sides.