### PR TITLE
fix(cron): pulse-check reminder actually sends emails (closes #85)

### DIFF
--- a/app/api/cron/pulse-check-reminder/route.ts
+++ b/app/api/cron/pulse-check-reminder/route.ts
@@ -1,12 +1,48 @@
 import { NextResponse, NextRequest } from "next/server";
 import { createServiceClient } from "@/lib/supabase/server";
+import { getResendClient, FROM_EMAIL } from "@/lib/email";
+import {
+  pulseReminderEmailHtml,
+  pulseReminderEmailText,
+  pulseReminderSubject,
+  type PulseReminderVariant,
+} from "@/lib/email/pulse-check-reminder-template";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const SEND_DELAY_MS = 200;
+
+type Outcome = {
+  participant_id: number;
+  variant: PulseReminderVariant;
+  status: "sent" | "error";
+  error?: string;
+};
+
+function variantForDeadline(
+  msUntilDeadline: number
+): PulseReminderVariant | null {
+  const daysUntilDeadline = Math.ceil(msUntilDeadline / ONE_DAY_MS);
+  if (msUntilDeadline <= 0) return "final";
+  if (daysUntilDeadline === 1) return "one_day";
+  if (daysUntilDeadline === 3) return "three_day";
+  return null;
+}
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrl) {
+    console.error(
+      "[pulse-check-reminder] NEXT_PUBLIC_APP_URL is not set — aborting before any send"
+    );
+    return NextResponse.json(
+      { error: "NEXT_PUBLIC_APP_URL is not set" },
+      { status: 500 }
+    );
   }
 
   const supabase = createServiceClient();
