### PR TITLE
chore: ignore Office documents in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,14 @@ supabase/.branches/
 docs/Upskiller Community Manager*.xlsx
 docs/Upskiller Community Manager*.csv
 
+# Office docs may contain credentials/PII — never commit
+*.docx
+*.doc
+*.xlsx
+*.xls
+*.pptx
+*.ppt
+
 # migration script venv + run logs
 scripts/migration/.venv/
 scripts/migration/run_*.log


### PR DESCRIPTION
## Summary
- Add `*.docx`, `*.doc`, `*.xlsx`, `*.xls`, `*.pptx`, `*.ppt` to `.gitignore`
- Office docs commonly contain credentials, PII, or other sensitive content; this prevents them from entering version control going forward
- Follow-up to the `docs/OLOS-environments.docx` history rewrite (force-pushed to `dev` and `feature/short-form-dashboard`)

## Test plan
- [ ] `.gitignore` diff is additive; no existing patterns removed
- [ ] No currently-tracked Office docs exist (verified via `git ls-files | grep -iE '\.(docx?|xlsx?|pptx?)$'` — returns nothing)
- [ ] Try `git add some-test.docx` locally → should be ignored