### PR TITLE
fix: shared-pod RLS + register reactivation + temporarily disable revocation cron (launch hotfix)

### DIFF
--- a/app/api/pods/[pod_id]/register/route.ts
+++ b/app/api/pods/[pod_id]/register/route.ts
@@ -36,20 +36,30 @@ export const POST = withAuth(
       return NextResponse.json({ error: window.message }, { status: 403 });
     }
 
-    // Check already registered for this pod
+    // Existing membership? Two cases:
+    //   - Active (inactive_at IS NULL): true duplicate registration — bail
+    //   - Inactive (inactive_at IS NOT NULL): reactivate by clearing inactive_at,
+    //     preserves the original joined_at + audit trail (architecture brief §5
+    //     "Soft delete everywhere, reactivation must be possible")
     const { data: existing } = await auth.supabase
       .from("pod_memberships")
-      .select("id")
+      .select("id, inactive_at, joined_at")
       .eq("pod_id", podId)
       .eq("participant_id", participantId)
       .maybeSingle();
 
-    if (existing) {
+    if (existing && existing.inactive_at === null) {
       return NextResponse.json(
         { error: "You are already registered for this pod." },
         { status: 400 }
       );
     }
+
+    // Reactivation path: same membership, just clearing the soft-delete marker.
+    // The 2-pod-cap check below uses `.is("inactive_at", null)` so it correctly
+    // counts only currently-active memberships — the inactive row we're about
+    // to reactivate doesn't double-count against the cap before reactivation.
+    const isReactivation = existing !== null;
 
     // Check 2-pod cap for this cycle
     const { data: cyclePods } = await auth.supabase
@@ -66,15 +76,31 @@ export const POST = withAuth(
       );
     }
 
