### PR TITLE
docs: onboarding architecture review + launch plan + roadmap §3.7 (foundational for #110)

### DIFF
--- a/docs/OLOS-roadmap.md
+++ b/docs/OLOS-roadmap.md
@@ -231,6 +231,35 @@ graph TD
 *Per the Wave 3 board section ("see projects membership"). Moderator can see which of their pod's members ended up in which project.*
 - Issue: TBD
 
+## §3.7 — Cross-cutting: onboarding state-machine consolidation
+*Authored 2026-05-31 after a 7-agent architectural review of the May launch hot-fix cascade. Consolidates the participant onboarding lifecycle into a single idempotent state machine. Cuts across Wave 1 follow-ups, Wave 2 account-management work, and Wave 3 cron infrastructure — placed here because the work lands during Wave 3 but its scope is cross-wave.*
+
+**Background:** the May 2026 Energy-cohort cascade revealed that `cycle_enrollments.status inactive → active` is written from only one code path (`app/api/pods/[pod_id]/register/route.ts`), while pod and pod_membership writes happen from many — admin SQL, migration script, seed, invitation callback. Combined with a buggy revocation cron, this revoked ~75% of the cohort. The full diagnosis spans 23 broken edges across 6 subsystems — see [docs/architecture-review-onboarding-state-machine.md](./architecture-review-onboarding-state-machine.md).
+
+**Solution:** one `reconcileEnrollmentActivation` helper called by every lifecycle code path, plus admin/moderator UI for the manual fixes currently requiring SQL, plus a redesigned revocation cron with cycle-scoped checks and a warning state before revocation.
+
+**Three phases:**
+- **Phase A** (~half-day) — reconciler + auth-callback `ignoreDuplicates` fix + placeholder-name guard in `fulfillInvitation` + RLS `WITH CHECK` migration + `pod_memberships_select` tightening.
+- **Phase B** (~one day) — admin/moderator self-service UI: PATCH /api/participants/[id], `/profile/edit` dual mode (Mode A self-edit, Mode B forced completion), admin pod-membership add/remove, admin pod-status override, stuck-inactive filter.
+- **Phase C** (~1–2 days) — revocation cron v2: cycle-scoped queries, baseline = `MAX(activated_at, pod_registration_open_at)`, two-stage handler (warning + 3-day grace, then revoke), idempotency via unique partial index on `access_revocations`. Re-register cron in `vercel.json` after ≥48h staging soak.
+
+**Subsumed tickets** (closed as completed via the link-back convention, since the work IS being done — in #110):
+- #102 (profile-completion redirect Mode B) → Phase B
+- #98 (Mode A profile edit) → Phase B
+- #103 (fulfillInvitation guard) → Phase A
+- #107 (revocation cron redesign) → Phase C
+- #94 (Unknown-names root cause) → root cause documented in §1.6 of the architecture review; remediation via Phase B admin UI
+
+**Downgraded follow-ups** (left open at size/s after #110 ships):
+- #51 (members API with pulse status) → depends on Phase B UI scaffolding
+- #87 (per-member pulse indicator) → depends on #51 + Phase B
+
+**Independent (not consolidated):**
+- #86 (already-submitted-this-week pulse-check page state) — UX-only, no state-machine interaction
+- #97 (multi-pulse question) — product/content decision, not architecture
+
+- Issue: [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110)
+
 ---
 
 # §4 — Backlog (post-Showcase)
@@ -278,8 +307,8 @@ These block specific issues. Resolve before the affected work starts.
 | §1.10 | [ISSUE-W1-010](https://github.com/TheUpskillingLabs/OLOS/issues/48) | superseded | — | n/a | No GET API endpoint needed — moderator review reads Supabase directly via [pulse-check-dashboard.tsx](../app/(dashboard)/pods/%5Bpod_id%5D/pulse-check-dashboard.tsx) with RLS enforcing role-based scoping. Re-open if a non-UI consumer of pulse history emerges. |
 | §1.11 | [ISSUE-W1-011](https://github.com/TheUpskillingLabs/OLOS/issues/49) | shipped, AC gaps | — | shipped pre-#49 | Route at [app/(dashboard)/pulse-check/page.tsx](../app/(dashboard)/pulse-check/page.tsx); submits to `/api/pulse-checks` ([form line 197](../app/(dashboard)/pulse-check/pulse-check-form.tsx#L197)). **Gaps vs AC**: (1) "already submitted this week" UX missing — form renders even after submission and relies on server 409; (2) uses native React state, not `react-hook-form` + `zod`; (3) options read server-side from `option_lists`, not via `GET /api/options`. Locking semantic differs: 7-day-from-last-pulse, not week-anchored. Keyboard nav + inline error UX needs manual verification. |
 | §1.12 | [ISSUE-W1-012](https://github.com/TheUpskillingLabs/OLOS/issues/50) | shipped | — | shipped pre-#50 | [copy.ts](../app/(dashboard)/pulse-check/copy.ts) — 13 keyed sections (page, status, context, reflection, forces, engagement, nominations, closing, submit, confirmation, history, locked, nav). No `TODO` / `Lorem ipsum` placeholders. Stakeholder-review AC is a process item (Brendan / Ann Marie), not a code item. Copy work — non-engineering. |
-| §1.13 | [ISSUE-W1-013](https://github.com/TheUpskillingLabs/OLOS/issues/51) | shipped, AC gap | — | shipped pre-#51 | [app/api/pods/[pod_id]/members/route.ts](../app/api/pods/%5Bpod_id%5D/members/route.ts) exists with `?status=active` filter + RLS-based 403. **Gap**: response does NOT include `last_pulse_check.{scheduled_date, completed_at}` per AC. UI side-steps the gap by querying `pulse_checks` directly server-side from the pod detail page. Either extend the route OR close acknowledging the bypass. |
-| §1.14 | [ISSUE-W1-014](https://github.com/TheUpskillingLabs/OLOS/issues/52) | shipped, AC gaps | — | shipped pre-#52 | Members table + `PulseCheckDashboard` render at [app/(dashboard)/pods/[pod_id]/page.tsx](../app/(dashboard)/pods/%5Bpod_id%5D/page.tsx), gated on `isAdmin / isModeratorForPod / pulse_checks:read`. **Gaps vs AC**: (1) route is `/pods/[id]`, not `/pods/[id]/members`; (2) members table shows active/inactive, not per-member pulse indicator — pulse data lives in a separate aggregate-stats dashboard below; (3) no traffic-light semantics (green/yellow/red); (4) no sortable list + URL query param; (5) non-moderator visitors see the page without the pulse dashboard rather than a hard 403. |
+| §1.13 | [ISSUE-W1-013](https://github.com/TheUpskillingLabs/OLOS/issues/51) | downgraded to size/s follow-up after #110 | — | shipped pre-#51 | [app/api/pods/[pod_id]/members/route.ts](../app/api/pods/%5Bpod_id%5D/members/route.ts) exists with `?status=active` filter + RLS-based 403. **Gap**: response does NOT include `last_pulse_check.{scheduled_date, completed_at}` per AC. UI side-steps the gap by querying `pulse_checks` directly server-side from the pod detail page. **2026-05-31:** downgraded as part of the §3.7 / #110 consolidation — read-only enhancement that depends on Phase B UI scaffolding but is not subsumed. Pick up after #110 lands. |
+| §1.14 | [ISSUE-W1-014](https://github.com/TheUpskillingLabs/OLOS/issues/52) | shipped, AC gaps; follow-up #87 downgraded | — | shipped pre-#52 | Members table + `PulseCheckDashboard` render at [app/(dashboard)/pods/[pod_id]/page.tsx](../app/(dashboard)/pods/%5Bpod_id%5D/page.tsx), gated on `isAdmin / isModeratorForPod / pulse_checks:read`. **Gaps vs AC**: (1) route is `/pods/[id]`, not `/pods/[id]/members`; (2) members table shows active/inactive, not per-member pulse indicator — pulse data lives in a separate aggregate-stats dashboard below; (3) no traffic-light semantics (green/yellow/red); (4) no sortable list + URL query param; (5) non-moderator visitors see the page without the pulse dashboard rather than a hard 403. The per-member pulse-indicator follow-up [#87](https://github.com/TheUpskillingLabs/OLOS/issues/87) downgraded to size/s + priority/p2 on 2026-05-31 as part of the §3.7 / #110 consolidation — depends on #51 + Phase B. |
 
 ---
 

--- a/docs/architecture-review-onboarding-state-machine.md
+++ b/docs/architecture-review-onboarding-state-machine.md
@@ -1,0 +1,358 @@
+# OLOS Onboarding State Machine — Architecture Review
+
+## Executive Summary
+
+OLOS has a structurally coherent set of authentication, registration, pod, enrollment, cron, and admin subsystems, but the **participant lifecycle state machine is fragmented across at least 8 mutation sites with no central reconciler**. The `cycle_enrollments.status inactive -> active` transition — the single most important business event in the platform — is fired from exactly one code path (`app/api/pods/[pod_id]/register/route.ts:133-150`), while pods and pod_memberships are mutated from many. The result was the May 2026 Energy cascade (a daily cron + cross-cycle bug + missing grace period revoked ~75% of the cohort) and three stranded `Unknown`-name participants (migration script wrote placeholder rows; no UI exists to fix them). This document maps every write site, names the broken edges, and proposes a 3-phase consolidation: (A) extract a `reconcileEnrollmentActivation` helper and fix the invitation-callback `ignoreDuplicates` bug, (B) ship the admin/moderator UI for the manual fixes currently requiring SQL, (C) redesign the revocation cron with cycle-scoped checks, grace periods, and a warning state.
+
+---
+
+## 1. Current State Assessment
+
+### 1.1 Five subsystems, one machine
+
+The six subsystem maps reveal that participant identity moves through six conceptual states (`anonymous`, `invited`, `registered`, `enrolled-inactive`, `enrolled-active`, `revoked`/`inactive`), but the implementation distributes writes across these tables: `participants`, `cycle_enrollments`, `pod_memberships`, `pods`, `moderator_assignments`, `invitations`, `access_revocations`, `participant_permissions`, `user_roles`.
+
+**Single point of activation.** The `cycle_enrollments.status` field is the gate that controls whether a participant can submit, vote, and see pod content. It transitions `inactive -> active` in only two places in the normal flow:
+- `app/api/pods/[pod_id]/register/route.ts:133-139` — bulk activation when a registration tips a `forming` pod over `pod_min`.
+- `app/api/pods/[pod_id]/register/route.ts:144-150` — single-participant activation when joining an already-`active` pod.
+
+Both branches filter on `status='inactive'`, so a row that doesn't exist silently no-ops. There are **no database triggers** on `cycle_enrollments` (verified by grep across all 20 migrations) — every transition is application-layer.
+
+**Invitation-fulfillment activation is broken.** `app/api/auth/callback/route.ts:56-63` writes `status='active'` with `ignoreDuplicates: true`. If the invited participant has a pre-existing `inactive` row (created by `/api/cycles/[cycle_id]/interest` at `interest/route.ts:115` or `/api/registrations` at `registrations/route.ts:114`), the upsert is a no-op and they remain `inactive`. The literal `'active'` in this code path is misleading.
+
+**Migration backfill bypasses the activation path.** `scripts/migration/migrate.py` Pass 5 (line ~1190) writes directly to `pod_memberships` via psycopg, completely bypassing the pod-register route and its reconciliation side effects. Similarly, `supabase/seed.sql` (lines 488-528) and the ops reset script (`scripts/ops/reset-energy-participants.sql`) operate at the SQL layer with no Audit and no reconciler.
+
+### 1.2 Every write to `cycle_enrollments.status`
+
+| File:Line | Trigger | Operation | Initial/Final |
+|---|---|---|---|
+| `app/api/registrations/route.ts:114` | `POST /api/registrations` (long form, with `cycle_id`) | INSERT | `status='inactive'` |
+| `app/api/cycles/[cycle_id]/interest/route.ts:115` | `POST /api/cycles/[cycle_id]/interest` | INSERT | `status='inactive'` |
+| `app/api/auth/callback/route.ts:60` | OAuth callback `fulfillInvitation()` with `invitation.cycle_id` | UPSERT (`ignoreDuplicates=true`) | `status='active'` (no-op if row exists — BUG) |
+| `app/api/pods/[pod_id]/register/route.ts:135` | `POST /api/pods/[pod_id]/register` (pod tips past `pod_min`) | UPDATE (batch, all members) | `inactive -> active` |
+| `app/api/pods/[pod_id]/register/route.ts:146` | `POST /api/pods/[pod_id]/register` (joining already-active pod) | UPDATE (joining participant only) | `inactive -> active` |
+| `app/api/revocations/reactivate/[participant_id]/route.ts:20` | Admin reactivation button | UPDATE | `inactive -> active`, clears `inactive_date` |
+| `app/api/cron/revocation-check/route.ts:78` | Cron sweep (currently unscheduled; PR #108 removed cron entry) | UPDATE | `active -> inactive`, sets `inactive_date` |
+| `app/api/revocations/check/[cycle_id]/route.ts:82` | Admin "Run inactivity check" button | UPDATE | `active -> inactive`, sets `inactive_date` |
+| `scripts/ops/reset-energy-participants.sql:208-210` | Operator-run reset | DELETE (hard) | row removed, no `access_revocations` row |
+| `supabase/migrations/00001_initial_schema.sql:131` | Schema default | DEFAULT | `'inactive'` (comment mentions `'revoked'` but no code writes it) |
+
+### 1.3 Soft-delete and reactivation surface
+
+| Soft-deletable row | Column | Soft-delete sites | Reactivation sites |
+|---|---|---|---|
+| `pod_memberships` | `inactive_at` | register route DELETE (`register/route.ts:190`), cron (`revocation-check/route.ts:63`), admin revocations (`revocations/check/route.ts:66`) | register route POST (`register/route.ts:84`), admin reactivate (`revocations/reactivate/route.ts:27`) |
+| `project_memberships` | `left_at` | cron (`revocation-check/route.ts:69`), admin revocations | admin reactivate (`revocations/reactivate/route.ts:37`) |
+| `moderator_assignments` | `removed_at` | `pods/[id]/moderators/remove/route.ts:18` | **no reactivation path** — must re-INSERT (which the API allows via UPSERT) |
+| `cycle_enrollments` | `inactive_date` + `status='inactive'` | cron, admin revocations | admin reactivate, register route side-effect |
+| `invitations` | `status='revoked'` | `PATCH /api/invitations/[id]` | none (must create a new invitation) |
+
+### 1.4 Service-client / RLS posture
+
+The auth-rls map enumerates ~29 `createServiceClient()` call sites — including the entire dashboard layout (`app/(dashboard)/layout.tsx`) — so **RLS in this codebase is defense-in-depth, not the primary control**. The primary control is route-handler and page-level role checks. The single place RLS actually fires on a user-facing read path is `app/(dashboard)/pods/[pod_id]/page.tsx`, which uses the cookie-bound client for the pod_memberships→participants join — which is exactly why migration `00020_participants_select_shared_pod.sql` was needed in PR #108 to fix the blank-pod-mate-names bug.
+
+Two RLS follow-ups are pending: `participants_update_own` (00002:56) still has no `WITH CHECK` clause (matching the gap that 00019 fixed for `solution_proposals`), and `pod_memberships_select USING (true)` (00002:105) leaks soft-deleted membership rows to all authenticated users.
+
+### 1.5 Cron surface
+
+Only two cron routes exist (`app/api/cron/pulse-check-reminder/route.ts`, `app/api/cron/revocation-check/route.ts`). PR #108 removed `revocation-check` from `vercel.json`. The route still exists but is unscheduled. When it WAS scheduled, three bugs combined to cascade-revoke the Energy cohort:
+1. `not_in_pod` counts `pod_memberships` cross-cycle (`revocation-check/route.ts:38-42`) — under-detects when a stale membership exists from a prior cycle, over-revokes when none exists.
+2. The soft-delete UPDATE on `pod_memberships` (line 63) is ALSO cross-cycle — soft-deletes memberships in unrelated cycles.
+3. The 7-day pulse-check rule uses `participants.created_at` as the baseline (line 71). A participant created >7 days before cycle activation is revocation-eligible on day 1 of the cycle, before any reminder is sent (the reminder cron uses the same baseline but only emails on day 4/6/7).
+
+### 1.6 Placeholder names
+
+`scripts/migration/migrate.py:711-716` (Pass 1 — missing first/last names) and `:884-885` (Pass 1.5 — orphan-email stubs) write `first_name='Unknown'` / `last_name='Unknown'`. Three prod participants have these values today. The dashboard layout (`app/(dashboard)/layout.tsx`) renders `Welcome, Unknown` and avatar initials `UU`. There is **no PATCH route** on `/api/participants/[participant_id]/route.ts` (verified in moderator-admin-tooling map gap #3), no admin name-edit UI, no self-edit UI, and no submit-endpoint guard. The launch plan at `docs/launch-plan-2026-05-31.md` describes the intended fix; nothing is implemented in this branch yet beyond the plan doc itself.
+
+---
+
+## 2. State Machine Diagram (current implementation)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Anonymous
+    Anonymous --> Invited: admin POST /api/invitations (server-authoritative)
+    Anonymous --> RegisteredNoCycle: short-form /api/registrations/short (server-authoritative)
+    Invited --> RegisteredViaInvite: OAuth callback + fulfillInvitation (server-authoritative)
+    RegisteredNoCycle --> EnrolledInactive: POST /api/cycles/[id]/interest (server-authoritative)
+    RegisteredViaInvite --> EnrolledActiveBuggy: callback upsert status=active (BROKEN if inactive row exists)
+    RegisteredViaInvite --> EnrolledInactive: pre-existing inactive row + ignoreDuplicates=true (BUG path)
+    EnrolledInactive --> EnrolledActive: pod tips past pod_min OR joins active pod (server-authoritative, single point)
+    EnrolledActive --> InactiveRevoked: cron OR admin revocations/check (server-authoritative, cron currently UNSCHEDULED)
+    EnrolledActive --> EnrolledInactiveStale: leave last pod (NO transition today, drift)
+    InactiveRevoked --> EnrolledActive: admin /api/revocations/reactivate (manual)
+    EnrolledInactive --> StuckForever: pod never reaches pod_min OR migration bypass (manual SQL to fix)
+    EnrolledInactive --> InactivePlaceholderName: migration script Unknown name (manual SQL to fix)
+    EnrolledActiveBuggy --> [*]
+    EnrolledActive --> [*]
+    note right of EnrolledInactive
+        Single point of activation:
+        pods/[id]/register/route.ts:133-150
+    end note
+    note right of StuckForever
+        No reconciler; no admin UI
+    end note
+```
+
+Legend: paths annotated "server-authoritative" fire deterministically from route handlers. Paths annotated "manual" require an operator to either run SQL or click an admin UI button. The `StuckForever` and `InactivePlaceholderName` states are unrecoverable from the participant's perspective today.
+
+---
+
+## 3. Current Onboarding Flow (actual code paths)
+
+```mermaid
+flowchart TD
+    classDef broken stroke:#f00,stroke-width:3px
+    classDef ok stroke:#0a0,stroke-width:2px
+
+    Email[Email received]
+    Email -->|invitation magic link| Login1["/login?invite=token"]
+    Email -->|public signup link| Login2["/login"]
+    AdminSQL[Admin runs migrate.py or SQL]
+    AdminSQL --> StubRow["participants row<br/>auth_user_id=NULL<br/>first_name='Unknown'"]:::broken
+
+    Login1 --> CookieSet[invite_token cookie set]
+    CookieSet --> OAuth[supabase signInWithOAuth google]
+    Login2 --> OAuth
+    OAuth --> Callback["/api/auth/callback"]
+
+    Callback -->|no participant row| RegisterPage["/register"]
+    Callback -->|participant row exists| LinkAuth["UPDATE participants.auth_user_id"]
+    Callback -->|invite_token present| FulfillInv["fulfillInvitation()"]
+
+    RegisterPage --> ShortForm["POST /api/registrations/short<br/>INSERT participant only<br/>NO cycle_enrollment"]
+    ShortForm --> Dash1["/dashboard - no cycle"]:::broken
+
+    LinkAuth --> FulfillInv
+    FulfillInv -->|"upsert cycle_enrollments<br/>status=active<br/>ignoreDuplicates=true"| UpsertActive["upsert active"]:::broken
+    UpsertActive -->|"existing row stays inactive"| EnrInactive["cycle_enrollments status=inactive"]:::broken
+    UpsertActive -->|"no prior row -> active"| EnrActive["cycle_enrollments status=active"]:::ok
+
+    StubRow -->|first sign-in| LinkAuth
+    StubRow -.->|"Unknown name passes through<br/>NO guard in fulfillInvitation"| FulfillInv
+
+    EnrInactive --> Interest["/cycles/id/join"]
+    Interest --> PodReg["pod-registration window<br/>POST /api/pods/id/register"]
+    PodReg -->|"count >= pod_min<br/>OR pod already active"| Activate["UPDATE cycle_enrollments<br/>status=active"]:::ok
+    PodReg -->|"pod never reaches pod_min"| Stuck["STUCK inactive forever"]:::broken
+
+    EnrActive --> Dashboard["/dashboard with cycle"]
+    Activate --> Dashboard
+
+    Dashboard -->|"first_name=Unknown<br/>NO layout guard"| BadDash["Welcome, Unknown<br/>avatar UU"]:::broken
+    Dashboard -->|"can submit/vote<br/>NO placeholder check"| Submit["proposal/vote/pulse endpoints"]:::broken
+
+    Cron["/api/cron/revocation-check<br/>UNSCHEDULED post-PR108"] -.->|when re-enabled| BadCheck["cross-cycle pod count<br/>created_at baseline<br/>no grace period"]:::broken
+    BadCheck --> EnrInactive
+```
+
+---
+
+## 4. Broken Edges
+
+| # | Edge / expected transition | Reality | File:line | Severity | Tickets |
+|---|---|---|---|---|---|
+| 1 | Activate enrollment when pod reaches `pod_min` via ANY path (admin, migration, seed) | Only fires from `pods/[id]/register/route.ts:133-150`. Other paths leave members `inactive` forever. | `app/api/pods/[pod_id]/register/route.ts:119-150` | critical | #107 |
+| 2 | Invitation acceptance should promote pre-existing `inactive` row to `active` | `ignoreDuplicates: true` makes it a no-op; participant lands on dashboard `inactive`. | `app/api/auth/callback/route.ts:60` | critical | #107 |
+| 3 | Placeholder-name participants must not reach dashboard or submission endpoints | No layout-level guard; dashboard renders `Welcome, Unknown`. No submission-endpoint guard. | `app/(dashboard)/layout.tsx`, all submission routes | critical | #102, #103 |
+| 4 | Admin can edit any participant's first/last name | No `PATCH /api/participants/[id]` route exists. Verified gap in admin map. | `app/api/participants/[participant_id]/route.ts` | high | #102, #94, #98 |
+| 5 | Participant can self-edit their own profile | No `/profile/edit` route. No Mode A form. | not present | high | #98 |
+| 6 | Pod auto-activation should retry / be reconciled if inline UPDATE fails | No retry, no reconciler. Two concurrent registrations can each fire activation logic; no transaction wraps the multi-step INSERT/COUNT/UPDATE. | `app/api/pods/[pod_id]/register/route.ts:119-140` | high | #107 |
+| 7 | Leaving last pod should demote `cycle_enrollments.status` | DELETE on pod_membership doesn't touch enrollment. Cron is supposed to catch it; cron is unscheduled. | `app/api/pods/[pod_id]/register/route.ts:159-201` | high | #107 |
+| 8 | Revocation cron `not_in_pod` should be cycle-scoped | Counts `pod_memberships` cross-cycle; the UPDATE on line 63 also cross-cycle. | `app/api/cron/revocation-check/route.ts:38-42, 63` | critical | #107 |
+| 9 | Revocation cron 7-day rule needs a per-cycle baseline | Falls back to `participants.created_at`, revoking participants created >7 days before cycle activation on day 1. | `app/api/cron/revocation-check/route.ts:71` | critical | #107 |
+| 10 | Warning before revocation | No warning state, no `warned_at` column. | not present | high | #107 |
+| 11 | Idempotent `access_revocations` writes | No unique constraint on `(participant_id, cycle_id, reason)`. | `supabase/migrations/00001_initial_schema.sql:268-277` | medium | #107 |
+| 12 | Idempotent pulse-check-reminder emails | No `pulse_check_reminders_sent` table; double-firing the cron sends double emails. | `app/api/cron/pulse-check-reminder/route.ts` | medium | #107 |
+| 13 | Admin can manually add/remove pod memberships | DELETE `/api/pods/[id]/register` uses `auth.user.participantId`, not admin-supplied. No alternative admin route. RLS allows it; gap is missing API + UI. | `app/api/pods/[pod_id]/register/route.ts` | high | new |
+| 14 | Admin can force pod status forming → active | No `PATCH /api/pods/[id]` route. RLS allows; gap is missing API. | not present | high | new |
+| 15 | Admin can reactivate `inactive` enrollment that lacks an `access_revocations` row | Reactivate button only renders for rows present in `access_revocations`. Stuck-from-inception enrollments invisible. | `app/(dashboard)/admin/cycles/[cycle_id]/revocations-section.tsx` | medium | new |
+| 16 | `fulfillInvitation` guards against placeholder-name acceptance | No guard; bulk invite for `Unknown` participants succeeds and activates the row. | `app/api/auth/callback/route.ts` | high | #103 |
+| 17 | `participants_update_own` RLS has `WITH CHECK` | Missing — same gap that 00019 fixed for `solution_proposals`. | `supabase/migrations/00002_rls_policies.sql:56` | medium | new |
+| 18 | `pod_memberships_select` hides soft-deleted rows from non-owners | `USING (true)` leaks `inactive_at IS NOT NULL` rows globally. | `supabase/migrations/00002_rls_policies.sql:105` | medium | new |
+| 19 | OAuth callback email lookup is case-insensitive | `.eq('email', email)` is case-sensitive; 00016 added case-insensitive index but callback wasn't updated. | `app/api/auth/callback/route.ts:115` | medium | new |
+| 20 | `cycle_enrollments.status='revoked'` is documented but never written | Schema comment lists it; only `'inactive'` is ever written. | `supabase/migrations/00001_initial_schema.sql:131` | low | none |
+| 21 | `pods.status='archived'` documented in UI types but never written | UI declares `'closed' | 'inactive'` union but no code writes either. | `app/(dashboard)/pods/[pod_id]/page.tsx` | low | none |
+| 22 | Moderator-tooling UI has mutating controls | `/moderator` and `/moderator/cycles/[id]/vote-progress` are read-only; rename + finalize routes exist but no UI to trigger from moderator landing. | `app/(dashboard)/moderator/page.tsx` | medium | #87 |
+| 23 | Pulse status visible on member list (per-member indicator) | No members API surfaces pulse status. | not present | medium | #51, #87 |
+
+---
+
+## 5. Proposed Unified Architecture
+
+### 5.1 Core idea — one reconciler, many callers
+
+Introduce `lib/enrollment/reconciler.ts` exporting:
+
+```ts
+async function reconcileEnrollmentActivation(
+  serviceClient: SupabaseClient,
+  participantId: number,
+  cycleId: number,
+  opts?: { reason?: string; logRevocation?: boolean }
+): Promise<{ before: Status; after: Status; mutated: boolean; }>
+```
+
+Behavior (idempotent):
+1. Read participant's active `pod_memberships` rows for `cycleId` (joined via `pods.cycle_id`).
+2. Read the corresponding `pods.status` values.
+3. Decide:
+   - If at least one membership is `inactive_at IS NULL` AND its pod is `status='active'` → ensure `cycle_enrollments.status='active'` and `inactive_date IS NULL`.
+   - Else → ensure `cycle_enrollments.status='inactive'`, set `inactive_date=now`, and (if `logRevocation=true`) INSERT `access_revocations` row with `reason`.
+4. Return the before/after and whether it mutated.
+
+Every site that today touches the lifecycle calls this:
+- `POST /api/pods/[pod_id]/register` — after INSERT/UPDATE, call reconciler for the joining participant. After auto-activating the pod, call reconciler for every existing member.
+- `DELETE /api/pods/[pod_id]/register` — after soft-delete, call reconciler for the leaver.
+- `fulfillInvitation` — after upserting `cycle_enrollments` (without `ignoreDuplicates`) and `moderator_assignments`, call reconciler.
+- New admin pod-membership add/remove routes — call reconciler.
+- Pod-status PATCH route — when forcing `active`, call reconciler for every current member.
+- Revocation cron — replaces the inline UPDATEs at `revocation-check/route.ts:63-78` with reconciler invocations.
+
+The reconciler is the **single source of truth for the `inactive ↔ active` transition** and runs in transactions where supported.
+
+### 5.2 Proposed flow
+
+```mermaid
+flowchart TD
+    classDef new stroke:#06c,stroke-width:3px
+    classDef reconciler fill:#ffd,stroke:#06c,stroke-width:2px
+
+    Email[Email]
+    Email -->|invite| Login["/login?invite"]
+    Email -->|signup| Login
+    Login --> OAuth[Google OAuth]
+    OAuth --> Callback["/api/auth/callback"]
+    Callback -->|"no participant"| Register["/register"]
+    Callback -->|"existing row"| LinkAuth["UPDATE auth_user_id<br/>(case-insensitive lookup)"]:::new
+    LinkAuth --> Fulfill["fulfillInvitation()<br/>NEW: placeholder-name guard<br/>NEW: drop ignoreDuplicates"]:::new
+    Register --> Short["POST /api/registrations/short<br/>strict session.user.id == body.auth_user_id"]:::new
+    Short --> ProfileCheck{"first_name == 'Unknown'?"}:::new
+    Fulfill --> Reconciler["reconcileEnrollmentActivation<br/>(idempotent, central)"]:::reconciler
+    LinkAuth --> ProfileCheck
+    ProfileCheck -->|yes| ProfileGate["/profile?required=true&next=X<br/>(layout guard)"]:::new
+    ProfileGate --> ProfileEdit["/profile/edit<br/>PATCH /api/participants/me"]:::new
+    ProfileEdit --> Dashboard
+    ProfileCheck -->|no| Dashboard["/dashboard"]
+    Reconciler --> Dashboard
+
+    Dashboard --> JoinPod["POST /api/pods/id/register"]
+    JoinPod --> Reconciler
+    Dashboard --> Leave["DELETE pod membership"]
+    Leave --> Reconciler
+
+    AdminUI["Admin /admin/cycles/[id]"]:::new
+    AdminUI --> AdminPodAdd["POST /api/admin/pods/id/memberships"]:::new
+    AdminUI --> AdminPodKick["DELETE /api/admin/pods/id/memberships/pid"]:::new
+    AdminUI --> AdminPodForce["PATCH /api/admin/pods/id status=active"]:::new
+    AdminUI --> AdminNameEdit["PATCH /api/participants/id"]:::new
+    AdminPodAdd --> Reconciler
+    AdminPodKick --> Reconciler
+    AdminPodForce --> Reconciler
+
+    NewCron["/api/cron/revocation-check<br/>v2 — re-registered in vercel.json"]:::new
+    NewCron --> CycleScoped["cycle-scoped pod count<br/>cycle.pod_registration_open_at baseline<br/>warned_at + 3-day grace"]:::new
+    CycleScoped --> Warn["Warning email + UPDATE warned_at"]:::new
+    CycleScoped --> Reconciler
+    Warn -.->|day N+3 still eligible| Reconciler
+
+    Submit["proposal / vote / pulse endpoints"]
+    Submit --> SubmitGuard{"placeholder name?"}:::new
+    SubmitGuard -->|yes| Block["403 {redirect_hint}"]:::new
+    SubmitGuard -->|no| ProcessSubmit["accept submission"]
+```
+
+### 5.3 Key proposed components
+
+1. **`lib/enrollment/reconciler.ts`** — single idempotent function. All lifecycle code paths call it.
+2. **Placeholder-name guard** — three layers of defense:
+   - Dashboard layout (`app/(dashboard)/layout.tsx`) reads participant, if `first_name='Unknown'` OR `last_name='Unknown'` issues `redirect('/profile?required=true&next=' + originalPath)`.
+   - `fulfillInvitation` (issue #103) — skip `cycle_enrollments` write if placeholder name; mark invitation `pending_profile_completion`.
+   - Submission endpoints (`POST /api/proposals`, `POST /api/votes`, `POST /api/pulse-checks`, `POST /api/pods/[id]/register`) — `403 {error: 'profile_incomplete', redirect_hint: '/profile?required=true'}`.
+3. **Admin UI surfaces** — new routes/components:
+   - `PATCH /api/participants/[id]` (self OR admin) + admin name-edit form (#102, #98, #94).
+   - `POST /api/admin/pods/[id]/memberships` + `DELETE …/[participant_id]` (admin pod swap).
+   - `PATCH /api/admin/pods/[id]` for status override.
+   - Participants-table filter for `status='inactive'` with one-click "Run reconciler" action.
+   - Render `revoked_systems` and `revocation_scope` in `RevocationsSection`.
+4. **Revocation cron v2** — single Vercel cron, multi-stage handler:
+   - Stage 1: identify eligible participants (cycle-scoped pod count, cycle-baseline pulse rule).
+   - Stage 2: for newly-eligible, send warning email + set `warned_at`.
+   - Stage 3: for those `warned_at + 3d <= now` still eligible, call reconciler with `logRevocation=true`.
+   - Idempotency: unique partial index on `access_revocations(participant_id, cycle_id, reason) WHERE revocation_scope = 'full'`; `pulse_check_reminders_sent(participant_id, cycle_id, variant)` UNIQUE.
+5. **RLS follow-ups**:
+   - `00021_participants_update_with_check.sql` adds `WITH CHECK (auth_user_id = auth.uid() OR is_admin_or_owner())`.
+   - `00022_pod_memberships_select_hide_soft_deleted.sql` rewrites `pod_memberships_select` to `USING (inactive_at IS NULL OR participant_id = current_participant_id() OR is_admin_or_owner())`.
+
+### 5.4 What does NOT change
+
+- The per-request `resolveUserRoles()` model in `lib/auth/roles.ts` stays — no JWT-claim mirroring.
+- Service-client usage in dashboard server components is acceptable; tightening it is a separate workstream.
+- `pods.status` stays `forming` / `active` only; no `archived`.
+- Soft-delete-everywhere invariant is preserved.
+
+---
+
+## 6. Acceptance Criteria
+
+1. A pod created via ANY path that reaches `pod_min` active members and `pods.status='active'` ends with every member's `cycle_enrollments.status='active'` within one reconciler tick.
+2. An invited participant with a pre-existing `inactive` enrollment row lands on `/dashboard` with `status='active'` after OAuth + invitation acceptance.
+3. A participant with `first_name='Unknown'` is redirected to `/profile?required=true&next=X` by the dashboard layout and receives `403 {error: 'profile_incomplete'}` from any submission endpoint.
+4. An admin can edit any participant's `first_name` / `last_name` / `preferred_name` from `/admin/participants/[id]/permissions` without raw SQL.
+5. An admin can add a pod_membership on behalf of any participant via the admin UI; the reconciler updates that participant's `cycle_enrollments` automatically.
+6. An admin can remove a participant from a pod via the admin UI; the reconciler demotes `cycle_enrollments` only if no remaining active pod membership exists for the cycle.
+7. Re-running `/api/cron/revocation-check` twice within one day produces zero duplicate `access_revocations` rows and zero duplicate emails.
+8. A test fixture with `participants.created_at = now() - interval '30 days'` and `cycle.pod_registration_open_at = now() - interval '3 days'` and a recent pulse-check is NOT revoked by the cron.
+9. The cron's `not_in_pod` check evaluates `pod_memberships` joined to `pods.cycle_id = current_cycle.id` (SQL test in CI).
+10. The cron sends a warning email at least 3 days before any revocation, and `warned_at` is set on the relevant row.
+11. RLS test: an authenticated non-admin user CANNOT SELECT `pod_memberships` rows with `inactive_at IS NOT NULL` other than their own.
+12. RLS test: an authenticated user CANNOT UPDATE their own `participants` row to set `auth_user_id = NULL`.
+13. Case-insensitive lookup in `/api/auth/callback` — a participant with `Email='Mixed.Case@x.com'` who signs in with `mixed.case@x.com` is correctly linked.
+14. `fulfillInvitation` does not activate `cycle_enrollments` if the participant has `first_name='Unknown'` (issue #103 guard).
+
+---
+
+## 7. Phased Rollout
+
+### Phase A — State machine centralization (~half-day)
+1. New `lib/enrollment/reconciler.ts` + unit tests.
+2. Replace inline activation in `pods/[pod_id]/register/route.ts:119-150` with reconciler call.
+3. Fix `auth/callback/route.ts:60` — drop `ignoreDuplicates`, call reconciler after `fulfillInvitation`.
+4. Placeholder-name guard in `fulfillInvitation` (#103).
+5. Migration `00021_participants_update_with_check.sql`.
+6. Migration `00022_pod_memberships_select_hide_soft_deleted.sql`.
+7. Case-insensitive email lookup in callback.
+8. Strict `session.user.id == body.auth_user_id` check in both registration routes.
+
+### Phase B — Admin/moderator self-service UI (~one day)
+1. `PATCH /api/participants/[id]` route + admin name-edit form + Mode A `/profile/edit` (#98, #102, #94).
+2. Mode B layout redirect for placeholder-name participants (#102).
+3. Submission-endpoint placeholder guards (defense in depth).
+4. Admin pod-membership add/remove routes + UI buttons in `pods-list.tsx`.
+5. Admin pod-status override.
+6. "Stuck inactive" filter on `participants-table.tsx` with reconciler-trigger button.
+7. Render `revoked_systems` / `revocation_scope` in `RevocationsSection`.
+8. Per-member pulse indicator if cheap (#87 — otherwise defer).
+
+### Phase C — Revocation cron redesign (~1-2 days)
+1. New `warned_at` column on `cycle_enrollments` (or new `enrollment_warnings` table — decide based on whether per-reason warnings are needed).
+2. Cycle-scoped `pod_memberships` query in cron.
+3. New baseline: `GREATEST(cycle_enrollments.activated_at, cycle.pod_registration_open_at)`.
+4. Two-stage cron handler: warning then revocation (3-day gap, configurable).
+5. `pulse_check_reminders_sent` table with UNIQUE constraint.
+6. Unique partial index on `access_revocations` for idempotency.
+7. Re-register cron in `vercel.json`.
+8. Staging soak ≥ 48 hours before merging Phase C to `main`.
+
+---
+
+## 8. Architectural Principles Preserved
+
+| Invariant (from `docs/OLOS-architecture-brief.md`) | How the proposal honors it |
+|---|---|
+| 1. Phase windows are server-enforced | Reconciler runs only inside route handlers and the cron; admin overrides explicitly bypass via `withAdminAuth`. No client-side state changes. |
+| 2. Roles stack; visibility is the union | Unchanged — `resolveUserRoles()` per-request model retained; admin name-edit + pod controls go through `withAdminAuth`. |
+| 3. Pod membership multi (≤2 per cycle); project membership exclusive (=1) | Admin pod-add API honors the 2-pod cap (re-uses existing check from `register/route.ts:65-70`); reconciler does not change membership counts, only enrollment status. |
+| 4. Resources provision at activation, not formation | Reconciler is the activation event — when it flips `inactive -> active`, downstream provisioning hooks (currently inline in the register route) move into a single post-reconciliation step. |
+| 5. Soft delete everywhere | Hard DELETE in `reset-energy-participants.sql` is flagged as out-of-band; all new admin routes soft-delete via `inactive_at` / `removed_at` / `left_at`. `access_revocations` audit row written by the reconciler whenever it demotes. |
+

--- a/docs/consolidated-issue-draft-onboarding-state-machine.md
+++ b/docs/consolidated-issue-draft-onboarding-state-machine.md
@@ -1,0 +1,108 @@
+## Milestone
+v1.0 (May 2026 launch cycle)
+
+## Labels
+`area/backend`, `area/frontend`, `area/database`, `priority/p0`, `size/l`, `type/architecture`
+
+## Estimate
+2-3 days
+
+## Goal
+Consolidate the fragmented participant onboarding/enrollment lifecycle into a single, idempotent state machine with one centralized "enrollment activation reconciler," explicit reactivation paths for every soft-deletable row, admin/moderator self-service UI for the fixes currently requiring raw SQL, server-side guards against placeholder-name participants, and a redesigned revocation cron with grace periods and warning states. This eliminates the cascade that took down ~75% of the Energy cohort and the placeholder-name gap that stranded Aaron McKeever (#61) and two other prod participants.
+
+## Context
+See the architecture review (`docs/architecture-review-onboarding-state-machine.md`) for the full current-state assessment, broken-edges table, state-machine and flow diagrams, and proposed unified design.
+
+Root causes (from the six subsystem maps):
+1. `cycle_enrollments.status` flips `inactive -> active` from ONLY one code path in the normal flow: `app/api/pods/[pod_id]/register/route.ts:133-150`. Pods activated by any other path (admin SQL, migration script `scripts/migration/migrate.py` Pass 5, `supabase/seed.sql`, future admin UI) leave member enrollments stuck `inactive`.
+2. Invitation fulfillment writes `status='active'` with `ignoreDuplicates=true` (`app/api/auth/callback/route.ts:60`), so an invited participant who already has an `inactive` row from `/api/cycles/[cycle_id]/interest` stays `inactive` forever.
+3. The revocation cron's `not_in_pod` rule counts `pod_memberships` across ALL cycles (cron route line 38-42) while the soft-delete UPDATE on line 63 is also cross-cycle — simultaneously over-deletes and under-detects.
+4. The 7-day pulse rule has no grace period and uses `participants.created_at` as the baseline, so a participant created >7 days before cycle activation is revocation-eligible on day 1.
+5. Three prod participants have `first_name='Unknown'` from `scripts/migration/migrate.py:711-716, 884-885`; no PATCH route exists on `/api/participants/[participant_id]`, no admin name-edit UI, no self-fix UI, and no server-side block on submit/vote endpoints.
+6. `fulfillInvitation()` has no placeholder-name guard.
+7. No admin UI for: manual pod-membership add/remove, manual pod activation, editing participant names, reactivating an `inactive` enrollment that has no `access_revocations` row.
+
+## Scope (In)
+### Phase A — State machine centralization (half-day)
+- Extract `reconcileEnrollmentActivation(participantId, cycleId, podId?)` helper into `lib/enrollment/reconciler.ts`. Idempotent. Promotes `cycle_enrollments.status` `inactive -> active` whenever (a) the participant has at least one active `pod_memberships` row for the cycle AND (b) at least one pod they belong to is `status='active'`. Conversely, demotes `active -> inactive` (with `access_revocations` audit row) when no active pod membership remains.
+- Replace inline activation logic in `app/api/pods/[pod_id]/register/route.ts:119-150` with a single call to the reconciler.
+- Fix `app/api/auth/callback/route.ts:56-63`: drop `ignoreDuplicates: true`, switch to explicit upsert-then-promote, and call the reconciler after `fulfillInvitation()` completes.
+- Add placeholder-name guard at the top of `fulfillInvitation()` (issue #103): if the participant's `first_name='Unknown'` OR `last_name='Unknown'`, set an `invitation_pending_profile_completion` flag and skip the `cycle_enrollments` upsert until the participant completes their profile.
+- Add a follow-up migration `00021_*_with_check.sql` adding `WITH CHECK` clauses to `participants_update_own` (matching what 00019 did for `solution_proposals`).
+- Tighten `pod_memberships_select` RLS so soft-deleted rows are visible only to the row owner or admin (current `USING (true)` leaks revoked memberships).
+- Add unit tests covering the reconciler for: net-new pod activation, late join into an already-active pod, invitation acceptance for a participant with a pre-existing inactive row, leave-last-pod demotion.
+
+### Phase B — Admin/moderator self-service UI (one day)
+- `PATCH /api/participants/[participant_id]` — partial-update route accepting `first_name`, `last_name`, `preferred_name`. Admin OR self. Returns the updated row.
+- Mode A `/profile/edit` form (issue #98) — participant self-service.
+- Mode B `/profile?required=true&next=X` route + dashboard-layout redirect (issue #102) — server-side enforced redirect when `first_name='Unknown' OR last_name='Unknown'`. Includes 403 + `redirect_hint` JSON on submission endpoints (`/api/proposals`, `/api/votes`, `/api/pulse-checks`, `/api/pods/[id]/register`) as defense in depth.
+- Admin manual pod-membership controls on `/admin/cycles/[cycle_id]`:
+  - `POST /api/admin/pods/[pod_id]/memberships` — admin-supplied `participant_id`; honors 2-pod cap; calls reconciler.
+  - `DELETE /api/admin/pods/[pod_id]/memberships/[participant_id]` — admin soft-delete with reason; calls reconciler.
+- Admin pod-status override `PATCH /api/admin/pods/[pod_id]` for `status` (forming/active/closed). Validates pod_min when forcing `active`.
+- Admin name-edit form on `/admin/participants/[participant_id]/permissions`.
+- Surface "stuck inactive (never activated)" enrollments in `participants-table.tsx` with a filter and a one-click "Activate via reconciler" action (only fires if the participant is actually eligible).
+- Render `revoked_systems` and `revocation_scope` columns in `RevocationsSection`.
+
+### Phase C — Revocation cron redesign (1-2 days)
+- Re-register `/api/cron/revocation-check` in `vercel.json` (PR #108 removed it; this re-adds it with the new semantics safely).
+- Fix the cross-cycle bug at `app/api/cron/revocation-check/route.ts:38-42` and line 63: scope `pod_memberships` lookups and UPDATEs by joining to `pods.cycle_id`.
+- Add a `warned_at` column to `cycle_enrollments` (or a new `enrollment_warnings` table). Introduce a two-strike rule:
+  - Day N of eligibility: send warning email, set `warned_at`.
+  - Day N+3 (configurable per cycle): if still eligible, revoke.
+- Replace `participants.created_at` baseline with `MAX(cycle_enrollments.activated_at, cycle.pod_registration_open_at)` so a participant cannot be revoked for missing a pulse check before their cycle was active.
+- Add per-(participant, cycle, reason) idempotency on `access_revocations` INSERTs (unique partial index).
+- Add per-(participant, cycle, variant) idempotency on the pulse-check-reminder cron via a new `pulse_check_reminders_sent` table.
+- Add `pre_revocation_warning` cron variant under the same scheduled job (single Vercel cron entry, multi-stage handler).
+
+## Scope (Out)
+- Multi-pulse-question product change (#97) — separate product decision, not architecture.
+- Per-member pulse indicator moderator UX (#87) — depends on Phase B but rendered separately.
+- Already-submitted pulse-check page state (#86) — small UX fix, do as separate PR.
+- Members API with pulse status (#51) — covered by Phase B but tracked as its own follow-up.
+- Hard-delete or archived pod states — `pods.status='archived'` is not in scope; current `forming/active` is sufficient.
+- JWT-claim mirroring of roles/permissions — the per-request `resolveUserRoles()` model is preserved.
+
+## Acceptance Criteria
+1. A pod created via ANY path (admin SQL, migration script, seed, or normal self-register) — once it has `status='active'` and `>= pod_min` active members — has all member `cycle_enrollments.status='active'` within one reconciler tick.
+2. An invited participant with a pre-existing `inactive` enrollment row lands on `/dashboard` with `status='active'` after accepting the invitation (issue caused by `ignoreDuplicates: true`).
+3. A participant whose `first_name='Unknown'` is redirected to `/profile?required=true&next=X` from the dashboard layout and gets `403 {error: 'profile_incomplete', redirect_hint: '/profile?required=true'}` from any submission endpoint.
+4. An admin can edit any participant's name from `/admin/participants/[id]/permissions` with no SQL.
+5. An admin can manually add/remove a pod_membership on behalf of any participant; the reconciler updates `cycle_enrollments` automatically.
+6. The revocation cron, when re-enabled, does NOT revoke a participant who registered before the cycle activated and whose first 7 days post-activation included a pulse check.
+7. The revocation cron sends a warning email at least 3 days before any revocation.
+8. The `not_in_pod` check evaluates membership scoped to the current cycle only (verified by SQL test in CI).
+9. Re-running the revocation cron twice in one day produces zero duplicate `access_revocations` rows and zero duplicate emails.
+10. `pod_memberships` with `inactive_at IS NOT NULL` are not visible to non-admin, non-owner authenticated users (RLS test).
+11. `participants_update_own` policy has `WITH CHECK (auth_user_id = auth.uid() OR is_admin_or_owner())`.
+
+## Test Plan
+### Automated
+- Unit tests for `reconcileEnrollmentActivation` covering all 4 scenarios above.
+- Integration test: invitation flow with pre-existing inactive enrollment row.
+- Integration test: revocation cron with backdated `created_at` (-30d), recent cycle activation (-3d), pulse check 1 day ago — must NOT revoke.
+- RLS regression test: anonymous + authenticated-non-admin trying to SELECT inactive `pod_memberships`.
+- Idempotency test: run revocation cron twice in a row.
+
+### Manual
+- Restore Aaron McKeever (#61) via admin UI without SQL.
+- Fix the three `Unknown` prod participants via admin name-edit form.
+- Walk a fresh participant from invitation email through to `enrolled-active` and verify no `inactive` stranding.
+- Pod admin-create flow: admin creates pod, admin-adds 4 members via new UI, verifies all 4 enrollments flip `active`.
+- Force-leave: admin removes a member from an active pod via UI, verifies enrollment correctly demotes (if no remaining pod) or stays active (if other pod).
+
+## Phased Rollout
+**Phase A** (~0.5 day): centralized reconciler, callback fix, placeholder guard in `fulfillInvitation`, RLS WITH CHECK migration, pod_memberships_select tightening. PR into `dev`.
+**Phase B** (~1 day): all admin/moderator UI. Depends on Phase A reconciler. PR into `dev`.
+**Phase C** (~1-2 days): cron redesign + re-registration in `vercel.json`. Depends on Phase A schema/RLS work. PR into `dev`. **Do not merge Phase C to `main` until staging soak ≥ 48 hours.**
+
+## Supersedes / Subsumes
+- Subsumes #102 (profile-completion redirect Mode B) — implemented as part of Phase B.
+- Subsumes #98 (Mode A profile edit) — implemented as part of Phase B.
+- Subsumes #103 (fulfillInvitation guard) — implemented in Phase A.
+- Subsumes #107 (P0 cron redesign) — implemented in Phase C.
+- Subsumes #94 (Unknown-names root cause) — answer documented in architecture review; remediation via Phase B name-edit UI.
+- Downgrades #51 (members API w/ pulse status) — depends on Phase B but tracked separately as smaller follow-up.
+- Downgrades #87 (per-member pulse indicator) — depends on Phase B but UX-only follow-up.
+- Keeps as-is #86 (already-submitted pulse page state) — separate UX concern, not architectural.
+- Keeps as-is #97 (multi-pulse question) — product decision, not architecture.

--- a/docs/launch-plan-2026-05-31.md
+++ b/docs/launch-plan-2026-05-31.md
@@ -1,0 +1,288 @@
+# Launch Plan — Energy Cycle 3
+
+**Date authored**: 2026-05-31
+**Cycle phase**: Solution proposal phase closing today; voting opens 2026-06-01
+**Author**: Hot-fix session bundle (PR #108, ticket #107, related)
+**Status**: Tier 0 in progress (PR #108 merged to dev, promotion to main pending)
+
+---
+
+## Goal
+
+Over the next several hours, ensure:
+
+1. All registered participants have access to OLOS.
+2. They can submit proposals, vote, and complete pulse checks.
+3. When account problems arise, moderators/admins can solve them without manually
+   running SQL or introducing other invariant violations.
+4. Code quality is preserved — soft-delete invariants, RLS, server-side
+   validation, audit trails.
+
+This plan is structured by impact, not by ticket order. The biggest obstacles
+are addressed first so smaller tickets cascade into quick fixes.
+
+---
+
+## Current state snapshot
+
+### Production database (Energy cycle 3, as of 2026-05-31)
+
+| Metric | Value |
+|---|---|
+| Total cycle enrollments | 24 |
+| Active | 16 |
+| Inactive | 8 (all with zero active pod_memberships — correctly inactive) |
+| Active pods | 5 (Clean Energy), 8 (Recycling) |
+| Forming pods | 6 (Sustainable Travel), 7 (others) |
+| Unknown-name participants | 3 |
+| Beta tester status | Aaron McKeever (id=61) fully unblocked |
+
+### Code state
+
+| Branch | State |
+|---|---|
+| `main` | Production. Last merged: PR #92 (2026-05-26-ish) |
+| `dev` | PR #104 + PR #108 merged. Awaiting promotion to main. |
+| `fix/participants-rls-shared-pod-visibility` | PR #108 (now merged) |
+
+### Cron state on production
+
+- **PROD CURRENTLY HAS REVOCATION-CHECK CRON LIVE** — it will fire at 10 UTC
+  unless the dev → main promotion deploys before then.
+- `pulse-check-reminder` cron is unaffected; remains scheduled.
+
+---
+
+## Tier 0 — Stop the bleeding (critical path)
+
+**Window**: must complete before 10 UTC on 2026-06-01.
+
+**Why it's first**: until `vercel.json` from PR #108 reaches production, the
+revocation-check cron will fire at 10 UTC and re-deactivate the 10 enrollments
+we hand-activated last night. Losing the cohort mid-launch is the worst-case
+outcome and it's recoverable but disruptive.
+
+### Steps
+
+| # | Action | Owner | Validation |
+|---|---|---|---|
+| 1 | Merge PR #108 to `dev` | done | `git log origin/dev --oneline` shows commit `823f200` |
+| 2 | Smoke-test dev deployment (see Tier 0.5 below) | adm-2k | All checklist items pass |
+| 3 | Open dev → main promotion PR | adm-2k + agent | PR opens against `main` |
+| 4 | Merge promotion PR | adm-2k | PR shows merged state |
+| 5 | Verify Vercel production deploy succeeded | adm-2k | `vercel deployments` shows new revision serving |
+| 6 | Verify Vercel cron dashboard | adm-2k | `revocation-check` no longer listed |
+
+### Smoke-test acceptance criteria for dev
+
+After the dev deployment redeploys with PR #108:
+
+- [ ] Dev preview URL loads without 500s
+- [ ] As a regular participant: log in, view a pod-detail page, see other members' names (not blank)
+- [ ] As a regular participant: leave a pod via the UI, then re-register — original `joined_at` preserved
+- [ ] As a moderator: pod-detail page shows full member list
+- [ ] Cron dashboard on dev: `revocation-check` not scheduled
+- [ ] Type check passes: `npx tsc --noEmit`
+- [ ] No new schema drift between dev DB and prod DB
+
+---
+
+## Tier 0.5 — Promotion PR construction
+
+The promotion PR bundles **PR #104 (Ann Marie's form refactor + 00019)** and
+**PR #108 (RLS + reactivation + cron disable)** into a single dev → main merge.
+
+### Pre-promotion checks
+
+- [ ] `git diff main..dev --stat` reviewed — no surprise files
+- [ ] No unmerged migrations against prod (`mcp__supabase-prod__list_migrations` vs `supabase/migrations/`)
+- [ ] No service-role keys or secrets in the diff
+- [ ] PR #104 + #108 test plans both check out on dev
+
+### Promotion PR body should reference
+
+- PR #104 + PR #108 as the two bundled change sets
+- Ticket #107 for the deferred cron redesign
+- Manual prod cleanups already applied (Pod 8 activation, 10 enrollment activations, Aaron)
+- Migration 00020 already applied to prod via MCP
+
+---
+
+## Tier 1 — The cascade-unlocking feature: profile editing
+
+**Window**: ~2-3 hours, after Tier 0 deploys.
+
+### The architectural insight
+
+Multiple open tickets describe the same feature from different angles:
+
+| Ticket | What it asks for | Closed by profile-edit? |
+|---|---|---|
+| #102 | Redirect placeholder-name participants to a completion form | Yes (Mode B) |
+| #98 | Fabian asked "can I edit my profile?" | Yes (Mode A) |
+| #94 | Root cause of Unknown names | Partially — the redirect heals existing Unknowns |
+| #103 | fulfillInvitation guard against placeholder data | Reduces urgency — self-healing replaces the proactive guard |
+
+**Building this once closes 4 tickets and removes the admin burden of fixing
+names via SQL.** This is the single highest-leverage move on the board.
+
+### Architecture
+
+One page that serves two modes:
+
+```
+/profile
+  ├── Mode A: voluntary edit
+  │     - Linked from the nav
+  │     - Editable: first_name, last_name, preferred_name, contact_consent,
+  │       LinkedIn, neighborhood, work_situation
+  │     - Submit → PATCH /api/participants/me → success state
+  │
+  └── Mode B: forced completion
+        - Triggered by layout redirect when participant has placeholder data
+          (first_name = 'Unknown' OR last_name = 'Unknown')
+        - Same form, with "You need to complete your profile to continue"
+        - After successful submit, returns to the originally-requested URL
+        - Cannot be bypassed (layout enforces redirect)
+```
+
+### Implementation steps (dependency order)
+
+1. **Validation schema**: `lib/validations/participants-update.ts`
+   - Zod schema, subset of `registrationSchema`
+   - Required: first_name, last_name (non-placeholder)
+   - Optional: preferred_name, LinkedIn, neighborhood, work_situation
+
+2. **API route**: `app/api/participants/me/route.ts`
+   - PATCH endpoint
+   - Body validated by the above schema
+   - RLS via `participants_update_own` policy (already exists from 00002)
+   - Returns updated participant row
+
+3. **Server component page**: `app/(dashboard)/profile/page.tsx`
+   - Fetches own participant row via Supabase server client
+   - Renders profile-form client component
+
+4. **Form component**: `app/(dashboard)/profile/profile-form.tsx`
+   - React-hook-form + zodResolver
+   - Uses the `FormField` pattern from PR #104
+   - Pre-populated with current values
+   - Submits PATCH, shows success state
+
+5. **Layout redirect**: `app/(dashboard)/layout.tsx`
+   - After `resolveUserRoles`, check participant name fields
+   - If placeholder, redirect to `/profile?required=true&next=<originalPath>`
+   - Unless already on `/profile` or `/logout`
+
+6. **Server-side enforcement**: defense in depth in proposal-submit + vote-submit endpoints
+   - Reject participants with placeholder names with 403 + redirect hint
+   - Layout might be bypassable via direct API calls; the server has to enforce too
+
+### What this does NOT cover (deferred)
+
+- Admin "edit any participant's profile" UI (lower priority; admins have Supabase Studio)
+- Email change (out of scope; email is identity)
+- Profile photo upload (not a launch requirement)
+
+---
+
+## Tier 2 — Pulse-check polish
+
+**Window**: ~1 hour, after Tier 1 lands.
+
+### #86 — Already-submitted-this-week page state
+
+After Tier 1, this is a quick win:
+
+- Pattern is established by the profile-edit page (check current state, render conditionally)
+- `/pulse-check`: check if a `pulse_checks` row exists for this week's `scheduled_date`
+- If yes, render "Thanks, see you next week" instead of the form
+- Use existing `FormField` and dashboard chrome
+
+### #87 — Per-member pulse indicator (DEFERRED)
+
+Moderator-facing polish; participants don't see it. Push to post-launch.
+
+---
+
+## Tier 3 — Ticket cleanup
+
+**Window**: 15 min, after Tier 0 deploys.
+
+The inventory has stale state after PR #104 and PR #108. Close-out sweep:
+
+| Issue | Action | Reason |
+|---|---|---|
+| #93 (LinkedIn) | Close | Closed by PR #104 |
+| #94 (Why Unknown) | Close with comment linking to #102 + #107 | Root cause known; remediation in #102 |
+| #95 (react-hook-form) | Close | Closed by PR #104 |
+| #96 (dropdowns) | Downgrade to p2 + keep open | Trigger styled; options panel still browser-default |
+| #97 (multi-pulse) | Add roadmap note as a product question | Not a code bug — needs product decision |
+| #98 (edit profile) | Close after Tier 1 ships | Subsumed by profile-edit |
+| #99 (propose-form refactor) | Downgrade to p2 + keep open | Not addressed by #104; not blocking |
+| #102 | Close after Tier 1 ships | Implementation complete |
+| #103 | Downgrade to p2 | Self-heal replaces proactive guard |
+
+Also update `docs/OLOS-roadmap.md §6 status` to reflect actual shipped state.
+
+---
+
+## Tier 4 — Intentional deferrals
+
+These have value but don't move the launch goal. Document so they're not lost:
+
+| Ticket | Why deferred |
+|---|---|
+| #107 (cron redesign) | Multi-day work; the disable is sufficient until post-launch |
+| #105 (LinkedIn URL hardening) | Defense-in-depth; no exploit path observed |
+| #106 (form a11y) | WCAG compliance; not launch-blocking |
+| #76 (CI workflow) | High-value ops; doesn't unblock users |
+| #77 (auto-apply migrations) | High-value ops; doesn't unblock users |
+| #51 (members API) | Backlog; depends on architectural decisions in #107 |
+| #62 (User Permissions) | Backlog; not launch-blocking |
+| #65 (architecture brief refresh) | Documentation; do after launch lessons-learned |
+
+---
+
+## Architectural principles applied
+
+| Principle | Application |
+|---|---|
+| Single Responsibility | Profile-edit page has one job; redirect logic in one place; validation in one schema |
+| Don't Repeat Yourself | One form covers voluntary + forced modes; one API route for all profile updates |
+| Least Privilege | RLS on participants enforces own-row-only updates; no service-client bypass needed |
+| Defense in Depth | Layout redirect AND server-side API check; client validation + server zod |
+| Soft-delete invariant | PR #108 restored for pod_memberships; profile-edit introduces no new deletes |
+| Audit trail | Existing `participants.updated_at` (if present); follow-up in #107 |
+| Idempotent migrations | All recent migrations use `IF NOT EXISTS` / `DROP POLICY IF EXISTS` |
+| Server-authoritative state | Phase windows, role checks, RLS all server-enforced |
+
+---
+
+## Specific risks tracked
+
+1. **8 remaining inactive participants** — no pod memberships. Need to verify
+   pod registration window is still open per the late-joiner hot fix. If it's
+   not, they're stuck.
+
+2. **No revocation cron post-disable** — until #107 ships, genuinely-inactive
+   participants accumulate. Acceptable for launch window; means more manual
+   moderation post-launch.
+
+3. **Promotion PR conflict surface** — PR #104 and PR #108 both touch the
+   codebase. Verify no conflicts before merging dev → main.
+
+4. **Aaron's missing pulse_check** — he claims to have submitted one but the DB
+   shows zero. Unblocking him solved the access issue; the missing pulse-check
+   data point is still unexplained and worth a separate look post-launch.
+
+---
+
+## Cross-reference
+
+- Branch session work: `git log dev --since=2026-05-30`
+- Hot-fix PR: #108
+- Cron redesign ticket: #107
+- Architecture brief: `docs/OLOS-architecture-brief.md`
+- Auth subdoc: `lib/auth/CLAUDE.md`
+- Environment matrix: `docs/environments.md`

--- a/docs/launch-plan-2026-05-31.md
+++ b/docs/launch-plan-2026-05-31.md
@@ -259,6 +259,52 @@ These have value but don't move the launch goal. Document so they're not lost:
 
 ---
 
+## RLS observations from smoke test (2026-05-31)
+
+### Inactive-pod-membership visibility
+
+Migration 00020's `participants_select_visible` policy was designed so a
+user must have `pm_self.inactive_at IS NULL` to satisfy the EXISTS branch.
+In practice, during dev smoke-testing we noted that participants whose
+pod_memberships are inactive can still see the names of pod-mates who
+share that same pod.
+
+This is non-blocking for the launch — the visibility is scoped to pods
+the user has any historical membership in, not the whole org, and the
+exposure is name-only (not email or contact info). The policy was
+explicit about active-only on both sides, so this likely indicates either:
+
+- A test session viewed under a role that hits the `is_admin_or_owner()`
+  short-circuit, OR
+- A cached client-side view holding rows from before the membership flipped
+  to inactive, OR
+- A subtle interaction with `current_participant_id()` that returns a
+  different participant than expected when the viewer has multiple memberships
+
+Tracking as a follow-up to re-verify post-launch; not a launch blocker
+since the exposure surface is narrow (names of own pod's historical mates).
+
+### Existing read-only `/profile` page from PR #104
+
+During lint validation we discovered Ann Marie's PR #104 already shipped
+a read-only `/profile` page at `app/(dashboard)/profile/page.tsx`. This
+**changes the Tier 1 scope** in this plan:
+
+- Original: build a new `/profile` page with two modes (voluntary edit + forced completion)
+- Revised: add an **edit mode** to the existing read-only page; preserve the read mode as the default landing
+
+The existing page has all the data wiring (participant fetch, options
+grouping, enrollments). Tier 1 becomes:
+
+1. New `/profile/edit` route OR an in-page edit toggle on `/profile`
+2. New PATCH `/api/participants/me/route.ts`
+3. New zod schema for the update payload
+4. Layout-level redirect for placeholder-name participants → `/profile/edit?required=true&next=<path>`
+5. Server-side enforcement on submission routes (proposal, vote)
+
+This is a SMALLER change than the original plan estimated. Same architectural
+benefits, less code.
+
 ## Specific risks tracked
 
 1. **8 remaining inactive participants** — no pod memberships. Need to verify

--- a/docs/launch-plan-2026-05-31.md
+++ b/docs/launch-plan-2026-05-31.md
@@ -3,7 +3,9 @@
 **Date authored**: 2026-05-31
 **Cycle phase**: Solution proposal phase closing today; voting opens 2026-06-01
 **Author**: Hot-fix session bundle (PR #108, ticket #107, related)
-**Status**: Tier 0 in progress (PR #108 merged to dev, promotion to main pending)
+**Status**: Tier 0 complete (PR #109 deployed to prod 14:41 UTC). Tier 3 ticket-cleanup complete; consolidated work tracked in [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110). Tier 1 = Phase A of #110.
+
+**Update 2026-05-31 post-launch**: the original Tier 1 plan to ship #102's profile-edit redirect has been consolidated into a wider state-machine remediation tracked at [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110). The architecture review at [docs/architecture-review-onboarding-state-machine.md](./architecture-review-onboarding-state-machine.md) surfaced 23 broken edges across 6 subsystems — including a critical `ignoreDuplicates=true` bug in `fulfillInvitation()` that the original Tier 1 scope would not have caught. See roadmap §3.7 for the consolidated plan. Tickets #102, #98, #103, #107, #94 closed as completed-via-#110; #51, #87 downgraded.
 
 ---
 


### PR DESCRIPTION
## Summary

Docs-only PR — no code changes. Lands the foundational reference material for the consolidated onboarding state-machine work tracked at [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110), so subsequent code PRs (Phase A [#111](https://github.com/TheUpskillingLabs/OLOS/pull/111), Phase B, Phase C) can reference these docs at stable paths on \`dev\` and \`main\`.

## Background

The branch name reflects its origin (issue #102, profile-completion redirect). After a 7-agent architectural review surfaced 23 broken edges across 6 onboarding subsystems, #102's narrow scope was consolidated into the broader [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110). Tickets #102, #98, #103, #107, #94 closed as completed-via-#110; #51, #87 downgraded to size/s follow-ups; #86 and #97 remain independent. The 4 docs in this PR document that decision tree and the implementation plan it produced.

## Files added / modified

| File | Type | Purpose |
|---|---|---|
| \`docs/architecture-review-onboarding-state-machine.md\` | NEW (358 lines) | Full architecture review: current-state assessment with file:line citations, 2 mermaid diagrams (state machine + onboarding flow), 23-row broken-edges table, proposed unified design with reconciler + admin UI + cron v2 + RLS migrations, 14 acceptance criteria, 3-phase rollout |
| \`docs/consolidated-issue-draft-onboarding-state-machine.md\` | NEW (108 lines) | Pre-staged body for issue #110 — kept as a docs artifact for future reference / regeneration |
| \`docs/launch-plan-2026-05-31.md\` | NEW (336 lines) | Tier-by-tier launch coordination doc from the May hot-fix session. Header updated post-merge of #109 to note Tier 0 complete and consolidation into #110 |
| \`docs/OLOS-roadmap.md\` | MODIFIED (33 lines added) | New §3.7 "Cross-cutting: onboarding state-machine consolidation" describing the 3-phase rollout with subsume/downgrade ticket map. §6 entries §1.13 + §1.14 updated to note the downgrades and link-backs |

## Why now, before Phase A merges

PR #111 (Phase A) commits reference these docs by path. If Phase A merges to \`dev\` first, those references point to files that don't exist on \`dev\` yet (they only live on this branch). Landing this docs PR first creates the architectural foundation that Phase A's code implements.

## Mermaid rendering verified

All 3 mermaid diagrams (1 stateDiagram-v2, 2 flowchart) parsed and rendered cleanly via \`@mermaid-js/mermaid-cli\`. GitHub will render them inline in the doc preview.

## Verification

- [x] No code changes — only \`docs/\` paths modified
- [x] All 4 files commit history preserved across the 4 commits on this branch (rebased on \`dev\` so the linear history is clean)
- [x] Cross-references between docs are consistent (architecture review § cited in roadmap, launch plan, and consolidated issue body)

## Related

- Foundation for [#111](https://github.com/TheUpskillingLabs/OLOS/pull/111) (Phase A code) and the upcoming Phase B / Phase C PRs
- Architecture review cites \`docs/OLOS-architecture-brief.md\` invariants — preserved per §8 of the review