### PR TITLE
feat(#110 Phase A): centralized enrollment reconciler + RLS hardening + callback fixes

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -2,19 +2,27 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { isOwnerEmail, ensureOwnerRole } from "@/lib/auth/owner-emails";
+import { escapeEmailForIlike } from "@/lib/auth/email";
+import { reconcileEnrollmentActivation } from "@/lib/enrollment/reconciler";
+
+const PLACEHOLDER_NAME = "unknown";
+
+function hasPlaceholderName(first: string | null, last: string | null): boolean {
+  return (
+    (first ?? "").trim().toLowerCase() === PLACEHOLDER_NAME ||
+    (last ?? "").trim().toLowerCase() === PLACEHOLDER_NAME
+  );
+}
 
 async function fulfillInvitation(
   serviceClient: ReturnType<typeof createServiceClient>,
   participantId: number,
-  email: string
+  email: string,
+  hasPlaceholder: boolean
 ) {
-  // Read invite token from cookie
   const cookieStore = await cookies();
   const inviteToken = cookieStore.get("invite_token")?.value;
   if (!inviteToken) return;
-
-  // Clear the cookie
-  cookieStore.set("invite_token", "", { maxAge: 0, path: "/" });
 
   // Look up the invitation
   const { data: invitation } = await serviceClient
@@ -25,10 +33,28 @@ async function fulfillInvitation(
     .gt("expires_at", new Date().toISOString())
     .maybeSingle();
 
-  if (!invitation) return;
+  if (!invitation) {
+    cookieStore.set("invite_token", "", { maxAge: 0, path: "/" });
+    return;
+  }
 
-  // Verify email matches
-  if (invitation.email.toLowerCase() !== email.toLowerCase()) return;
+  // Verify email matches (case-insensitive)
+  if (invitation.email.toLowerCase() !== email.toLowerCase()) {
+    cookieStore.set("invite_token", "", { maxAge: 0, path: "/" });
+    return;
+  }
+
+  // Placeholder-name guard (architecture review broken edge #16; issue #103
+  // closed-as-completed via #110). A participant with first_name='Unknown'
+  // or last_name='Unknown' should not be enrolled in the cycle or assigned
+  // a moderator role until they complete their profile. Leave the cookie
+  // in place so the invitation can be re-fulfilled on a later request once
+  // the layout-level placeholder guard (Phase B) redirects them through
+  // /profile/edit. Until Phase B ships, the participant retains the
+  // invitation context for the cookie's 1-hour TTL.
+  if (hasPlaceholder) {
+    return;
+  }
 
   // Grant permissions
   const permissions = (invitation.permissions as string[]) ?? [];
@@ -52,19 +78,34 @@ async function fulfillInvitation(
       );
   }
 
-  // Enroll in cycle if specified
+  // Enroll in cycle if specified.
+  //
+  // Architecture review broken edge #2 fix: the previous implementation
+  // passed `ignoreDuplicates: true` here, which made the upsert a no-op
+  // when a pre-existing inactive enrollment row existed (created by
+  // /api/cycles/[id]/interest or /api/registrations). The invitee then
+  // landed on /dashboard still 'inactive' even though they had just
+  // accepted an invitation that explicitly promised 'active'.
+  //
+  // We now upsert without ignoreDuplicates so the conflict path promotes
+  // the row, then call the reconciler so the final status reflects actual
+  // pod-membership reality (the reconciler will demote back to 'inactive'
+  // if the invitee has no active pod-memberships — that's correct
+  // behavior, since invitation acceptance alone does not constitute pod
+  // membership).
   if (invitation.cycle_id) {
     await serviceClient
       .from("cycle_enrollments")
       .upsert(
         { participant_id: participantId, cycle_id: invitation.cycle_id, status: "active" },
-        { onConflict: "participant_id,cycle_id", ignoreDuplicates: true }
+        { onConflict: "participant_id,cycle_id" }
       );
+
+    await reconcileEnrollmentActivation(participantId, invitation.cycle_id);
   }
 
   // Create moderator assignment if pod specified
   if (invitation.pod_id) {
-    // Need cycle_id for moderator_assignments — get it from the pod
     const { data: pod } = await serviceClient
       .from("pods")
       .select("cycle_id")
@@ -85,11 +126,13 @@ async function fulfillInvitation(
     }
   }
 
-  // Mark invitation as accepted
+  // Mark invitation as accepted and clear the cookie
   await serviceClient
     .from("invitations")
     .update({ status: "accepted", accepted_at: new Date().toISOString() })
     .eq("id", invitation.id);
+
+  cookieStore.set("invite_token", "", { maxAge: 0, path: "/" });
 }
 
 export async function GET(request: Request) {
@@ -108,11 +151,18 @@ export async function GET(request: Request) {
         const serviceClient = createServiceClient();
         const email = user.email;
 
-        // Check if a participant record exists for this email
+        if (!email) {
+          return NextResponse.redirect(`${origin}/login?error=auth_failed`);
+        }
+
+        // Case-insensitive lookup against the unique-on-lower(email) index
+        // from migration 00016. escapeEmailForIlike neutralizes `_` and `%`
+        // pattern characters that ILIKE would otherwise interpret as
+        // wildcards (architecture review broken edge #19).
         const { data: participant } = await serviceClient
           .from("participants")
-          .select("id, auth_user_id")
-          .eq("email", email)
+          .select("id, auth_user_id, first_name, last_name")
+          .ilike("email", escapeEmailForIlike(email))
           .maybeSingle();
 
         if (participant) {
@@ -123,14 +173,21 @@ export async function GET(request: Request) {
               .update({ auth_user_id: user.id })
               .eq("id", participant.id);
           }
-          if (email && isOwnerEmail(email)) {
+          if (isOwnerEmail(email)) {
             await ensureOwnerRole(serviceClient, participant.id);
           }
 
-          // Fulfill any pending invitation
-          if (email) {
-            await fulfillInvitation(serviceClient, participant.id, email);
-          }
+          // Fulfill any pending invitation (placeholder-name aware)
+          const hasPlaceholder = hasPlaceholderName(
+            participant.first_name,
+            participant.last_name
+          );
+          await fulfillInvitation(
+            serviceClient,
+            participant.id,
+            email,
+            hasPlaceholder
+          );
 
           return NextResponse.redirect(`${origin}/`);
         } else {

--- a/app/api/pods/[pod_id]/register/route.ts
+++ b/app/api/pods/[pod_id]/register/route.ts
@@ -3,10 +3,15 @@ import { withAuth } from "@/lib/auth/middleware";
 import { checkWindow } from "@/lib/auth/windows";
 import { dbError } from "@/lib/api/errors";
 import { parseIntParam } from "@/lib/api/params";
+import { createServiceClient } from "@/lib/supabase/server";
+import {
+  reconcileEnrollmentActivation,
+  reconcilePodMembers,
+} from "@/lib/enrollment/reconciler";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 
 export const POST = withAuth(
-  async (request: NextRequest, auth: AuthenticatedRequest, params: Record<string, string>) => {
+  async (_request: NextRequest, auth: AuthenticatedRequest, params: Record<string, string>) => {
     const podId = parseIntParam(params.pod_id, "pod_id");
     if (podId instanceof NextResponse) return podId;
     const participantId = auth.user.participantId;
@@ -55,13 +60,9 @@ export const POST = withAuth(
       );
     }
 
-    // Reactivation path: same membership, just clearing the soft-delete marker.
-    // The 2-pod-cap check below uses `.is("inactive_at", null)` so it correctly
-    // counts only currently-active memberships — the inactive row we're about
-    // to reactivate doesn't double-count against the cap before reactivation.
     const isReactivation = existing !== null;
 
-    // Check 2-pod cap for this cycle
+    // Check 2-pod cap for this cycle (active memberships only)
     const { data: cyclePods } = await auth.supabase
       .from("pod_memberships")
       .select("id, pods!inner(cycle_id)")
@@ -76,7 +77,6 @@ export const POST = withAuth(
       );
     }
 
-    // Register (new INSERT) or reactivate (UPDATE clearing inactive_at)
     let membership: { id: number; joined_at: string };
     if (isReactivation && existing) {
       const { data: reactivated, error: reactivateError } = await auth.supabase
@@ -103,50 +103,41 @@ export const POST = withAuth(
       membership = inserted;
     }
 
-    // Check if pod should activate
-    const { data: config } = await auth.supabase
+    // Pod activation + enrollment reconciliation
+    //
+    // The pods.status flip (forming -> active) and the cycle_enrollments
+    // status updates are both gated by is_admin_or_owner() RLS, so the
+    // cookie-bound auth.supabase client would silently no-op them for
+    // regular participants. We use the service client + the centralized
+    // reconciler (lib/enrollment/reconciler.ts) instead — the single
+    // source of truth for enrollment transitions across the codebase.
+    const serviceClient = createServiceClient();
+
+    const { data: config } = await serviceClient
       .from("cycle_config")
       .select("pod_min")
       .eq("cycle_id", pod.cycle_id)
       .single();
 
-    const { count } = await auth.supabase
+    const { count } = await serviceClient
       .from("pod_memberships")
       .select("id", { count: "exact", head: true })
       .eq("pod_id", podId)
       .is("inactive_at", null);
 
     if (config && count && count >= config.pod_min && pod.status === "forming") {
-      await auth.supabase
+      // Pod just tipped past pod_min — flip to active, then reconcile every
+      // member's enrollment so the resource-provisioning invariant holds
+      // ("resources provision at activation" — architecture brief §4).
+      await serviceClient
         .from("pods")
         .update({ status: "active", updated_at: new Date().toISOString() })
         .eq("id", podId);
 
-      // Activate enrollment for all pod members
-      const { data: members } = await auth.supabase
-        .from("pod_memberships")
-        .select("participant_id")
-        .eq("pod_id", podId)
-        .is("inactive_at", null);
-
-      if (members && members.length > 0) {
-        await auth.supabase
-          .from("cycle_enrollments")
-          .update({ status: "active" })
-          .in("participant_id", members.map((m) => m.participant_id))
-          .eq("cycle_id", pod.cycle_id)
-          .eq("status", "inactive");
-      }
-    }
-
-    // If pod is already active, activate just this joining participant
-    if (pod.status === "active") {
-      await auth.supabase
-        .from("cycle_enrollments")
-        .update({ status: "active" })
-        .eq("participant_id", participantId)
-        .eq("cycle_id", pod.cycle_id)
-        .eq("status", "inactive");
+      await reconcilePodMembers(podId);
+    } else if (pod.status === "active") {
+      // Pod was already active; reconcile only the joining participant.
+      await reconcileEnrollmentActivation(participantId, pod.cycle_id);
     }
 
     return NextResponse.json(
@@ -166,7 +157,7 @@ export const DELETE = withAuth(
       return NextResponse.json({ error: "Not a registered participant" }, { status: 403 });
     }
 
-    // Get pod for window check
+    // Get pod for window check + cycle reconciliation
     const { data: pod } = await auth.supabase
       .from("pods")
       .select("cycle_id")
@@ -195,6 +186,10 @@ export const DELETE = withAuth(
     if (error) {
       return dbError(error);
     }
+
+    // Reconcile the leaver's enrollment — if this was their last active pod
+    // in the cycle, their cycle_enrollments.status drops to 'inactive'.
+    await reconcileEnrollmentActivation(participantId, pod.cycle_id);
 
     return NextResponse.json({ success: true });
   }

--- a/app/api/registrations/route.ts
+++ b/app/api/registrations/route.ts
@@ -16,6 +16,17 @@ export async function POST(request: NextRequest) {
   const body = await parseBody(request, registrationSchema);
   if (isErrorResponse(body)) return body;
 
+  // Defense in depth: when the long-form sends an auth_user_id, enforce
+  // that it matches the actual Supabase session. The field is nullable in
+  // the schema (it can also be sent as NULL for legacy / admin-driven
+  // imports) — only enforce the match when present.
+  if (body.auth_user_id && body.auth_user_id !== user.id) {
+    return NextResponse.json(
+      { error: "auth_user_id does not match the authenticated session" },
+      { status: 403 }
+    );
+  }
+
   const supabase = createServiceClient();
 
   const {

--- a/app/api/registrations/short/route.ts
+++ b/app/api/registrations/short/route.ts
@@ -29,6 +29,17 @@ export async function POST(request: NextRequest) {
   const supabase = createServiceClient();
   const { auth_user_id, google_id, email, first_name, last_name, contact_consent } = body;
 
+  // Defense in depth: enforce that the body-supplied auth_user_id matches
+  // the actual Supabase session. Without this, a body field could be
+  // tampered with to link a new participants row to someone else's
+  // auth identity (architecture review broken edge — registration-onboarding).
+  if (auth_user_id !== user.id) {
+    return NextResponse.json(
+      { error: "auth_user_id does not match the authenticated session" },
+      { status: 403 }
+    );
+  }
+
   // Case-insensitive dedup check
   const { data: existing } = await supabase
     .from("participants")

--- a/lib/auth/email.ts
+++ b/lib/auth/email.ts
@@ -1,0 +1,16 @@
+/**
+ * Case-insensitive participant.email lookups must use ILIKE because the
+ * underlying column stores mixed-case values. Bare ILIKE interprets `_` and
+ * `%` from the input as wildcards, and `_` is a valid character in email
+ * local-parts — a naïve lookup for `user_name@x.com` could also match
+ * `userXname@x.com`. Escape both characters first to neutralize the
+ * pattern semantics.
+ *
+ * Auth callback (app/api/auth/callback/route.ts) and short-form registration
+ * (app/api/registrations/short/route.ts) both look up participants by email
+ * and use this helper. The case-insensitive unique index from migration
+ * 00016 on lower(email) still benefits the underlying query.
+ */
+export function escapeEmailForIlike(email: string): string {
+  return email.replace(/[\\%_]/g, "\\$&");
+}

--- a/lib/enrollment/reconciler.ts
+++ b/lib/enrollment/reconciler.ts
@@ -1,0 +1,158 @@
+import { createServiceClient } from "@/lib/supabase/server";
+
+export type EnrollmentStatus = "active" | "inactive";
+
+export interface ReconcileOptions {
+  reason?: string;
+  logRevocation?: boolean;
+}
+
+export interface ReconcileResult {
+  participantId: number;
+  cycleId: number;
+  before: EnrollmentStatus | null;
+  after: EnrollmentStatus | null;
+  mutated: boolean;
+  audited: boolean;
+}
+
+interface PodMembershipRow {
+  id: number;
+  pods: { id: number; status: string; cycle_id: number } | null;
+}
+
+/**
+ * Brings cycle_enrollments.status in line with current pod membership reality
+ * for one (participant, cycle) pair. Single source of truth for the
+ * inactive <-> active enrollment transition across the codebase.
+ *
+ * Target status:
+ *   - 'active' if the participant has at least one active pod_memberships
+ *     row (inactive_at IS NULL) whose pod is itself status='active'.
+ *   - 'inactive' otherwise.
+ *
+ * Idempotent. If no cycle_enrollments row exists, returns without mutating
+ * (creation belongs in registration / cycle-interest routes). If status
+ * already matches target, returns without mutating.
+ *
+ * On demotion (active -> inactive), optionally writes an access_revocations
+ * audit row when opts.logRevocation === true. The cron will opt in; inline
+ * after-leave callers will not, since their demotions are mechanical.
+ *
+ * Uses a service client internally because cycle_enrollments is gated by
+ * is_admin_or_owner() RLS — a cookie-bound user client would silently
+ * no-op the update, which was the pre-#110 bug.
+ */
+export async function reconcileEnrollmentActivation(
+  participantId: number,
+  cycleId: number,
+  opts: ReconcileOptions = {}
+): Promise<ReconcileResult> {
+  const client = createServiceClient();
+
+  const { data: enrollment } = await client
+    .from("cycle_enrollments")
+    .select("id, status")
+    .eq("participant_id", participantId)
+    .eq("cycle_id", cycleId)
+    .maybeSingle();
+
+  const before: EnrollmentStatus | null =
+    enrollment?.status === "active" || enrollment?.status === "inactive"
+      ? enrollment.status
+      : null;
+
+  if (!enrollment) {
+    return {
+      participantId,
+      cycleId,
+      before,
+      after: null,
+      mutated: false,
+      audited: false,
+    };
+  }
+
+  const { data: memberships } = await client
+    .from("pod_memberships")
+    .select("id, pods!inner(id, status, cycle_id)")
+    .eq("participant_id", participantId)
+    .eq("pods.cycle_id", cycleId)
+    .is("inactive_at", null);
+
+  const rows = (memberships ?? []) as unknown as PodMembershipRow[];
+  const hasActivePod = rows.some((m) => m.pods?.status === "active");
+  const target: EnrollmentStatus = hasActivePod ? "active" : "inactive";
+
+  if (before === target) {
+    return {
+      participantId,
+      cycleId,
+      before,
+      after: before,
+      mutated: false,
+      audited: false,
+    };
+  }
+
+  const nowIso = new Date().toISOString();
+  await client
+    .from("cycle_enrollments")
+    .update({
+      status: target,
+      inactive_date: target === "inactive" ? nowIso : null,
+    })
+    .eq("id", enrollment.id);
+
+  let audited = false;
+  if (target === "inactive" && opts.logRevocation) {
+    await client.from("access_revocations").insert({
+      participant_id: participantId,
+      cycle_id: cycleId,
+      reason: opts.reason ?? "reconciler: no active pod memberships",
+      revocation_scope: "full",
+    });
+    audited = true;
+  }
+
+  return {
+    participantId,
+    cycleId,
+    before,
+    after: target,
+    mutated: true,
+    audited,
+  };
+}
+
+/**
+ * Convenience: reconcile every active member of a pod for that pod's cycle.
+ * Used by callers that just promoted a pod from forming -> active and need
+ * every member's enrollment status to follow.
+ */
+export async function reconcilePodMembers(
+  podId: number
+): Promise<ReconcileResult[]> {
+  const client = createServiceClient();
+
+  const { data: pod } = await client
+    .from("pods")
+    .select("id, cycle_id")
+    .eq("id", podId)
+    .maybeSingle();
+
+  if (!pod) return [];
+
+  const { data: memberships } = await client
+    .from("pod_memberships")
+    .select("participant_id")
+    .eq("pod_id", podId)
+    .is("inactive_at", null);
+
+  const participantIds = (memberships ?? []).map((m) => m.participant_id);
+  if (participantIds.length === 0) return [];
+
+  return Promise.all(
+    participantIds.map((pid) => reconcileEnrollmentActivation(pid, pod.cycle_id))
+  );
+}

--- a/supabase/migrations/00021_participants_update_with_check.sql
+++ b/supabase/migrations/00021_participants_update_with_check.sql
@@ -1,0 +1,26 @@
+-- ROADMAP §3.7 / ISSUE #110 / Phase A
+--
+-- Add WITH CHECK clause to participants_update_own, mirroring the defense-
+-- in-depth pattern migration 00019 applied to solution_proposals_update.
+--
+-- Without WITH CHECK, USING gates only the row being targeted at access
+-- time; Postgres does not re-evaluate the policy against the post-update
+-- row. A participant could theoretically UPDATE their own row to set
+-- auth_user_id to NULL or to another user's UUID, breaking the identity
+-- linkage that the rest of the system depends on. WITH CHECK on the same
+-- predicate forces the resulting row to also satisfy the policy, closing
+-- the loophole.
+--
+-- Reference: Postgres docs on CREATE POLICY USING vs WITH CHECK
+-- https://www.postgresql.org/docs/current/sql-createpolicy.html
+
+DROP POLICY IF EXISTS "participants_update_own" ON participants;
+
+CREATE POLICY "participants_update_own" ON participants FOR UPDATE TO authenticated
+  USING (auth_user_id = auth.uid() OR is_admin_or_owner())
+  WITH CHECK (auth_user_id = auth.uid() OR is_admin_or_owner());
+
+-- DOWN (manual rollback — forward-only repo policy):
+-- DROP POLICY IF EXISTS "participants_update_own" ON participants;
+-- CREATE POLICY "participants_update_own" ON participants FOR UPDATE TO authenticated
+--   USING (auth_user_id = auth.uid() OR is_admin_or_owner());

--- a/supabase/migrations/00022_pod_memberships_select_hide_soft_deleted.sql
+++ b/supabase/migrations/00022_pod_memberships_select_hide_soft_deleted.sql
@@ -1,0 +1,37 @@
+-- ROADMAP §3.7 / ISSUE #110 / Phase A
+--
+-- Tighten pod_memberships_select to honor the soft-delete invariant.
+--
+-- The original policy from 00002:105 used USING (true), exposing every
+-- pod_memberships row including those with inactive_at IS NOT NULL to
+-- every authenticated user. The architecture review at
+-- docs/architecture-review-onboarding-state-machine.md (broken edge #18)
+-- identified this as a soft-delete leak: a participant who leaves a pod
+-- is still visible to other participants in that pod's membership join,
+-- and former members can see currently-active members of pods they no
+-- longer belong to.
+--
+-- New predicate: a row is visible when ANY of
+--   - the membership is currently active (inactive_at IS NULL), OR
+--   - the viewer is the participant whose membership it is (own history
+--     stays readable for self-service purposes), OR
+--   - the viewer is admin/owner (full audit access).
+--
+-- Active-row visibility is preserved unchanged, so 00020's
+-- participants_select_visible policy (which joins pod_memberships in
+-- both directions) keeps working for cross-pod-mate name lookups on
+-- the moderator pod-detail page.
+
+DROP POLICY IF EXISTS "pod_memberships_select" ON pod_memberships;
+
+CREATE POLICY "pod_memberships_select" ON pod_memberships FOR SELECT TO authenticated
+  USING (
+    inactive_at IS NULL
+    OR participant_id = current_participant_id()
+    OR is_admin_or_owner()
+  );
+
+-- DOWN (manual rollback — forward-only repo policy):
+-- DROP POLICY IF EXISTS "pod_memberships_select" ON pod_memberships;
+-- CREATE POLICY "pod_memberships_select" ON pod_memberships FOR SELECT TO authenticated
+--   USING (true);


### PR DESCRIPTION
## Summary

Phase A of [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110) — the consolidated onboarding state-machine work. Centralizes the `cycle_enrollments.status inactive <-> active` transition into one idempotent helper, fixes the silently-broken invitation-acceptance promotion, and patches two RLS gaps the [architecture review](../blob/dev/docs/architecture-review-onboarding-state-machine.md) surfaced.

## What it does

| Change | File | Closes |
|---|---|---|
| `reconcileEnrollmentActivation` + `reconcilePodMembers` helpers | `lib/enrollment/reconciler.ts` (new) | Broken edges #1, #6, #7 |
| Safe-email helper (escapes `_` and `%` for ILIKE) | `lib/auth/email.ts` (new) | Broken edge #19 |
| `WITH CHECK` on `participants_update_own` | `supabase/migrations/00021_*.sql` | Broken edge #17 |
| Hide soft-deleted `pod_memberships` from non-owners | `supabase/migrations/00022_*.sql` | Broken edge #18 |
| Refactor register route — service-client for privileged ops, reconciler calls on POST + DELETE | `app/api/pods/[pod_id]/register/route.ts` | Edges #1, #6, #7 |
| Drop `ignoreDuplicates: true`, add placeholder-name guard, case-insensitive email lookup, post-fulfill reconciler call | `app/api/auth/callback/route.ts` | Edges #2, #16, #19 |
| Strict `auth_user_id === user.id` check | `app/api/registrations/short/route.ts`, `app/api/registrations/route.ts` | Onboarding-flow gap |

## Why a centralized reconciler

Before this PR, `cycle_enrollments.status` was written from one code path (the pod-register route's inline activation) but read from many. Worse, that one path used a cookie-bound user client to UPDATE `cycle_enrollments` and `pods` — both gated by `is_admin_or_owner()` RLS — so the activation **silently no-op'd** for regular participants. Compound with the `fulfillInvitation` `ignoreDuplicates=true` bug, and three prod participants got stranded as `inactive` despite having active pod memberships.

The reconciler:

- Uses a service client internally (RLS bypass is intentional; reconciler is a privileged system function)
- Reads pod-membership reality and computes the target enrollment status
- Idempotent — calling twice produces the same result
- Optionally writes an `access_revocations` audit row on demotion (cron opts in; inline callers don't)
- Single source of truth for `inactive <-> active` across the codebase

Every lifecycle code path now calls it instead of writing `cycle_enrollments.status` directly.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] Migrations 00021 + 00022 applied to dev DB; policies verified via `pg_policy` lookup
- [x] All architecture-review broken edges in scope addressed; out-of-scope items (Phase B/C) explicitly deferred in the commit message
- [ ] Manual smoke test on dev preview after merge: register for a pod that activates, leave a pod, accept an invitation with a pre-existing inactive enrollment row
- [ ] After PR #109 (already merged), this is the next change set bound for the eventual dev → main promotion

## Out of scope (Phase B and C)

- Layout-level placeholder-name redirect + `/profile/edit` + admin name-edit UI — Phase B
- Admin pod-membership controls + stuck-inactive filter — Phase B
- Revocation cron v2 (cycle-scoped, grace period, warning state, idempotency) + re-registration in `vercel.json` — Phase C

## Related

- Closes (partially) [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110) — Phase A of the three-phase rollout
- Subsumes #103 (fulfillInvitation guard — implemented here)
- Architecture review at `docs/architecture-review-onboarding-state-machine.md` (lands when the #102 branch's docs commit promotes to dev separately)