-    // Register
-    const { data: membership, error } = await auth.supabase
-      .from("pod_memberships")
-      .insert({ participant_id: participantId, pod_id: podId })
-      .select("id, joined_at")
-      .single();
+    // Register (new INSERT) or reactivate (UPDATE clearing inactive_at)
+    let membership: { id: number; joined_at: string };
+    if (isReactivation && existing) {
+      const { data: reactivated, error: reactivateError } = await auth.supabase
+        .from("pod_memberships")
+        .update({ inactive_at: null })
+        .eq("id", existing.id)
+        .select("id, joined_at")
+        .single();
 
-    if (error) {
-      return dbError(error);
+      if (reactivateError) {
+        return dbError(reactivateError);
+      }
+      membership = reactivated;
+    } else {
+      const { data: inserted, error: insertError } = await auth.supabase
+        .from("pod_memberships")
+        .insert({ participant_id: participantId, pod_id: podId })
+        .select("id, joined_at")
+        .single();
+
+      if (insertError) {
+        return dbError(insertError);
+      }
+      membership = inserted;
     }
 
     // Check if pod should activate
@@ -156,11 +182,15 @@ export const DELETE = withAuth(
       return NextResponse.json({ error: window.message }, { status: 403 });
     }
 
+    // Soft-delete per architecture brief §5: set inactive_at rather than DROP
+    // the row. Preserves the audit trail and enables re-registration via the
+    // reactivation path in POST above.
     const { error } = await auth.supabase
       .from("pod_memberships")
-      .delete()
+      .update({ inactive_at: new Date().toISOString() })
       .eq("pod_id", podId)
-      .eq("participant_id", participantId);
+      .eq("participant_id", participantId)
+      .is("inactive_at", null);
 
     if (error) {
       return dbError(error);

--- a/supabase/migrations/00020_participants_select_shared_pod.sql
+++ b/supabase/migrations/00020_participants_select_shared_pod.sql
@@ -1,0 +1,42 @@
+-- Allow participants to see other participants who share an active pod with them.
+--
+-- Existing policy (`participants_select_own` from 00002):
+--   USING ((auth_user_id = auth.uid()) OR is_admin_or_owner())
+--
+-- This locked every regular participant to seeing ONLY their own row. The
+-- moderator pod-detail page joins `pod_memberships → participants` to render
+-- names; under that policy the join returned NULL for everyone except the
+-- viewer, producing rows-with-blank-names in the members table.
+--
+-- This migration replaces the policy with a broader (but still scoped) one:
+-- a participant can SELECT another participant's row iff they share an
+-- ACTIVE pod_membership. Cross-pod isolation is preserved — Pod-5 members
+-- still cannot see Pod-8 members unless someone is in both.
+--
+-- Soft-delete is honored: a participant whose membership has
+-- `inactive_at IS NOT NULL` is not considered a current pod-mate.
+--
+-- Admins/owners retain global access via `is_admin_or_owner()`.
+
+DROP POLICY IF EXISTS "participants_select_own" ON participants;
+
+CREATE POLICY "participants_select_visible" ON participants FOR SELECT TO authenticated
+  USING (
+    auth_user_id = auth.uid()
+    OR is_admin_or_owner()
+    OR EXISTS (
+      SELECT 1
+      FROM pod_memberships pm_self
+      JOIN pod_memberships pm_other
+        ON pm_other.pod_id = pm_self.pod_id
+      WHERE pm_self.participant_id = current_participant_id()
+        AND pm_other.participant_id = participants.id
+        AND pm_self.inactive_at IS NULL
+        AND pm_other.inactive_at IS NULL
+    )
+  );
+
+-- DOWN (manual rollback — forward-only repo policy):
+-- DROP POLICY IF EXISTS "participants_select_visible" ON participants;
+-- CREATE POLICY "participants_select_own" ON participants FOR SELECT TO authenticated
+--   USING ((auth_user_id = auth.uid()) OR is_admin_or_owner());

--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,6 @@
     {
       "path": "/api/cron/pulse-check-reminder",
       "schedule": "0 9 * * *"
-    },
-    {
-      "path": "/api/cron/revocation-check",
-      "schedule": "0 10 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Hot-fix bundle for the Energy cycle launch on 2026-05-31. Three coordinated changes addressing four bugs discovered while diagnosing a beta tester (Aaron McKeever) who was locked out.

## Changes

### 1. \`supabase/migrations/00020_participants_select_shared_pod.sql\` (RLS)

Replaces \`participants_select_own\` policy (self-only) with \`participants_select_visible\` which adds a shared-active-pod-membership branch. **Fixes "I can see my own name but other pod members have blank names" in the moderator pod-detail view** — the join was returning NULL for non-self rows because RLS hid them.

Already applied to dev + prod via \`apply_migration\` before this PR; both DBs verified post-apply.

### 2. \`app/api/pods/[pod_id]/register/route.ts\` (reactivation + soft-delete)

Two coordinated fixes on the same route:

- **POST register reactivation path**: existence check now distinguishes active vs inactive existing memberships. Active → "already registered" (true duplicate). Inactive → UPDATE clearing \`inactive_at\` (reactivation, preserving \`joined_at\` audit trail).
- **DELETE → soft-delete**: previously called \`.delete()\` on pod_memberships, contradicting the architecture brief §5 "soft delete everywhere" invariant. Now UPDATE sets \`inactive_at = now()\`. Combined with the reactivation path, a participant can leave + rejoin a pod without losing their original join date.

### 3. \`vercel.json\` (revocation cron disabled)

Removes \`/api/cron/revocation-check\` from the cron schedule. The route code remains in place; the cron simply won't fire on a schedule.

**Why**: the route had been deactivating ~75% of the Energy cohort (\`status='inactive'\` on cycle_enrollments) via two too-aggressive rules — a 7-day pulse-check timeout with no new-user grace period, and a "not_in_pod" check that races with the enrollment-activation flow. Full diagnosis + redesign plan tracked in **#107**.

## Manual prod cleanup applied alongside this PR

These are SQL operations done via MCP, not part of the PR diff, but documented here:

- **Pod 8 (Recycling)** manually transitioned from \`forming\` → \`active\` (8 active members, pod_min=5; transition should have fired but didn't because members joined through paths that don't run the activation block)
- **10 cycle_enrollments** bulk-activated for participants with at least one active pod_membership: \`UPDATE cycle_enrollments SET status='active' WHERE cycle_id=3 AND status='inactive' AND participant_id IN (SELECT participant_id FROM pod_memberships pm JOIN pods p ON p.id=pm.pod_id WHERE p.cycle_id=3 AND pm.inactive_at IS NULL)\`
- **Aaron McKeever (id=61)** specifically reactivated: both pod_memberships (Clean Energy + Sustainable Travel) had their \`inactive_at\` cleared, cycle_enrollment status flipped to active
- Energy cycle_enrollments now: 16 active, 8 inactive (the 8 inactive have no pod_memberships, correctly inactive per architecture brief)

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] 00020 policy applied + verified on dev + prod (USING clause includes shared-pod branch)
- [x] Aaron unblocked on prod (pod_memberships active, enrollment active)
- [ ] Smoke-test on dev preview after merge: as a regular participant, view a pod-detail page and confirm other members' names render
- [ ] Smoke-test: leave a pod, then re-register — confirm the original \`joined_at\` is preserved and registration succeeds
- [ ] After main deploy: confirm Vercel cron dashboard no longer lists revocation-check

## Related

- Closes the Aaron McKeever beta tester report (no formal issue filed; covered in session conversation)
- New ticket #107 for the proper revocation-check cron redesign
- Does NOT close #102 (profile-completion redirect) or #103 (fulfillInvitation guard) — those are still tracked separately