@@ -19,19 +55,26 @@ export async function GET(request: NextRequest) {
 
   const cycleIds = (cycles || []).map((c) => c.id);
   if (cycleIds.length === 0) {
-    return NextResponse.json({ sent_count: 0, timestamp: new Date().toISOString() });
+    return NextResponse.json({
+      sent_count: 0,
+      outcomes: [],
+      timestamp: new Date().toISOString(),
+    });
   }
 
   const { data: enrollments } = await supabase
     .from("cycle_enrollments")
-    .select("participant_id, participants:participant_id(id, email, last_pulse_completed_at, created_at)")
+    .select(
+      "participant_id, participants:participant_id(id, email, last_pulse_completed_at, created_at)"
+    )
     .in("cycle_id", cycleIds)
     .eq("status", "active");
 
+  const pulseCheckUrl = `${appUrl}/pulse-check`;
+  const resend = getResendClient();
+
   const seen = new Set<number>();
-  let sent3 = 0;
-  let sent1 = 0;
-  let sentFinal = 0;
+  const outcomes: Outcome[] = [];
 
   for (const enrollment of enrollments || []) {
     const participant = Array.isArray(enrollment.participants)
@@ -44,32 +87,65 @@ export async function GET(request: NextRequest) {
     const baseline =
       participant.last_pulse_completed_at ?? participant.created_at;
     if (!baseline) continue;
+    if (!participant.email) continue;
 
     const deadlineMs = new Date(baseline).getTime() + 7 * ONE_DAY_MS;
-    const msUntilDeadline = deadlineMs - now;
-    const daysUntilDeadline = Math.ceil(msUntilDeadline / ONE_DAY_MS);
+    const variant = variantForDeadline(deadlineMs - now);
+    if (!variant) continue;
 
-    if (daysUntilDeadline === 3) {
-      console.log(
-        `[pulse-check-reminder] 3-day reminder: ${participant.email}`
+    try {
+      const { error: sendError } = await resend.emails.send({
+        from: FROM_EMAIL,
+        to: participant.email,
+        subject: pulseReminderSubject(variant),
+        html: pulseReminderEmailHtml({ variant, pulseCheckUrl }),
+        text: pulseReminderEmailText({ variant, pulseCheckUrl }),
+      });
+
+      if (sendError) {
+        console.error(
+          `[pulse-check-reminder] send failed participant_id=${participant.id} variant=${variant} error=${sendError.message ?? String(sendError)}`
+        );
+        outcomes.push({
+          participant_id: participant.id,
+          variant,
+          status: "error",
+          error: sendError.message ?? String(sendError),
+        });
+      } else {
+        console.log(
+          `[pulse-check-reminder] sent participant_id=${participant.id} variant=${variant}`
+        );
+        outcomes.push({ participant_id: participant.id, variant, status: "sent" });
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error(
+        `[pulse-check-reminder] exception participant_id=${participant.id} variant=${variant} error=${message}`
       );
-      sent3++;
-    } else if (daysUntilDeadline === 1) {
-      console.log(
-        `[pulse-check-reminder] 1-day reminder: ${participant.email}`
-      );
-      sent1++;
-    } else if (msUntilDeadline <= 0) {
-      console.log(
-        `[pulse-check-reminder] FINAL NOTICE (overdue): ${participant.email}`
-      );
-      sentFinal++;
+      outcomes.push({
+        participant_id: participant.id,
+        variant,
+        status: "error",
+        error: message,
+      });
     }
+
+    await new Promise((r) => setTimeout(r, SEND_DELAY_MS));
   }
 
+  const sentCount = outcomes.filter((o) => o.status === "sent").length;
+  const errorCount = outcomes.filter((o) => o.status === "error").length;
+
   return NextResponse.json({
-    sent_count: sent3 + sent1 + sentFinal,
-    breakdown: { three_day: sent3, one_day: sent1, final: sentFinal },
+    sent_count: sentCount,
+    error_count: errorCount,
+    breakdown: {
+      three_day: outcomes.filter((o) => o.variant === "three_day" && o.status === "sent").length,
+      one_day: outcomes.filter((o) => o.variant === "one_day" && o.status === "sent").length,
+      final: outcomes.filter((o) => o.variant === "final" && o.status === "sent").length,
+    },
+    outcomes,
     timestamp: new Date().toISOString(),
   });
 }

--- a/lib/email/pulse-check-reminder-template.ts
+++ b/lib/email/pulse-check-reminder-template.ts
@@ -1,0 +1,140 @@
+export type PulseReminderVariant = "three_day" | "one_day" | "final";
+
+type PulseReminderProps = {
+  variant: PulseReminderVariant;
+  pulseCheckUrl: string;
+};
+
+function variantCopy(variant: PulseReminderVariant): {
+  subject: string;
+  heading: string;
+  lede: string;
+  cta: string;
+} {
+  switch (variant) {
+    case "three_day":
+      return {
+        subject: "Pulse check due in 3 days",
+        heading: "Quick check-in coming up",
+        lede: "Your weekly pulse check is due in <strong style=\"color:#ffffff;\">3 days</strong>. It's a couple of minutes — what you learned, what's working, what got in the way.",
+        cta: "Submit pulse check →",
+      };
+    case "one_day":
+      return {
+        subject: "Pulse check due tomorrow",
+        heading: "One more day",
+        lede: "Your weekly pulse check is due <strong style=\"color:#ffffff;\">tomorrow</strong>. Take two minutes now and it's off your plate.",
+        cta: "Submit pulse check →",
+      };
+    case "final":
+      return {
+        subject: "Pulse check overdue",
+        heading: "Pulse check overdue",
+        lede: "Your weekly pulse check is now overdue. Submitting today keeps you active in your cohort and helps your moderator know how to support you.",
+        cta: "Submit pulse check →",
+      };
+  }
+}
+
+function variantTextLede(variant: PulseReminderVariant): string {
+  switch (variant) {
+    case "three_day":
+      return "Your weekly pulse check is due in 3 days. It's a couple of minutes — what you learned, what's working, what got in the way.";
+    case "one_day":
+      return "Your weekly pulse check is due tomorrow. Take two minutes now and it's off your plate.";
+    case "final":
+      return "Your weekly pulse check is now overdue. Submitting today keeps you active in your cohort and helps your moderator know how to support you.";
+  }
+}
+
+export function pulseReminderEmailHtml({
+  variant,
+  pulseCheckUrl,
+}: PulseReminderProps): string {
+  const { heading, lede, cta } = variantCopy(variant);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${heading}</title>
+</head>
+<body style="margin:0;padding:0;background-color:#0f1117;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#0f1117;padding:48px 16px;">
+    <tr>
+      <td align="center">
+        <table width="560" cellpadding="0" cellspacing="0" style="max-width:560px;width:100%;">
+          <!-- Logo / wordmark -->
+          <tr>
+            <td style="padding-bottom:32px;">
+              <span style="font-size:18px;font-weight:700;color:#ffffff;letter-spacing:-0.02em;">
+                The Upskilling Labs
+              </span>
+            </td>
+          </tr>
+
+          <!-- Card -->
+          <tr>
+            <td style="background-color:#1a1d27;border:1px solid rgba(255,255,255,0.08);border-radius:12px;padding:40px 36px;">
+              <h1 style="margin:0 0 12px;font-size:22px;font-weight:700;color:#ffffff;letter-spacing:-0.02em;">
+                ${heading}
+              </h1>
+              <p style="margin:0 0 28px;font-size:15px;line-height:1.6;color:rgba(200,210,230,0.75);">
+                ${lede}
+              </p>
+
+              <!-- CTA button -->
+              <table cellpadding="0" cellspacing="0" style="margin-bottom:32px;">
+                <tr>
+                  <td style="border-radius:8px;background-color:#0094a0;">
+                    <a href="${pulseCheckUrl}"
+                       style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;letter-spacing:-0.01em;border-radius:8px;">
+                      ${cta}
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Fallback link -->
+              <p style="margin:0 0 16px;font-size:12px;color:rgba(200,210,230,0.45);line-height:1.6;">
+                If the button doesn't work, paste this link into your browser:<br />
+                <a href="${pulseCheckUrl}" style="color:#00b8c8;word-break:break-all;">${pulseCheckUrl}</a>
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top:24px;">
+              <p style="margin:0;font-size:12px;color:rgba(200,210,230,0.35);line-height:1.6;">
+                You're receiving this because you're an active participant in an Upskilling Labs cycle.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+export function pulseReminderEmailText({
+  variant,
+  pulseCheckUrl,
+}: PulseReminderProps): string {
+  const { heading } = variantCopy(variant);
+  return `${heading}
+
+${variantTextLede(variant)}
+
+Submit your pulse check here:
+${pulseCheckUrl}
+
+You're receiving this because you're an active participant in an Upskilling Labs cycle.`;
+}
+
+export function pulseReminderSubject(variant: PulseReminderVariant): string {
+  return variantCopy(variant).subject;
+}


### PR DESCRIPTION
## Summary

Closes #85 (ISSUE-W1-016). The reminder cron at `app/api/cron/pulse-check-reminder/route.ts` previously identified recipients correctly but only `console.log`'d their addresses — no Resend dispatch, no template. Participants would never have received the 3-day / 1-day / overdue reminders.

## Changes

- **New template** at [lib/email/pulse-check-reminder-template.ts](lib/email/pulse-check-reminder-template.ts) with three variants (`three_day`, `one_day`, `final`). HTML + plain-text + subject helpers. Mirrors the structure and branding of `invitation-template.ts`.
- **Cron route** now dispatches via Resend per recipient using the same `getResendClient` / `FROM_EMAIL` helpers as the invitation send.
- **`NEXT_PUBLIC_APP_URL` required up front** — returns 500 if missing. No silent fallback to `request.headers.get("host")` (Vercel cron never runs against localhost, and we don't want to mail participants links to the internal `*.vercel.app` hostname).
- **Per-row try/catch** so one Resend failure doesn't abort the run. Outcomes array returned in the JSON response for observability.
- **PII-safe logging** — logs `participant_id` + `variant` only, no email addresses (per the `scripts/ops/CLAUDE.md` rule).
- **200ms delay** between sends to stay polite under Resend rate limits (matches the bulk-invite script pattern).

## Out of scope (deferred)

- Per-participant dedupe via a `last_reminder_sent_at` column on `participants`. Today the cron can re-send the same variant on consecutive days if a participant sits in the same window — graceful over-send, will revisit if it bites.

## Test plan

- [ ] Manual: trigger `/api/cron/pulse-check-reminder` against dev with `Authorization: Bearer $CRON_SECRET` — verify outcomes array, one email per identified recipient
- [ ] Confirm `NEXT_PUBLIC_APP_URL` is set in both dev and prod Vercel envs (would 500 otherwise)
- [ ] Set `NEXT_PUBLIC_APP_URL=""` locally and confirm the route returns 500 with the expected error
- [ ] Verify Resend dashboard shows the three template variants when triggered

## Depends on

- Nothing — drop-in change. Vercel cron schedule already exists in vercel.json.

## Verifying after deploy

Hit the route once manually post-deploy to confirm Resend sends land. After that, the 9 UTC cron will fire daily without further intervention.