### PR TITLE
fix(pods): scope pulse-check dashboard to moderator's own pod

### DIFF
--- a/app/(dashboard)/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/pods/[pod_id]/page.tsx
@@ -61,11 +61,14 @@ export default async function PodDetailPage({
   const userRoles = user
     ? await resolveUserRoles(serviceClient, user.id)
     : null;
+  // Cross-pod access requires `participants:read` (granted to owner/admin/observer),
+  // NOT `pulse_checks:read` — moderators have the latter globally per 00009 but
+  // must remain pod-scoped via isModeratorForPod for their assigned pod.
   const canViewDashboard =
     userRoles &&
     (isAdmin(userRoles) ||
       isModeratorForPod(userRoles, pod.id) ||
-      can(userRoles, "pulse_checks:read"));
+      can(userRoles, "participants:read"));
 
   // Fetch pulse check data for dashboard (using service client to bypass RLS)
   let pulseCheckData: {


### PR DESCRIPTION
## Summary

Privacy fix: moderators assigned to one pod could see pulse-check submissions from any other pod via the pod-detail dashboard.

### Root cause

The gate at [app/(dashboard)/pods/[pod_id]/page.tsx](app/(dashboard)/pods/%5Bpod_id%5D/page.tsx) was:

```ts
const canViewDashboard =
  userRoles &&
  (isAdmin(userRoles) ||
    isModeratorForPod(userRoles, pod.id) ||
    can(userRoles, "pulse_checks:read"));   // ← granted globally to moderators
```

Per [supabase/migrations/00009_permissions_model.sql line 64](supabase/migrations/00009_permissions_model.sql#L64), every moderator gets `pulse_checks:read` as an unscoped permission. The third branch therefore fired for any moderator regardless of which pod they were viewing.

### Fix

One-line change: swap `"pulse_checks:read"` for `"participants:read"`. The latter is granted only to owner/admin/observer (not moderator), so moderators now fall through to the pod-scoped `isModeratorForPod` check.

### Verified against dev DB

| Permission | Holders | Roles |
|---|---|---|
| `participants:read` | 12 | owner, admin, observer (no moderator) |
| `pulse_checks:read` | 14 | owner, admin, observer, **moderator** |

Two moderators on dev previously had cross-pod view; both will now correctly see only their assigned pod's data.

Observers retain global read access — that's by design per [docs/OLOS-architecture-brief.md:54](docs/OLOS-architecture-brief.md#L54) ("All cycles, read-only").

## Test plan

- [ ] Sign in as a moderator of Pod A on dev → navigate to /pods/[A] → confirm dashboard renders with pulse data
- [ ] As same moderator → navigate to /pods/[B] (a pod they don't moderate) → confirm dashboard is hidden, members list still visible
- [ ] Sign in as an observer → navigate to any pod → confirm dashboard still renders (cross-pod access preserved for observer role)
- [ ] Sign in as a regular participant → navigate to a pod they're in → confirm dashboard is hidden (no change from before)