### PR TITLE
feat(moderator-dashboard): Poderator dashboard (chunks 1–13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ next-env.d.ts
 
 # local dev scripts (untracked utilities)
 scripts/dev/
+
+# superpowers skill runner (local tooling, not project source)
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,4 @@
 ## Subdocs
 
 - [lib/auth/CLAUDE.md](lib/auth/CLAUDE.md) — sign-in flow, role resolution, invitation flow, and the `TUL_MVP_Spec.md`-vs-implementation deviations (Issues #44, #45). Read before touching anything in `lib/auth/`, `app/api/auth/`, `app/(auth)/`, or `lib/email/`.
+- [docs/poderator-dashboard/CLAUDE.md](docs/poderator-dashboard/CLAUDE.md) — naming conventions, route structure, new DB tables, auth integration, and build order for the Poderator dashboard. Read before touching `app/(dashboard)/moderator/` or any `00019`+ migration.

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -107,7 +107,7 @@ export default async function DashboardLayout({
 
   return (
     <div className="flex min-h-screen flex-col">
-      <header className="sticky top-0 z-50 border-b border-whisper bg-[rgba(11,16,22,0.97)] backdrop-blur-sm backdrop-saturate-150">
+      <header className="sticky top-0 z-50 border-b border-whisper bg-[rgba(42,49,66,0.97)] backdrop-blur-sm backdrop-saturate-150">
         <div className="mx-auto flex h-[60px] max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
           <Link
             href="/dashboard"

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -129,7 +129,7 @@ export default async function DashboardLayout({
             )}
             {showPods && (
               <Link href="/moderator" className={navLinkClass}>
-                My Pods
+                {moderatorUser ? "Poderator" : "All pods"}
               </Link>
             )}
             {adminUser && (

--- a/app/(dashboard)/moderator/_components/pulse-response-card.tsx
+++ b/app/(dashboard)/moderator/_components/pulse-response-card.tsx
@@ -1,0 +1,151 @@
+/**
+ * Shared pulse-response card.
+ *
+ * Used by:
+ *   - The pulse review side panel (pods/[pod_id]/pulse-review-panel.tsx)
+ *     — one card per pulse for a single member.
+ *   - The "Recent pulses" feed tab (pods/[pod_id]/recent-pulses-feed.tsx)
+ *     — chronological stream of submitted pulses across the whole pod.
+ *
+ * The feed-tab variant accepts a `header` slot so it can render the
+ * member's avatar + name above the response fields; the side-panel
+ * variant omits the header (the panel title already identifies the
+ * member).
+ *
+ * Card visuals match the original ResponseCard from the side panel
+ * (border, missed-state styling); changing those visuals here is
+ * intentional and changes both call sites at once.
+ */
+import * as React from "react";
+
+export type PulseResponseLike = {
+  scheduled_date: string;
+  completed_at: string | null;
+  survey_responses: Record<string, unknown> | null;
+};
+
+export function PulseResponseCard({
+  response,
+  header,
+}: {
+  response: PulseResponseLike;
+  /** Optional content rendered above the date row (e.g. member identity). */
+  header?: React.ReactNode;
+}) {
+  const submitted = response.completed_at !== null;
+  const sr = (response.survey_responses ?? {}) as Record<string, unknown>;
+  return (
+    <div
+      className={`rounded-md border p-4 ${
+        submitted
+          ? "border-whisper bg-white/[0.02]"
+          : "border-yellow-500/20 bg-yellow-500/[0.04]"
+      }`}
+    >
+      {header && <div className="mb-3">{header}</div>}
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <div className="text-sm font-medium text-white tabular-nums">
+          {formatDate(response.scheduled_date)}
+        </div>
+        <div
+          className={`text-xs ${
+            submitted ? "text-aqua" : "text-yellow-300"
+          }`}
+        >
+          {submitted
+            ? `submitted ${formatTime(response.completed_at!)}`
+            : "missed"}
+        </div>
+      </div>
+
+      {submitted && <ResponseFields sr={sr} />}
+    </div>
+  );
+}
+
+function ResponseFields({ sr }: { sr: Record<string, unknown> }) {
+  return (
+    <dl className="space-y-2.5 text-xs">
+      <TextField sr={sr} keyName="accomplishment" label="What I did" />
+      <TextField sr={sr} keyName="highlight" label="Highlight" />
+      <TextField sr={sr} keyName="challenge" label="Challenge" />
+      <TextField sr={sr} keyName="blockers" label="Blockers" />
+      <TextField sr={sr} keyName="tailwinds" label="Tailwinds" />
+      <TextField sr={sr} keyName="mitigation_strategy" label="Mitigation" />
+      <TextField sr={sr} keyName="anything_else" label="Anything else" />
+      <ArrayField sr={sr} keyName="tools_used" label="Tools used" />
+    </dl>
+  );
+}
+
+function TextField({
+  sr,
+  keyName,
+  label,
+}: {
+  sr: Record<string, unknown>;
+  keyName: string;
+  label: string;
+}) {
+  const v = sr[keyName];
+  if (typeof v !== "string" || !v.trim()) return null;
+  return (
+    <div>
+      <dt className="mb-0.5 text-cloud/45 uppercase tracking-widest text-[10px]">
+        {label}
+      </dt>
+      <dd className="whitespace-pre-wrap text-cloud/85">{v}</dd>
+    </div>
+  );
+}
+
+function ArrayField({
+  sr,
+  keyName,
+  label,
+}: {
+  sr: Record<string, unknown>;
+  keyName: string;
+  label: string;
+}) {
+  const v = sr[keyName];
+  if (!Array.isArray(v) || v.length === 0) return null;
+  return (
+    <div>
+      <dt className="mb-0.5 text-cloud/45 uppercase tracking-widest text-[10px]">
+        {label}
+      </dt>
+      <dd className="flex flex-wrap gap-1.5">
+        {v
+          .filter((x): x is string => typeof x === "string" && !!x.trim())
+          .map((tool) => (
+            <span
+              key={tool}
+              className="rounded-full bg-white/[0.06] px-2 py-0.5 text-cloud/80"
+            >
+              {tool}
+            </span>
+          ))}
+      </dd>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/app/(dashboard)/moderator/ai-summary-block.tsx
+++ b/app/(dashboard)/moderator/ai-summary-block.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Sparkles } from "lucide-react";
+import { Sparkles, X } from "lucide-react";
 import type { PulseComment } from "@/lib/moderator/pod-insights";
 
 /**
@@ -14,6 +14,13 @@ import type { PulseComment } from "@/lib/moderator/pod-insights";
  * Same component used on both All pods (cross-pod scope) and per-pod
  * surfaces — the scope only changes what `comments` and `rangeLabel`
  * are passed in.
+ *
+ * Two paths to clipboard:
+ *   1. "Copy prompt + responses" — one-click copy, no preview
+ *   2. "Preview" — opens a modal showing the full bundle (full prompt +
+ *      every included comment, not just the first 4); modal has its own
+ *      Copy button so the user can confirm what's about to paste into
+ *      their AI tool before sending it.
  */
 export function AISummaryBlock({
   scope,
@@ -27,12 +34,14 @@ export function AISummaryBlock({
   rangeLabel: string;
 }) {
   const [copied, setCopied] = React.useState(false);
+  const [previewOpen, setPreviewOpen] = React.useState(false);
 
   const fallbackPrompt =
     "Summarize the themes across these pulse comments. Flag members or topics worth attention this week. Cite specific responses. Be descriptive, not judgmental.";
 
+  const bundle = buildBundle(prompt ?? fallbackPrompt, comments);
+
   const onCopy = async () => {
-    const bundle = buildBundle(prompt ?? fallbackPrompt, comments);
     try {
       await navigator.clipboard.writeText(bundle);
       setCopied(true);
@@ -89,7 +98,14 @@ export function AISummaryBlock({
         )}
       </div>
 
-      <div>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => setPreviewOpen(true)}
+          disabled={comments.length === 0}
+          className="rounded border border-whisper bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-cloud transition-colors hover:border-white/[0.12] hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Preview
+        </button>
         <button
           onClick={onCopy}
           disabled={comments.length === 0}
@@ -98,7 +114,116 @@ export function AISummaryBlock({
           {copied ? "Copied!" : "Copy prompt + responses"}
         </button>
       </div>
+
+      <PreviewDialog
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        bundle={bundle}
+        rangeLabel={rangeLabel}
+        scopeLabel={scopeLabel}
+        commentCount={comments.length}
+      />
     </div>
+  );
+}
+
+/**
+ * Modal preview of the AI-summary bundle. Uses the native <dialog>
+ * element — backdrop styling is in app/globals.css. The dialog renders
+ * the full text (not truncated to 4 comments like the inline preview)
+ * in a read-only textarea, with its own Copy button so the user can
+ * confirm before pasting.
+ */
+function PreviewDialog({
+  open,
+  onClose,
+  bundle,
+  rangeLabel,
+  scopeLabel,
+  commentCount,
+}: {
+  open: boolean;
+  onClose: () => void;
+  bundle: string;
+  rangeLabel: string;
+  scopeLabel: string;
+  commentCount: number;
+}) {
+  const dialogRef = React.useRef<HTMLDialogElement>(null);
+  const [dialogCopied, setDialogCopied] = React.useState(false);
+
+  React.useEffect(() => {
+    const d = dialogRef.current;
+    if (!d) return;
+    if (open && !d.open) d.showModal();
+    if (!open && d.open) d.close();
+  }, [open]);
+
+  // Reset copy feedback whenever the dialog reopens.
+  React.useEffect(() => {
+    if (open) setDialogCopied(false);
+  }, [open]);
+
+  const onDialogCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(bundle);
+      setDialogCopied(true);
+      setTimeout(() => setDialogCopied(false), 2500);
+    } catch {
+      // ignore — textarea is selectable as fallback
+    }
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      onCancel={onClose}
+      className="w-full max-w-3xl rounded-md border border-whisper bg-ink p-0 text-cloud shadow-2xl backdrop:bg-[rgba(28,34,48,0.7)]"
+    >
+      <div className="flex items-start justify-between gap-4 border-b border-whisper px-5 py-4">
+        <div>
+          <div className="mb-1 text-xs uppercase tracking-widest text-aqua/80">
+            AI summary bundle
+          </div>
+          <div className="text-xs text-cloud/70">
+            {rangeLabel} · {commentCount} response
+            {commentCount === 1 ? "" : "s"} from {scopeLabel}
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded p-1 text-cloud/60 transition-colors hover:bg-white/[0.04] hover:text-cloud"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="px-5 py-4">
+        <textarea
+          readOnly
+          value={bundle}
+          className="h-96 w-full resize-none rounded-md border border-whisper bg-midnight px-3 py-2 font-mono text-xs leading-relaxed text-cloud/90 focus-visible:border-teal focus-visible:outline-none"
+        />
+        <div className="mt-1 text-[10px] text-cloud/50">
+          This is exactly what gets copied. Select-all + ⌘C also works.
+        </div>
+      </div>
+      <div className="flex items-center justify-end gap-2 border-t border-whisper px-5 py-3">
+        <button
+          onClick={onClose}
+          className="rounded border border-whisper bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-cloud transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]"
+        >
+          Close
+        </button>
+        <button
+          onClick={onDialogCopy}
+          className="rounded bg-teal/25 px-3 py-1.5 text-xs font-medium text-aqua transition-colors hover:bg-teal/35"
+        >
+          {dialogCopied ? "Copied!" : "Copy"}
+        </button>
+      </div>
+    </dialog>
   );
 }
 

--- a/app/(dashboard)/moderator/ai-summary-block.tsx
+++ b/app/(dashboard)/moderator/ai-summary-block.tsx
@@ -89,7 +89,7 @@ export function AISummaryBlock({
         )}
       </div>
 
-      <div className="flex items-center justify-between gap-3">
+      <div>
         <button
           onClick={onCopy}
           disabled={comments.length === 0}
@@ -97,9 +97,6 @@ export function AISummaryBlock({
         >
           {copied ? "Copied!" : "Copy prompt + responses"}
         </button>
-        <div className="text-xs text-cloud/50">
-          OLOS doesn&apos;t send anything. Paste into your own AI tool.
-        </div>
       </div>
     </div>
   );

--- a/app/(dashboard)/moderator/ai-summary-block.tsx
+++ b/app/(dashboard)/moderator/ai-summary-block.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as React from "react";
+import { Sparkles } from "lucide-react";
+import type { PulseComment } from "@/lib/moderator/pod-insights";
+
+/**
+ * AI-assisted summary block (PRD §7.10.3).
+ *
+ * OLOS does not run an LLM. This block bundles recent pulse comments
+ * (initials only) with the canonical prompt from cycle_config.ai_summary_prompt
+ * and lets the poderator copy the bundle to their own AI tool.
+ *
+ * Same component used on both All pods (cross-pod scope) and per-pod
+ * surfaces — the scope only changes what `comments` and `rangeLabel`
+ * are passed in.
+ */
+export function AISummaryBlock({
+  scope,
+  prompt,
+  comments,
+  rangeLabel,
+}: {
+  scope: "pod" | "all-pods";
+  prompt: string | null;
+  comments: PulseComment[];
+  rangeLabel: string;
+}) {
+  const [copied, setCopied] = React.useState(false);
+
+  const fallbackPrompt =
+    "Summarize the themes across these pulse comments. Flag members or topics worth attention this week. Cite specific responses. Be descriptive, not judgmental.";
+
+  const onCopy = async () => {
+    const bundle = buildBundle(prompt ?? fallbackPrompt, comments);
+    try {
+      await navigator.clipboard.writeText(bundle);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // Clipboard failed (no permission or unsupported); render textarea
+      // fallback inline next render. For now, just no-op.
+    }
+  };
+
+  const scopeLabel =
+    scope === "pod" ? "this pod" : "all your pods combined";
+
+  return (
+    <div className="rounded-md border border-teal/25 bg-teal/[0.04] p-5">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <div className="mb-1 text-xs uppercase tracking-widest text-aqua/80">
+            AI-assisted summary
+          </div>
+          <div className="text-sm text-cloud/85">
+            Bundle recent pulse comments with a ready-to-use prompt and
+            paste into ChatGPT, Claude, or your AI tool of choice.
+          </div>
+        </div>
+        <Sparkles className="mt-0.5 h-5 w-5 flex-shrink-0 text-aqua/70" />
+      </div>
+
+      <div className="mb-3 max-h-48 overflow-y-auto rounded-md border border-whisper bg-ink/40 p-4">
+        <div className="mb-2 text-[10px] uppercase tracking-widest text-cloud/40">
+          Pulse comments · {rangeLabel} · {comments.length} response
+          {comments.length === 1 ? "" : "s"} from {scopeLabel}
+        </div>
+        {comments.length === 0 ? (
+          <div className="text-xs text-cloud/50">
+            No free-text comments in this range yet.
+          </div>
+        ) : (
+          <div className="space-y-2.5 text-xs text-cloud/80">
+            {comments.slice(0, 4).map((c, idx) => (
+              <div key={`${c.participant_id}:${c.scheduled_date}:${idx}`}>
+                <span className="text-cloud/45">
+                  [{c.initials} · {formatWeek(c.scheduled_date)}]
+                </span>{" "}
+                {c.text}
+              </div>
+            ))}
+            {comments.length > 4 && (
+              <div className="italic text-cloud/45">
+                …{comments.length - 4} more comments included in the copy
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <button
+          onClick={onCopy}
+          disabled={comments.length === 0}
+          className="rounded bg-teal/25 px-3 py-1.5 text-xs font-medium text-aqua transition-colors hover:bg-teal/35 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {copied ? "Copied!" : "Copy prompt + responses"}
+        </button>
+        <div className="text-xs text-cloud/50">
+          OLOS doesn&apos;t send anything. Paste into your own AI tool.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function buildBundle(prompt: string, comments: PulseComment[]): string {
+  const header = prompt.trim();
+  const body = comments
+    .map(
+      (c) =>
+        `[${c.initials} · ${formatWeek(c.scheduled_date)}] ${c.text}`
+    )
+    .join("\n\n");
+  return `${header}\n\n---\n\n${body}\n`;
+}
+
+function formatWeek(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}

--- a/app/(dashboard)/moderator/cross-pod-insights-section.tsx
+++ b/app/(dashboard)/moderator/cross-pod-insights-section.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import * as React from "react";
+import type { CrossPodInsights } from "@/lib/moderator/cross-pod-insights";
+import { AISummaryBlock } from "./ai-summary-block";
+
+/**
+ * Cross-pod pulse insights (PRD §7.9.3).
+ *
+ * Renders on the All pods view. Same shape as §7.9.2 with per-pod
+ * breakdown. Suppressed for single-pod poderators (caller decides).
+ *
+ * Range toggle behaves the same as per-pod insights — both ranges
+ * pre-computed server-side, switching is local state.
+ */
+export function CrossPodInsightsSection({
+  fourWeeks,
+  fullCycle,
+  aiSummaryPrompt,
+}: {
+  fourWeeks: CrossPodInsights;
+  fullCycle: CrossPodInsights;
+  aiSummaryPrompt: string | null;
+}) {
+  const [range, setRange] = React.useState<"4w" | "full">("4w");
+  const active = range === "4w" ? fourWeeks : fullCycle;
+
+  return (
+    <section>
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="mb-1.5 text-xs uppercase tracking-widest text-teal">
+            Across your pods
+          </div>
+          <h2 className="text-lg font-semibold text-white">Pulse insights</h2>
+        </div>
+        <RangeToggle range={range} onChange={setRange} />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/40">
+            AI tool adoption by pod
+          </div>
+          {active.topTools.length === 0 ? (
+            <div className="text-sm text-cloud/60">No AI tools named yet.</div>
+          ) : (
+            <div className="space-y-3">
+              {active.topTools.map((row) => (
+                <div key={row.tool}>
+                  <div className="mb-1 flex items-baseline justify-between gap-2">
+                    <span className="text-sm font-medium text-cloud">
+                      {row.tool}
+                    </span>
+                    <span className="text-xs tabular-nums text-cloud/60">
+                      {row.members} member{row.members === 1 ? "" : "s"} total
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {row.byPod.map((p) => (
+                      <span
+                        key={p.pod_id}
+                        className="inline-flex items-center gap-1.5 rounded-full bg-white/[0.05] px-2.5 py-0.5 text-xs text-cloud/75"
+                      >
+                        {p.pod_name}
+                        <span className="tabular-nums opacity-80">
+                          {p.members}
+                        </span>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/40">
+            Engagement comparison — this week
+          </div>
+          {active.engagement.length === 0 ? (
+            <div className="text-sm text-cloud/60">No engagement data yet.</div>
+          ) : (
+            <div className="space-y-2.5">
+              {active.engagement.map((row) => {
+                const pct = Math.round(row.thisWeekRate * 100);
+                return (
+                  <div key={row.pod_id} className="flex items-center gap-3">
+                    <div className="flex-1 truncate text-xs text-cloud/80">
+                      {row.pod_name}
+                    </div>
+                    <div className="h-2 w-40 overflow-hidden rounded-full bg-white/[0.06]">
+                      <div
+                        className={`h-full transition-[width] ${
+                          pct >= 80
+                            ? "bg-aqua"
+                            : pct >= 50
+                              ? "bg-teal"
+                              : "bg-yellow-500/70"
+                        }`}
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                    <div className="w-12 text-right text-xs tabular-nums text-cloud/70">
+                      {row.thisWeekCompleted}/{row.thisWeekTotal}
+                    </div>
+                    <div className="w-10 text-right text-xs tabular-nums text-cloud/50">
+                      {pct}%
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <AISummaryBlock
+          scope="all-pods"
+          prompt={aiSummaryPrompt}
+          comments={active.recentComments}
+          rangeLabel={range === "4w" ? "last 4 weeks" : "full cycle"}
+        />
+      </div>
+    </section>
+  );
+}
+
+function RangeToggle({
+  range,
+  onChange,
+}: {
+  range: "4w" | "full";
+  onChange: (r: "4w" | "full") => void;
+}) {
+  const baseBtn = "rounded-full px-3 py-1 font-medium transition-colors";
+  return (
+    <div className="inline-flex items-center gap-1 self-start rounded-full bg-white/[0.04] p-1 text-xs sm:self-auto">
+      <button
+        onClick={() => onChange("4w")}
+        className={`${baseBtn} ${range === "4w" ? "bg-teal/20 text-aqua" : "text-cloud/60 hover:text-cloud"}`}
+      >
+        Last 4 weeks
+      </button>
+      <button
+        onClick={() => onChange("full")}
+        className={`${baseBtn} ${range === "full" ? "bg-teal/20 text-aqua" : "text-cloud/60 hover:text-cloud"}`}
+      >
+        Full cycle
+      </button>
+    </div>
+  );
+}

--- a/app/(dashboard)/moderator/layout.tsx
+++ b/app/(dashboard)/moderator/layout.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { TooltipStateProvider } from "./tooltip-state";
+
+/**
+ * Moderator dashboard layout — wraps all routes under /moderator with
+ * the TooltipStateProvider so tooltip auto-suppression (PRD §7.8)
+ * works across the All pods view, per-pod view, and any future
+ * dashboard surfaces.
+ *
+ * The (dashboard) parent layout still owns the global nav shell.
+ */
+export default function ModeratorLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <TooltipStateProvider>{children}</TooltipStateProvider>;
+}

--- a/app/(dashboard)/moderator/page.tsx
+++ b/app/(dashboard)/moderator/page.tsx
@@ -1,22 +1,26 @@
 import Link from "next/link";
 import { Users } from "lucide-react";
-import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { resolveUserRoles, isAdmin, isModerator, can } from "@/lib/auth/roles";
 import { EmptyState, StatusBadge } from "@/app/components/ui";
+import { getPodsForUser, type PodCard } from "@/lib/moderator/pods-list";
+import { getRollup } from "@/lib/moderator/rollup";
+import type { Band, Trend } from "@/lib/moderator/pulse-health";
 
-type PodStatus = "active" | "forming" | "closed" | "inactive";
-
-const POD_STATUS_VARIANT: Record<
-  PodStatus,
-  "active" | "forming" | "inactive"
-> = {
-  active: "active",
-  forming: "forming",
-  closed: "inactive",
-  inactive: "inactive",
-};
-
+/**
+ * All pods view (PRD §7.10).
+ *
+ * RSC composition:
+ *   - cross-pod at-risk nudges (§7.2)        — deferred to chunk 8
+ *   - pod summary cards (§7.10.1)            — this chunk
+ *   - members-needing-attention rollup (§7.10.2) — this chunk
+ *   - cross-pod pulse insights (§7.9.3)      — deferred to chunk 6 of build order
+ *   - AI-assisted summary block (§7.10.3)    — deferred to chunk 7 of build order
+ *
+ * Rollup + summary cards are suppressed for single-pod poderators per
+ * PRD §7.10 (their default landing is the per-pod view).
+ */
 export default async function ModeratorPage() {
   const supabase = await createClient();
   const {
@@ -24,6 +28,8 @@ export default async function ModeratorPage() {
   } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
+  // Service client used for the moderator-dashboard queries; mirrors the
+  // pattern in the previous stub.
   const serviceClient = createServiceClient();
   const userRoles = await resolveUserRoles(serviceClient, user.id);
 
@@ -31,68 +37,16 @@ export default async function ModeratorPage() {
   if (!hasPodAccess) redirect("/cycles");
 
   const admin = isAdmin(userRoles) || can(userRoles, "pods:read");
+  const cards = await getPodsForUser(serviceClient, userRoles);
 
-  // Admins see all pods; moderators see only their assigned pods
-  let pods: {
-    pod_id: number;
-    pod_name: string;
-    status: string;
-    cycle_name: string;
-    cycle_id: number;
-  }[] = [];
+  // Single-pod poderators don't see the All pods aggregates (PRD §7.10).
+  // Admins always see the full view because their assignment count is
+  // effectively unbounded.
+  const showAggregates = admin || cards.length > 1;
 
-  if (admin) {
-    // Fetch all pods across active cycles
-    const { data: allPods } = await serviceClient
-      .from("pods")
-      .select("id, name, status, cycle_id, cycles (name)")
-      .order("created_at", { ascending: false });
-
-    pods = (allPods ?? []).map((p) => {
-      const cycle = (p.cycles as unknown) as { name: string } | null;
-      return {
-        pod_id: p.id,
-        pod_name: p.name ?? `Pod ${p.id}`,
-        status: p.status,
-        cycle_name: cycle?.name ?? "",
-        cycle_id: p.cycle_id,
-      };
-    });
-  } else {
-    // Moderator: fetch only assigned pods
-    const { data: assignments } = await serviceClient
-      .from("moderator_assignments")
-      .select(
-        "pod_id, assigned_at, pods (id, name, status, cycle_id, cycles (name))"
-      )
-      .eq("participant_id", userRoles.participantId!)
-      .is("removed_at", null)
-      .order("assigned_at", { ascending: false });
-
-    pods = (assignments ?? []).map((a) => {
-      const pod = (a.pods as unknown) as {
-        id: number;
-        name: string | null;
-        status: string;
-        cycle_id: number;
-        cycles: { name: string } | null;
-      } | null;
-      return {
-        pod_id: a.pod_id,
-        pod_name: pod?.name ?? `Pod ${a.pod_id}`,
-        status: pod?.status ?? "unknown",
-        cycle_name: pod?.cycles?.name ?? "",
-        cycle_id: pod?.cycle_id ?? 0,
-      };
-    });
-  }
-
-  // Group pods by cycle
-  const podsByCycle: Record<string, typeof pods> = {};
-  for (const pod of pods) {
-    const key = pod.cycle_name || "Other";
-    (podsByCycle[key] ??= []).push(pod);
-  }
+  const rollup = showAggregates
+    ? await getRollup(serviceClient, { podIds: cards.map((c) => c.id) })
+    : null;
 
   return (
     <div>
@@ -101,11 +55,13 @@ export default async function ModeratorPage() {
       </h1>
       <p className="mb-8 text-sm text-cloud/80">
         {admin
-          ? "All pods across cycles. Click to view pulse check responses and member activity."
-          : "Pods you are assigned to moderate. View pulse check responses and member activity."}
+          ? "Pod health across cycles. Click a card to open the per-pod dashboard."
+          : cards.length === 1
+            ? "Your assigned pod. Click to open the per-pod dashboard."
+            : "Pod health across your assignments. Click a card to open the per-pod dashboard."}
       </p>
 
-      {pods.length === 0 ? (
+      {cards.length === 0 ? (
         <EmptyState
           icon={Users}
           title={admin ? "No pods yet" : "No assigned pods"}
@@ -117,35 +73,257 @@ export default async function ModeratorPage() {
         />
       ) : (
         <div className="space-y-8">
-          {Object.entries(podsByCycle).map(([cycleName, cyclePods]) => (
-            <div key={cycleName}>
-              <h2 className="mb-3 text-xs font-medium uppercase tracking-widest text-cloud/60">
-                {cycleName}
-              </h2>
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {cyclePods.map((pod) => {
-                  const variant =
-                    POD_STATUS_VARIANT[pod.status as PodStatus] ?? "inactive";
-                  return (
-                    <Link
-                      key={pod.pod_id}
-                      href={`/pods/${pod.pod_id}`}
-                      className="rounded-md border border-whisper bg-white/[0.02] p-4 transition-colors duration-150 ease-out hover:border-white/[0.12] hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2 focus-visible:ring-offset-midnight"
-                    >
-                      <div className="flex items-center justify-between gap-3">
-                        <span className="font-semibold tracking-tight text-white">
-                          {pod.pod_name}
-                        </span>
-                        <StatusBadge variant={variant}>{pod.status}</StatusBadge>
-                      </div>
-                    </Link>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
+          <PodCardGrid cards={cards} />
+          {rollup && (
+            <RollupBlock
+              rollup={rollup}
+              podCount={cards.length}
+            />
+          )}
         </div>
       )}
+    </div>
+  );
+}
+
+// ─── Pod summary cards (§7.10.1) ─────────────────────────────────────
+
+const POD_STATUS_VARIANT: Record<string, "active" | "forming" | "inactive"> = {
+  active: "active",
+  forming: "forming",
+  closed: "inactive",
+  inactive: "inactive",
+};
+
+const TREND_ARROW: Record<Trend, string> = {
+  up: "↑",
+  down: "↓",
+  flat: "→",
+};
+
+const TREND_COLOR: Record<Trend, string> = {
+  // PRD: ↓ in completion is good (warmer); ↑ in completion is good (cooler).
+  // For pulse-health "missing", trend reads from the completion rate so
+  // we want ↑ to indicate "more completion → cooler", ↓ to be a warning.
+  up: "text-aqua",
+  down: "text-yellow-300",
+  flat: "text-cloud/50",
+};
+
+const BAND_TEXT: Record<Band, string> = {
+  healthy: "text-white",
+  warning: "text-yellow-300",
+  critical: "text-red-300",
+};
+
+function PodCardGrid({ cards }: { cards: PodCard[] }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {cards.map((card) => (
+        <PodSummaryCard key={card.id} card={card} />
+      ))}
+    </div>
+  );
+}
+
+function PodSummaryCard({ card }: { card: PodCard }) {
+  const statusVariant = POD_STATUS_VARIANT[card.status] ?? "inactive";
+  const phaseSuffix = card.phase_close_at
+    ? formatPhaseSuffix(card.phase_open_at, card.phase_close_at)
+    : null;
+
+  return (
+    <Link
+      href={`/moderator/pods/${card.id}`}
+      className="block rounded-md border border-whisper bg-white/[0.02] p-5 transition-colors duration-150 ease-out hover:border-white/[0.12] hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2 focus-visible:ring-offset-midnight"
+    >
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="mb-1.5 text-xs uppercase tracking-widest text-cloud/40">
+            Pod
+          </div>
+          <div className="truncate text-base font-semibold text-white">
+            {card.name ?? `Pod ${card.id}`}
+          </div>
+        </div>
+        <StatusBadge variant={statusVariant} withDot>
+          {card.status}
+        </StatusBadge>
+      </div>
+
+      <div className="mt-5 grid grid-cols-2 gap-3">
+        <div>
+          <div className="mb-1 text-xs text-cloud/60">Pulse this week</div>
+          <div className="flex items-baseline gap-1.5">
+            <span
+              className={`text-2xl font-bold tabular-nums ${BAND_TEXT[card.band]}`}
+            >
+              {card.missing_this_week}
+            </span>
+            <span className="text-xs text-cloud/50">missing</span>
+            <span className={`ml-auto text-xs ${TREND_COLOR[card.trend]}`}>
+              {TREND_ARROW[card.trend]}
+            </span>
+          </div>
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-cloud/60">Members</div>
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-2xl font-bold tabular-nums text-white">
+              {card.active_member_count}
+            </span>
+            <span className="text-xs text-cloud/50">active</span>
+          </div>
+        </div>
+      </div>
+
+      {(card.phase_display_name || phaseSuffix) && (
+        <div className="mt-5 border-t border-whisper pt-4 text-xs text-cloud/60">
+          {card.phase_num && (
+            <span className="text-cloud/40">Phase {card.phase_num}</span>
+          )}
+          {card.phase_num && card.phase_display_name && (
+            <span>
+              {" · "}
+              {stripPhasePrefix(card.phase_display_name)}
+            </span>
+          )}
+          {phaseSuffix && <span>{` · ${phaseSuffix}`}</span>}
+        </div>
+      )}
+    </Link>
+  );
+}
+
+function stripPhasePrefix(displayName: string): string {
+  // "Phase 4: Solution Proposals" → "Solution Proposals"
+  return displayName.replace(/^Phase \d+:\s*/, "");
+}
+
+function formatPhaseSuffix(
+  openAt: string | null,
+  closeAt: string | null
+): string | null {
+  if (!closeAt) return null;
+  const now = Date.now();
+  const close = new Date(closeAt).getTime();
+  const open = openAt ? new Date(openAt).getTime() : null;
+  const dayMs = 86_400_000;
+
+  if (open !== null && now < open) {
+    const days = Math.max(1, Math.ceil((open - now) / dayMs));
+    return `opens in ${days}d`;
+  }
+  if (now > close) return "closed";
+  const days = Math.max(1, Math.ceil((close - now) / dayMs));
+  return `closes in ${days}d`;
+}
+
+// ─── Members-needing-attention rollup (§7.10.2) ──────────────────────
+
+function RollupBlock({
+  rollup,
+  podCount,
+}: {
+  rollup: NonNullable<Awaited<ReturnType<typeof getRollup>>>;
+  podCount: number;
+}) {
+  return (
+    <section>
+      <div className="mb-3">
+        <div className="mb-1.5 text-xs uppercase tracking-widest text-teal">
+          Across your pods
+        </div>
+        <h2 className="text-lg font-semibold text-white">Members needing attention</h2>
+      </div>
+
+      <div className="rounded-md border border-teal/20 bg-teal/[0.04] p-5">
+        <div className="mb-4 flex items-center justify-between">
+          <div className="text-xs uppercase tracking-widest text-aqua/80">
+            All your pods combined
+          </div>
+          <span className="text-xs tabular-nums text-cloud/50">
+            {rollup.totalActiveMembers} member
+            {rollup.totalActiveMembers === 1 ? "" : "s"} across {podCount} pod
+            {podCount === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+          <KPI
+            label="Pulsing this week"
+            value={rollup.pulsingThisWeek.submitted}
+            valueClass="text-white"
+            inline={`of ${rollup.pulsingThisWeek.total}`}
+            sub={`${rollup.pulsingThisWeek.percent}%`}
+          />
+          <KPI
+            label="At risk"
+            value={rollup.atRisk.members}
+            valueClass={
+              rollup.atRisk.members > 0 ? "text-yellow-300" : "text-white"
+            }
+            inline="members"
+            sub={
+              rollup.atRisk.members === 0
+                ? "no pods affected"
+                : `${rollup.atRisk.podsAffected} pod${rollup.atRisk.podsAffected === 1 ? "" : "s"} affected`
+            }
+          />
+          <KPI
+            label={`Pulses this period`}
+            value={rollup.pulsesThisPeriod.submitted}
+            valueClass="text-white"
+            inline="submitted"
+            sub={`of ${rollup.pulsesThisPeriod.possible} possible · ${rollup.pulsesThisPeriod.periodWeeks}w`}
+          />
+          <KPI
+            label="Engagement trend"
+            value={`${rollup.engagementTrend.currentPercent}%`}
+            valueClass="text-white"
+            inlineNode={
+              <span className={`text-base ${TREND_COLOR[rollup.engagementTrend.trend]}`}>
+                {TREND_ARROW[rollup.engagementTrend.trend]}
+              </span>
+            }
+            sub={
+              rollup.engagementTrend.priorPercent === null
+                ? "not enough history yet"
+                : `${rollup.engagementTrend.trend === "down" ? "down" : rollup.engagementTrend.trend === "up" ? "up" : "even"} from ${rollup.engagementTrend.priorPercent}% last week`
+            }
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function KPI({
+  label,
+  value,
+  valueClass,
+  inline,
+  inlineNode,
+  sub,
+}: {
+  label: string;
+  value: React.ReactNode;
+  valueClass: string;
+  inline?: string;
+  inlineNode?: React.ReactNode;
+  sub: string;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 text-xs text-cloud/60">{label}</div>
+      <div className="flex items-baseline gap-2">
+        <span className={`text-2xl font-bold tabular-nums ${valueClass}`}>
+          {value}
+        </span>
+        {inline && <span className="text-xs text-cloud/60">{inline}</span>}
+        {inlineNode}
+      </div>
+      <div className="mt-1 text-xs tabular-nums text-cloud/50">{sub}</div>
     </div>
   );
 }

--- a/app/(dashboard)/moderator/page.tsx
+++ b/app/(dashboard)/moderator/page.tsx
@@ -6,6 +6,10 @@ import { resolveUserRoles, isAdmin, isModerator, can } from "@/lib/auth/roles";
 import { EmptyState, StatusBadge } from "@/app/components/ui";
 import { getPodsForUser, type PodCard } from "@/lib/moderator/pods-list";
 import { getRollup } from "@/lib/moderator/rollup";
+import { getCrossPodInsights } from "@/lib/moderator/cross-pod-insights";
+import { CrossPodInsightsSection } from "./cross-pod-insights-section";
+import { getUiState } from "@/lib/moderator/ui-state";
+import { Switcher } from "./switcher";
 import type { Band, Trend } from "@/lib/moderator/pulse-health";
 
 /**
@@ -37,19 +41,72 @@ export default async function ModeratorPage() {
   if (!hasPodAccess) redirect("/cycles");
 
   const admin = isAdmin(userRoles) || can(userRoles, "pods:read");
-  const cards = await getPodsForUser(serviceClient, userRoles);
+  const [cards, uiState] = await Promise.all([
+    getPodsForUser(serviceClient, userRoles),
+    getUiState(serviceClient, userRoles.participantId),
+  ]);
+
+  // PRD §7.7: first-time single-pod poderators land on their pod;
+  // first-time multi-pod poderators land here. Returning poderators
+  // land wherever they last were — if they last viewed a pod we redirect.
+  if (!admin && cards.length === 1 && uiState.last_view === null) {
+    redirect(`/moderator/pods/${cards[0].id}`);
+  }
+  if (uiState.last_view && uiState.last_view !== "all_pods") {
+    const numericId = Number(uiState.last_view);
+    if (
+      !Number.isNaN(numericId) &&
+      cards.some((c) => c.id === numericId)
+    ) {
+      redirect(`/moderator/pods/${numericId}`);
+    }
+  }
 
   // Single-pod poderators don't see the All pods aggregates (PRD §7.10).
   // Admins always see the full view because their assignment count is
   // effectively unbounded.
   const showAggregates = admin || cards.length > 1;
 
-  const rollup = showAggregates
-    ? await getRollup(serviceClient, { podIds: cards.map((c) => c.id) })
-    : null;
+  const podIds = cards.map((c) => c.id);
+  const cycleIds = Array.from(new Set(cards.map((c) => c.cycle_id)));
+
+  const [rollup, crossPodFourWeeks, crossPodFullCycle, aiPromptRow] =
+    showAggregates
+      ? await Promise.all([
+          getRollup(serviceClient, { podIds }),
+          getCrossPodInsights(serviceClient, podIds, "4w"),
+          getCrossPodInsights(serviceClient, podIds, "full"),
+          cycleIds.length > 0
+            ? serviceClient
+                .from("cycle_config")
+                .select("ai_summary_prompt")
+                .in("cycle_id", cycleIds)
+                .limit(1)
+                .maybeSingle()
+            : Promise.resolve({ data: null }),
+        ])
+      : [null, null, null, { data: null }];
+
+  const aiSummaryPrompt =
+    (aiPromptRow.data?.ai_summary_prompt as string | null) ?? null;
+
+  const switcherPods = cards.map((c) => ({
+    id: c.id,
+    name: c.name ?? `Pod ${c.id}`,
+  }));
+  const showAllPodsEntry = admin || cards.length > 1;
 
   return (
     <div>
+      {(showAllPodsEntry || cards.length > 0) && (
+        <div className="mb-4">
+          <Switcher
+            pods={switcherPods}
+            current="all_pods"
+            showAllPods={showAllPodsEntry}
+          />
+        </div>
+      )}
       <h1 className="mb-2 text-2xl font-bold tracking-tight text-white">
         {admin ? "All pods" : "My pods"}
       </h1>
@@ -78,6 +135,13 @@ export default async function ModeratorPage() {
             <RollupBlock
               rollup={rollup}
               podCount={cards.length}
+            />
+          )}
+          {crossPodFourWeeks && crossPodFullCycle && (
+            <CrossPodInsightsSection
+              fourWeeks={crossPodFourWeeks}
+              fullCycle={crossPodFullCycle}
+              aiSummaryPrompt={aiSummaryPrompt}
             />
           )}
         </div>

--- a/app/(dashboard)/moderator/page.tsx
+++ b/app/(dashboard)/moderator/page.tsx
@@ -25,7 +25,22 @@ import type { Band, Trend } from "@/lib/moderator/pulse-health";
  * Rollup + summary cards are suppressed for single-pod poderators per
  * PRD §7.10 (their default landing is the per-pod view).
  */
-export default async function ModeratorPage() {
+export default async function ModeratorPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ view?: string }>;
+}) {
+  const sp = await searchParams;
+  /**
+   * Explicit "show me All pods" intent — set by the back-arrow link on
+   * per-pod pages and by the Switcher's "All pods" item. Required to
+   * defeat the returning-poderator auto-redirect below, which would
+   * otherwise immediately bounce the user back to the pod they came
+   * from (last_view still points at it; the persist call is
+   * fire-and-forget and races the navigation).
+   */
+  const explicitAllPods = sp.view === "all";
+
   const supabase = await createClient();
   const {
     data: { user },
@@ -48,11 +63,12 @@ export default async function ModeratorPage() {
 
   // PRD §7.7: first-time single-pod poderators land on their pod;
   // first-time multi-pod poderators land here. Returning poderators
-  // land wherever they last were — if they last viewed a pod we redirect.
-  if (!admin && cards.length === 1 && uiState.last_view === null) {
+  // land wherever they last were — if they last viewed a pod we redirect,
+  // UNLESS the request explicitly opted into All pods via ?view=all.
+  if (!explicitAllPods && !admin && cards.length === 1 && uiState.last_view === null) {
     redirect(`/moderator/pods/${cards[0].id}`);
   }
-  if (uiState.last_view && uiState.last_view !== "all_pods") {
+  if (!explicitAllPods && uiState.last_view && uiState.last_view !== "all_pods") {
     const numericId = Number(uiState.last_view);
     if (
       !Number.isNaN(numericId) &&

--- a/app/(dashboard)/moderator/pods/[pod_id]/ai-summary-block.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/ai-summary-block.tsx
@@ -1,0 +1,5 @@
+// Re-export from the shared location so both per-pod and cross-pod
+// surfaces use the same component. Originally built here; moved to
+// app/(dashboard)/moderator/ when chunk 9 (cross-pod insights)
+// needed to render it too.
+export { AISummaryBlock } from "../../ai-summary-block";

--- a/app/(dashboard)/moderator/pods/[pod_id]/dismiss-button.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/dismiss-button.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { X } from "lucide-react";
+
+/**
+ * Dismiss button for an at-risk nudge card.
+ *
+ * Posts to /api/moderator/nudges/dismiss with { pod_id, nudge_key },
+ * then triggers a router refresh so the dismissed nudge disappears
+ * from the server-rendered list. The nudge will re-fire automatically
+ * when the consecutive-miss run starts over after a recovery (the
+ * derived nudge_key changes — see lib/moderator/nudges.ts).
+ *
+ * Optimistic hide: the button hides itself locally while the request
+ * is in flight to avoid flicker. On error it restores and surfaces an
+ * inline message.
+ */
+export function DismissButton({
+  podId,
+  nudgeKey,
+}: {
+  podId: number;
+  nudgeKey: string;
+}) {
+  const router = useRouter();
+  const [pending, setPending] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const onClick = async () => {
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/moderator/nudges/dismiss", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pod_id: podId, nudge_key: nudgeKey }),
+      });
+      if (!res.ok && res.status !== 204) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed");
+      setPending(false);
+    }
+  };
+
+  if (pending) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      {error && (
+        <span className="text-xs text-red-300" title={error}>
+          retry
+        </span>
+      )}
+      <button
+        onClick={onClick}
+        aria-label="Dismiss nudge"
+        title="Dismiss this nudge — it will re-fire if the condition re-trips"
+        className="rounded p-1.5 text-cloud/40 transition-colors hover:bg-white/[0.04] hover:text-cloud/70"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/app/(dashboard)/moderator/pods/[pod_id]/insights-section.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/insights-section.tsx
@@ -77,6 +77,35 @@ export function PodInsightsSection({
             <CompletionBars weekly={active.weekly} />
           )}
         </div>
+
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-5 lg:col-span-2">
+          <div className="mb-3 flex items-baseline justify-between">
+            <div className="text-xs uppercase tracking-widest text-cloud/40">
+              Response depth trend
+            </div>
+            <div className="text-[10px] text-cloud/40">
+              avg chars per submitted pulse
+            </div>
+          </div>
+          {active.depth.length === 0 ? (
+            <div className="text-sm text-cloud/60">
+              No free-text responses yet.
+            </div>
+          ) : (
+            <DepthBars depth={active.depth} />
+          )}
+        </div>
+
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/40">
+            Tailwinds vs blockers
+          </div>
+          <SentimentBlock sentiment={active.sentiment} />
+          <div className="mt-3 text-xs text-cloud/50">
+            Count of pulses mentioning each. Higher tailwinds : blockers
+            suggests momentum.
+          </div>
+        </div>
       </div>
 
       <div className="mt-4">
@@ -147,6 +176,103 @@ function CompletionBars({
           </div>
         );
       })}
+    </div>
+  );
+}
+
+function DepthBars({ depth }: { depth: PodInsights["depth"] }) {
+  // Scale bars relative to the max in-range, so trend (up or down) is
+  // legible at a glance. Absolute char count is still shown on the right.
+  const max = Math.max(1, ...depth.map((d) => d.avgChars));
+  return (
+    <div className="space-y-2.5">
+      {depth.map((d) => {
+        const pct = Math.round((d.avgChars / max) * 100);
+        return (
+          <div key={d.scheduled_date} className="flex items-center gap-3">
+            <div className="w-24 flex-shrink-0 text-xs tabular-nums text-cloud/60">
+              {formatWeek(d.scheduled_date)}
+            </div>
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-white/[0.06]">
+              <div
+                className="h-full bg-aqua/70 transition-[width]"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            <div className="w-14 text-right text-xs tabular-nums text-cloud/70">
+              {d.avgChars} ch
+            </div>
+            <div className="w-10 text-right text-xs tabular-nums text-cloud/50">
+              n={d.samples}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SentimentBlock({
+  sentiment,
+}: {
+  sentiment: PodInsights["sentiment"];
+}) {
+  if (sentiment.length === 0) {
+    return (
+      <div className="text-sm text-cloud/60">
+        No tailwind or blocker comments yet.
+      </div>
+    );
+  }
+  const totals = sentiment.reduce(
+    (acc, s) => ({
+      tailwinds: acc.tailwinds + s.tailwinds,
+      blockers: acc.blockers + s.blockers,
+    }),
+    { tailwinds: 0, blockers: 0 }
+  );
+  const ratio =
+    totals.blockers === 0
+      ? totals.tailwinds === 0
+        ? null
+        : Infinity
+      : totals.tailwinds / totals.blockers;
+  const ratioLabel =
+    ratio === null
+      ? "—"
+      : ratio === Infinity
+        ? "all tailwinds"
+        : `${ratio.toFixed(1)}×`;
+
+  // Stacked bar visualizing the in-range split.
+  const total = totals.tailwinds + totals.blockers;
+  const tailPct = total === 0 ? 0 : (totals.tailwinds / total) * 100;
+  return (
+    <div>
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <div className="text-2xl font-bold tabular-nums text-white">
+          {ratioLabel}
+        </div>
+        <div className="text-xs text-cloud/60">tailwinds : blockers</div>
+      </div>
+      <div className="flex h-2 overflow-hidden rounded-full bg-white/[0.06]">
+        <div className="h-full bg-aqua" style={{ width: `${tailPct}%` }} />
+        <div
+          className="h-full bg-yellow-400/80"
+          style={{ width: `${100 - tailPct}%` }}
+        />
+      </div>
+      <div className="mt-2 flex items-center justify-between text-[11px] tabular-nums text-cloud/60">
+        <span>
+          <span className="text-aqua">●</span> {totals.tailwinds} tailwind
+          {totals.tailwinds === 1 ? "" : "s"}
+        </span>
+        <span>
+          {totals.blockers} blocker
+          {totals.blockers === 1 ? "" : "s"}{" "}
+          <span className="text-yellow-300">●</span>
+        </span>
+      </div>
     </div>
   );
 }

--- a/app/(dashboard)/moderator/pods/[pod_id]/insights-section.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/insights-section.tsx
@@ -38,11 +38,11 @@ export function PodInsightsSection({
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <div className="rounded-md border border-whisper bg-white/[0.02] p-5">
-          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/40">
+          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/60">
             Top AI tools
           </div>
           {active.topTools.length === 0 ? (
-            <div className="text-sm text-cloud/60">No AI tools named yet.</div>
+            <div className="text-sm text-cloud/85">No AI tools named yet.</div>
           ) : (
             <div className="flex flex-wrap gap-1.5">
               {active.topTools.map((t, i) => (
@@ -62,17 +62,17 @@ export function PodInsightsSection({
               ))}
             </div>
           )}
-          <div className="mt-3 text-xs text-cloud/50">
+          <div className="mt-3 text-xs text-cloud/70">
             Count is members who named the tool, not raw mentions.
           </div>
         </div>
 
         <div className="rounded-md border border-whisper bg-white/[0.02] p-5 lg:col-span-2">
-          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/40">
+          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/60">
             Pulse completion trend
           </div>
           {active.weekly.length === 0 ? (
-            <div className="text-sm text-cloud/60">No pulse history yet.</div>
+            <div className="text-sm text-cloud/85">No pulse history yet.</div>
           ) : (
             <CompletionBars weekly={active.weekly} />
           )}
@@ -80,15 +80,15 @@ export function PodInsightsSection({
 
         <div className="rounded-md border border-whisper bg-white/[0.02] p-5 lg:col-span-2">
           <div className="mb-3 flex items-baseline justify-between">
-            <div className="text-xs uppercase tracking-widest text-cloud/40">
+            <div className="text-xs uppercase tracking-widest text-cloud/60">
               Response depth trend
             </div>
-            <div className="text-[10px] text-cloud/40">
+            <div className="text-[10px] text-cloud/60">
               avg chars per submitted pulse
             </div>
           </div>
           {active.depth.length === 0 ? (
-            <div className="text-sm text-cloud/60">
+            <div className="text-sm text-cloud/85">
               No free-text responses yet.
             </div>
           ) : (
@@ -97,11 +97,11 @@ export function PodInsightsSection({
         </div>
 
         <div className="rounded-md border border-whisper bg-white/[0.02] p-5">
-          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/40">
+          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/60">
             Tailwinds vs blockers
           </div>
           <SentimentBlock sentiment={active.sentiment} />
-          <div className="mt-3 text-xs text-cloud/50">
+          <div className="mt-3 text-xs text-cloud/70">
             Count of pulses mentioning each. Higher tailwinds : blockers
             suggests momentum.
           </div>
@@ -219,7 +219,7 @@ function SentimentBlock({
 }) {
   if (sentiment.length === 0) {
     return (
-      <div className="text-sm text-cloud/60">
+      <div className="text-sm text-cloud/85">
         No tailwind or blocker comments yet.
       </div>
     );

--- a/app/(dashboard)/moderator/pods/[pod_id]/insights-section.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/insights-section.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import * as React from "react";
+import type { PodInsights } from "@/lib/moderator/pod-insights";
+import { AISummaryBlock } from "./ai-summary-block";
+
+/**
+ * Pod-level pulse insights (PRD §7.9.2) — top AI tools across the pod
+ * + weekly completion trend. Plus the AI-assisted summary block
+ * (§7.10.3) bound to the pod scope.
+ *
+ * Range toggle: 4-week default / full cycle. Both ranges are
+ * pre-computed server-side and passed in; switching is local state.
+ */
+export function PodInsightsSection({
+  fourWeeks,
+  fullCycle,
+  aiSummaryPrompt,
+}: {
+  fourWeeks: PodInsights;
+  fullCycle: PodInsights;
+  aiSummaryPrompt: string | null;
+}) {
+  const [range, setRange] = React.useState<"4w" | "full">("4w");
+  const active = range === "4w" ? fourWeeks : fullCycle;
+
+  return (
+    <section>
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="mb-1.5 text-xs uppercase tracking-widest text-teal">
+            For this pod
+          </div>
+          <h2 className="text-lg font-semibold text-white">Pulse insights</h2>
+        </div>
+        <RangeToggle range={range} onChange={setRange} />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/40">
+            Top AI tools
+          </div>
+          {active.topTools.length === 0 ? (
+            <div className="text-sm text-cloud/60">No AI tools named yet.</div>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {active.topTools.map((t, i) => (
+                <span
+                  key={t.tool}
+                  className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs ${
+                    i === 0
+                      ? "bg-teal/25 text-aqua"
+                      : i === 1
+                        ? "bg-teal/20 text-aqua"
+                        : "bg-teal/10 text-aqua/80"
+                  }`}
+                >
+                  {t.tool}
+                  <span className="tabular-nums opacity-80">{t.members}</span>
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="mt-3 text-xs text-cloud/50">
+            Count is members who named the tool, not raw mentions.
+          </div>
+        </div>
+
+        <div className="rounded-md border border-whisper bg-white/[0.02] p-5 lg:col-span-2">
+          <div className="mb-3 text-xs uppercase tracking-widest text-cloud/40">
+            Pulse completion trend
+          </div>
+          {active.weekly.length === 0 ? (
+            <div className="text-sm text-cloud/60">No pulse history yet.</div>
+          ) : (
+            <CompletionBars weekly={active.weekly} />
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <AISummaryBlock
+          scope="pod"
+          prompt={aiSummaryPrompt}
+          comments={active.recentComments}
+          rangeLabel={range === "4w" ? "last 4 weeks" : "full cycle"}
+        />
+      </div>
+    </section>
+  );
+}
+
+function RangeToggle({
+  range,
+  onChange,
+}: {
+  range: "4w" | "full";
+  onChange: (r: "4w" | "full") => void;
+}) {
+  const baseBtn =
+    "rounded-full px-3 py-1 font-medium transition-colors";
+  return (
+    <div className="inline-flex items-center gap-1 self-start rounded-full bg-white/[0.04] p-1 text-xs sm:self-auto">
+      <button
+        onClick={() => onChange("4w")}
+        className={`${baseBtn} ${range === "4w" ? "bg-teal/20 text-aqua" : "text-cloud/60 hover:text-cloud"}`}
+      >
+        Last 4 weeks
+      </button>
+      <button
+        onClick={() => onChange("full")}
+        className={`${baseBtn} ${range === "full" ? "bg-teal/20 text-aqua" : "text-cloud/60 hover:text-cloud"}`}
+      >
+        Full cycle
+      </button>
+    </div>
+  );
+}
+
+function CompletionBars({
+  weekly,
+}: {
+  weekly: PodInsights["weekly"];
+}) {
+  return (
+    <div className="space-y-2.5">
+      {weekly.map((w) => {
+        const pct = Math.round(w.rate * 100);
+        return (
+          <div key={w.scheduled_date} className="flex items-center gap-3">
+            <div className="w-24 flex-shrink-0 text-xs tabular-nums text-cloud/60">
+              {formatWeek(w.scheduled_date)}
+            </div>
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-white/[0.06]">
+              <div
+                className="h-full bg-teal transition-[width]"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            <div className="w-14 text-right text-xs tabular-nums text-cloud/70">
+              {w.completed}/{w.total}
+            </div>
+            <div className="w-10 text-right text-xs tabular-nums text-cloud/50">
+              {pct}%
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatWeek(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}

--- a/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
@@ -1,14 +1,6 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import {
-  AlertTriangle,
-  Code2,
-  ExternalLink,
-  Folder,
-  Hash,
-  Mail,
-  Users,
-} from "lucide-react";
+import { AlertTriangle, Users } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { resolveUserRoles, isAdmin, isModeratorForPod } from "@/lib/auth/roles";
 import { StatusBadge } from "@/app/components/ui";
@@ -16,7 +8,6 @@ import { getPodDetail, type PodDetail, type RosterRow } from "@/lib/moderator/po
 import { phaseGuidance } from "@/lib/moderator/phase-guidance";
 import { getPodInsights } from "@/lib/moderator/pod-insights";
 import type { Band, Trend } from "@/lib/moderator/pulse-health";
-import { RosterTable } from "./roster-table";
 import { PodInsightsSection } from "./insights-section";
 import { DismissButton } from "./dismiss-button";
 import { Switcher } from "../../switcher";
@@ -24,6 +15,7 @@ import { PersistLastView } from "./persist-last-view";
 import { ManagedTooltip } from "../../tooltip-state";
 import { getPodsForUser } from "@/lib/moderator/pods-list";
 import { getUiState } from "@/lib/moderator/ui-state";
+import { PodContentTabs } from "./pod-content-tabs";
 
 export const dynamic = "force-dynamic";
 
@@ -33,13 +25,12 @@ export const dynamic = "force-dynamic";
  * Composition:
  *   - status header (pod + cycle + phase + pulse-health + close timestamp)
  *   - at-risk nudge cards (read-only — dismiss action is chunk 8)
- *   - phase guidance copy (§7.5 plain-English + close/open timestamps)
- *   - member roster (server-rendered, sorted by joined_at; filter/sort
+ *   - phase guidance copy (§7.5 plain-English + close-only timestamp)
+ *   - member roster (server-rendered, sorted by last activity; filter/sort
  *     persistence is step 9)
- *   - pod resources block (§7.6 deep links + missing-resource affordance)
  *
- * Roster rows are inert here. The pulse review side panel is step 4 of
- * the build order.
+ * Pod Resources (§7.6) and the second "phase opened" deadline cell were
+ * intentionally removed — see docs/PRD-moderator-dashboard.md §10.
  */
 export default async function ModeratorPodPage({
   params,
@@ -70,11 +61,9 @@ export default async function ModeratorPodPage({
     getUiState(serviceClient, userRoles.participantId),
   ]);
   if (!detail) notFound();
-  // uiState is read here for symmetry with the All pods view; the
-  // client RosterTable will pick up filter/sort from /api/moderator/ui-state
-  // when the user actually opens the roster, so we don't need to pass it
-  // through props. (Future chunk wires server→client roster state.)
-  void uiState;
+  // Pass last_pod_tab through to seed the tab wrapper. Filter/sort still
+  // hydrates from /api/moderator/ui-state in the client (see RosterTable).
+  const initialTab = uiState.last_pod_tab ?? "members";
 
   // §7.9.2 pod-level insights — pre-compute both ranges so the client
   // toggle doesn't need a round-trip. Plus the AI-summary prompt for
@@ -124,15 +113,13 @@ export default async function ModeratorPodPage({
         />
       )}
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <PhaseGuidance detail={detail} />
-        <PodResources resources={detail.resources} />
-      </div>
+      <PhaseGuidance detail={detail} />
 
-      <RosterTable
+      <PodContentTabs
         members={detail.members}
         podId={detail.id}
         podName={detail.name ?? `Pod ${detail.id}`}
+        initialTab={initialTab}
       />
 
       {fourWeeksInsights && fullCycleInsights && (
@@ -369,7 +356,7 @@ function PhaseGuidance({ detail }: { detail: PodDetail }) {
     detail.phase_num as Parameters<typeof phaseGuidance>[0]
   );
   return (
-    <div className="rounded-md border border-whisper bg-white/[0.02] p-6 lg:col-span-2">
+    <div className="rounded-md border border-whisper bg-white/[0.02] p-6">
       <ManagedTooltip
         tooltipKey="phase_guidance_header"
         content="What this phase asks of your pod. The copy is curated per phase; the deadlines come from the cycle schedule."
@@ -399,7 +386,7 @@ function PhaseGuidance({ detail }: { detail: PodDetail }) {
         </p>
       )}
 
-      <div className="grid grid-cols-2 gap-4 border-t border-whisper pt-4">
+      <div className="border-t border-whisper pt-4">
         <DeadlineCell
           label={detail.phase_is_active ? "Current phase closes" : "Phase opens"}
           when={
@@ -408,15 +395,6 @@ function PhaseGuidance({ detail }: { detail: PodDetail }) {
               : detail.phase_open_at
           }
           accent={detail.phase_is_active ? "warning" : "muted"}
-        />
-        <DeadlineCell
-          label={detail.phase_is_active ? "Phase opened" : "Phase closes"}
-          when={
-            detail.phase_is_active
-              ? detail.phase_open_at
-              : detail.phase_close_at
-          }
-          accent="muted"
         />
       </div>
     </div>
@@ -463,110 +441,6 @@ function DeadlineCell({
             : `in ${days} day${days === 1 ? "" : "s"}`}
       </div>
     </div>
-  );
-}
-
-// ─── Pod resources (§7.6) ────────────────────────────────────────────
-
-function PodResources({
-  resources,
-}: {
-  resources: PodDetail["resources"];
-}) {
-  return (
-    <div className="rounded-md border border-whisper bg-white/[0.02] p-6">
-      <div className="mb-4 text-xs uppercase tracking-widest text-cloud/40">
-        Pod resources
-      </div>
-      <div className="space-y-2">
-        <ResourceLink
-          icon={Hash}
-          label="Slack channel"
-          value={
-            resources.slack_channel_id ? `#${resources.slack_channel_id}` : null
-          }
-          href={
-            resources.slack_channel_id
-              ? `slack://channel?id=${resources.slack_channel_id}`
-              : null
-          }
-        />
-        <ResourceLink
-          icon={Folder}
-          label="Drive folder"
-          value={resources.drive_folder_id}
-          href={
-            resources.drive_folder_id
-              ? `https://drive.google.com/drive/folders/${resources.drive_folder_id}`
-              : null
-          }
-        />
-        <ResourceLink
-          icon={Code2}
-          label="GitHub repo"
-          value={resources.github_repo_url}
-          href={resources.github_repo_url}
-        />
-        <ResourceLink
-          icon={Mail}
-          label="Google Group"
-          value={null}
-          href={null}
-          // Google Group url isn't on the pods table; flagged as missing
-          // until §7.6 wiring lands.
-        />
-      </div>
-    </div>
-  );
-}
-
-function ResourceLink({
-  icon: Icon,
-  label,
-  value,
-  href,
-}: {
-  icon: typeof Hash;
-  label: string;
-  value: string | null;
-  href: string | null;
-}) {
-  if (!href) {
-    return (
-      <div className="-mx-2 flex items-center gap-3 rounded-md border border-yellow-500/20 bg-yellow-500/[0.06] px-3 py-2.5">
-        <div className="grid h-8 w-8 flex-shrink-0 place-items-center rounded bg-white/[0.04]">
-          <Icon className="h-4 w-4 text-cloud/40" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="text-sm text-cloud/70">{label}</div>
-          <div className="flex items-center gap-1.5 text-xs text-yellow-300/90">
-            <AlertTriangle className="h-3 w-3" />
-            Missing — contact staff
-          </div>
-        </div>
-      </div>
-    );
-  }
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-      className="group -mx-2 flex items-center gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-white/[0.04]"
-    >
-      <div className="grid h-8 w-8 flex-shrink-0 place-items-center rounded bg-white/[0.06]">
-        <Icon className="h-4 w-4 text-cloud/60 transition-colors group-hover:text-aqua" />
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="text-sm text-cloud transition-colors group-hover:text-white">
-          {label}
-        </div>
-        {value && (
-          <div className="truncate text-xs text-cloud/50">{value}</div>
-        )}
-      </div>
-      <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-cloud/30" />
-    </a>
   );
 }
 

--- a/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
@@ -1,0 +1,594 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import {
+  AlertTriangle,
+  Code2,
+  ExternalLink,
+  Folder,
+  Hash,
+  Mail,
+  Users,
+} from "lucide-react";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { resolveUserRoles, isAdmin, isModeratorForPod } from "@/lib/auth/roles";
+import { StatusBadge } from "@/app/components/ui";
+import { getPodDetail, type PodDetail, type RosterRow } from "@/lib/moderator/pod-detail";
+import { phaseGuidance } from "@/lib/moderator/phase-guidance";
+import type { Band, Trend } from "@/lib/moderator/pulse-health";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Per-pod view (PRD §7.1, §7.2, §7.3, §7.5, §7.6).
+ *
+ * Composition:
+ *   - status header (pod + cycle + phase + pulse-health + close timestamp)
+ *   - at-risk nudge cards (read-only — dismiss action is chunk 8)
+ *   - phase guidance copy (§7.5 plain-English + close/open timestamps)
+ *   - member roster (server-rendered, sorted by joined_at; filter/sort
+ *     persistence is step 9)
+ *   - pod resources block (§7.6 deep links + missing-resource affordance)
+ *
+ * Roster rows are inert here. The pulse review side panel is step 4 of
+ * the build order.
+ */
+export default async function ModeratorPodPage({
+  params,
+}: {
+  params: Promise<{ pod_id: string }>;
+}) {
+  const { pod_id } = await params;
+  const podId = Number.parseInt(pod_id, 10);
+  if (Number.isNaN(podId)) notFound();
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const serviceClient = createServiceClient();
+  const userRoles = await resolveUserRoles(serviceClient, user.id);
+
+  // Pod-scoped auth: admin (any pod) OR active moderator assignment for this pod.
+  if (!isAdmin(userRoles) && !isModeratorForPod(userRoles, podId)) {
+    redirect("/moderator");
+  }
+
+  const detail = await getPodDetail(serviceClient, podId);
+  if (!detail) notFound();
+
+  const atRiskMembers = detail.members.filter(
+    (m) => m.pulse_status === "at_risk" && !m.is_inactive
+  );
+
+  return (
+    <div className="space-y-8">
+      <BackLink />
+      <StatusHeader detail={detail} />
+
+      {atRiskMembers.length > 0 && (
+        <AtRiskSection
+          members={atRiskMembers}
+          podName={detail.name ?? `Pod ${detail.id}`}
+          threshold={detail.at_risk_threshold}
+        />
+      )}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <PhaseGuidance detail={detail} />
+        <PodResources resources={detail.resources} />
+      </div>
+
+      <MemberRoster members={detail.members} />
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/moderator"
+      className="inline-flex items-center gap-1.5 text-xs text-cloud/60 transition-colors hover:text-cloud"
+    >
+      ← All pods
+    </Link>
+  );
+}
+
+// ─── Status header (§7.1) ─────────────────────────────────────────────
+
+const POD_STATUS_VARIANT: Record<string, "active" | "forming" | "inactive"> = {
+  active: "active",
+  forming: "forming",
+  closed: "inactive",
+  inactive: "inactive",
+};
+
+const BAND_TEXT: Record<Band, string> = {
+  healthy: "text-white",
+  warning: "text-yellow-300",
+  critical: "text-red-300",
+};
+
+const TREND_ARROW: Record<Trend, string> = {
+  up: "↑",
+  down: "↓",
+  flat: "→",
+};
+
+const TREND_COLOR: Record<Trend, string> = {
+  up: "text-aqua",
+  down: "text-yellow-300",
+  flat: "text-cloud/50",
+};
+
+function StatusHeader({ detail }: { detail: PodDetail }) {
+  const statusVariant = POD_STATUS_VARIANT[detail.status] ?? "inactive";
+  return (
+    <header>
+      <div className="mb-1.5 text-xs uppercase tracking-widest text-cloud/40">
+        {detail.cycle_name ? `${detail.cycle_name} · Pod` : "Pod"}
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-2xl font-bold tracking-tight text-white">
+          {detail.name ?? `Pod ${detail.id}`}
+        </h1>
+        <StatusBadge variant={statusVariant} withDot>
+          {detail.status}
+        </StatusBadge>
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 gap-4 rounded-md border border-whisper bg-white/[0.02] p-5 sm:grid-cols-3">
+        <div>
+          <div className="mb-1 text-xs text-cloud/60">Phase</div>
+          <div className="text-base font-semibold text-white">
+            {detail.phase_display_name ?? "—"}
+          </div>
+          {detail.phase_close_at && (
+            <div className="mt-1 text-xs text-cloud/60">
+              {detail.phase_is_active ? "Closes" : "Opens"}:{" "}
+              <span className="tabular-nums text-cloud">
+                {formatDateTime(
+                  detail.phase_is_active
+                    ? detail.phase_close_at
+                    : detail.phase_open_at ?? detail.phase_close_at
+                )}
+              </span>
+            </div>
+          )}
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-cloud/60">Pulse this week</div>
+          <div className="flex items-baseline gap-1.5">
+            <span
+              className={`text-2xl font-bold tabular-nums ${BAND_TEXT[detail.band]}`}
+            >
+              {detail.missing_this_week}
+            </span>
+            <span className="text-xs text-cloud/50">missing</span>
+            <span className={`ml-auto text-xs ${TREND_COLOR[detail.trend]}`}>
+              {TREND_ARROW[detail.trend]}
+            </span>
+          </div>
+          <div className="mt-1 text-xs text-cloud/50">
+            band: {detail.band}
+          </div>
+        </div>
+        <div>
+          <div className="mb-1 text-xs text-cloud/60">Active members</div>
+          <div className="text-2xl font-bold tabular-nums text-white">
+            {detail.active_member_count}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ─── At-risk nudges (§7.2) ────────────────────────────────────────────
+
+function AtRiskSection({
+  members,
+  podName,
+  threshold,
+}: {
+  members: RosterRow[];
+  podName: string;
+  threshold: number;
+}) {
+  return (
+    <section>
+      <div className="mb-3 flex items-baseline justify-between">
+        <h2 className="text-lg font-semibold text-white">
+          At-risk · needs attention
+        </h2>
+        <span className="text-xs text-cloud/60">
+          {threshold}-pulse miss threshold
+        </span>
+      </div>
+      <div className="space-y-3">
+        {members.map((m) => (
+          <AtRiskCard key={m.participant_id} member={m} podName={podName} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AtRiskCard({
+  member,
+  podName,
+}: {
+  member: RosterRow;
+  podName: string;
+}) {
+  const lastActiveCopy = member.last_activity_at
+    ? `last active ${daysAgo(member.last_activity_at)} days ago`
+    : "no pulse activity yet";
+  return (
+    <div className="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-4">
+      <div className="flex items-start gap-4">
+        <div className="grid h-10 w-10 flex-shrink-0 place-items-center rounded-full bg-white/[0.08] text-sm font-semibold text-cloud">
+          {member.initials}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <span className="text-sm font-semibold text-white">
+              {member.display_name}
+            </span>
+            {member.availability_snippet && (
+              <>
+                <span className="text-xs text-cloud/50">·</span>
+                <span className="truncate text-xs text-cloud/60">
+                  {member.availability_snippet}
+                </span>
+              </>
+            )}
+          </div>
+          <div className="mt-1.5 flex flex-wrap items-center gap-2 text-sm text-yellow-300">
+            <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+            <span className="font-medium">Missed consecutive pulses</span>
+            <span className="text-cloud/40">·</span>
+            <span className="text-cloud/60">{lastActiveCopy}</span>
+          </div>
+          <div className="mt-3 flex items-center gap-2 text-xs">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-cloud/70">
+              <Users className="h-3 w-3" />
+              {podName}
+            </span>
+          </div>
+        </div>
+        {member.email && (
+          <a
+            href={`mailto:${member.email}`}
+            className="rounded bg-teal/20 px-3 py-1.5 text-xs font-medium text-aqua transition-colors hover:bg-teal/30"
+          >
+            Email
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Phase guidance (§7.5) ───────────────────────────────────────────
+
+function PhaseGuidance({ detail }: { detail: PodDetail }) {
+  const guidance = phaseGuidance(
+    detail.phase_num as Parameters<typeof phaseGuidance>[0]
+  );
+  return (
+    <div className="rounded-md border border-whisper bg-white/[0.02] p-6 lg:col-span-2">
+      <div className="mb-1.5 text-xs uppercase tracking-widest text-teal">
+        Phase guidance
+      </div>
+      <h3 className="mb-4 text-lg font-semibold text-white">
+        {detail.phase_display_name ?? "Between phases"}
+      </h3>
+
+      {guidance ? (
+        <>
+          <p className="mb-3 text-sm leading-relaxed text-cloud/85">
+            {guidance.description}
+          </p>
+          {guidance.watchFor && (
+            <p className="mb-5 text-sm leading-relaxed text-cloud/70">
+              {guidance.watchFor}
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="mb-5 text-sm leading-relaxed text-cloud/70">
+          No active phase right now. Check in with your pod about what&apos;s next.
+        </p>
+      )}
+
+      <div className="grid grid-cols-2 gap-4 border-t border-whisper pt-4">
+        <DeadlineCell
+          label={detail.phase_is_active ? "Current phase closes" : "Phase opens"}
+          when={
+            detail.phase_is_active
+              ? detail.phase_close_at
+              : detail.phase_open_at
+          }
+          accent={detail.phase_is_active ? "warning" : "muted"}
+        />
+        <DeadlineCell
+          label={detail.phase_is_active ? "Phase opened" : "Phase closes"}
+          when={
+            detail.phase_is_active
+              ? detail.phase_open_at
+              : detail.phase_close_at
+          }
+          accent="muted"
+        />
+      </div>
+    </div>
+  );
+}
+
+function DeadlineCell({
+  label,
+  when,
+  accent,
+}: {
+  label: string;
+  when: string | null;
+  accent: "warning" | "muted";
+}) {
+  if (!when) {
+    return (
+      <div>
+        <div className="mb-1.5 text-xs uppercase tracking-widest text-cloud/40">
+          {label}
+        </div>
+        <div className="text-sm text-cloud/60">—</div>
+      </div>
+    );
+  }
+  const days = daysUntil(when);
+  return (
+    <div>
+      <div className="mb-1.5 text-xs uppercase tracking-widest text-cloud/40">
+        {label}
+      </div>
+      <div className="text-sm tabular-nums text-cloud">{formatDateTime(when)}</div>
+      <div
+        className={`mt-1 text-xs ${
+          accent === "warning" && days >= 0 && days <= 2
+            ? "text-yellow-300"
+            : "text-cloud/60"
+        }`}
+      >
+        {days < 0
+          ? `${Math.abs(days)} day${Math.abs(days) === 1 ? "" : "s"} ago`
+          : days === 0
+            ? "today"
+            : `in ${days} day${days === 1 ? "" : "s"}`}
+      </div>
+    </div>
+  );
+}
+
+// ─── Pod resources (§7.6) ────────────────────────────────────────────
+
+function PodResources({
+  resources,
+}: {
+  resources: PodDetail["resources"];
+}) {
+  return (
+    <div className="rounded-md border border-whisper bg-white/[0.02] p-6">
+      <div className="mb-4 text-xs uppercase tracking-widest text-cloud/40">
+        Pod resources
+      </div>
+      <div className="space-y-2">
+        <ResourceLink
+          icon={Hash}
+          label="Slack channel"
+          value={
+            resources.slack_channel_id ? `#${resources.slack_channel_id}` : null
+          }
+          href={
+            resources.slack_channel_id
+              ? `slack://channel?id=${resources.slack_channel_id}`
+              : null
+          }
+        />
+        <ResourceLink
+          icon={Folder}
+          label="Drive folder"
+          value={resources.drive_folder_id}
+          href={
+            resources.drive_folder_id
+              ? `https://drive.google.com/drive/folders/${resources.drive_folder_id}`
+              : null
+          }
+        />
+        <ResourceLink
+          icon={Code2}
+          label="GitHub repo"
+          value={resources.github_repo_url}
+          href={resources.github_repo_url}
+        />
+        <ResourceLink
+          icon={Mail}
+          label="Google Group"
+          value={null}
+          href={null}
+          // Google Group url isn't on the pods table; flagged as missing
+          // until §7.6 wiring lands.
+        />
+      </div>
+    </div>
+  );
+}
+
+function ResourceLink({
+  icon: Icon,
+  label,
+  value,
+  href,
+}: {
+  icon: typeof Hash;
+  label: string;
+  value: string | null;
+  href: string | null;
+}) {
+  if (!href) {
+    return (
+      <div className="-mx-2 flex items-center gap-3 rounded-md border border-yellow-500/20 bg-yellow-500/[0.06] px-3 py-2.5">
+        <div className="grid h-8 w-8 flex-shrink-0 place-items-center rounded bg-white/[0.04]">
+          <Icon className="h-4 w-4 text-cloud/40" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm text-cloud/70">{label}</div>
+          <div className="flex items-center gap-1.5 text-xs text-yellow-300/90">
+            <AlertTriangle className="h-3 w-3" />
+            Missing — contact staff
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="group -mx-2 flex items-center gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-white/[0.04]"
+    >
+      <div className="grid h-8 w-8 flex-shrink-0 place-items-center rounded bg-white/[0.06]">
+        <Icon className="h-4 w-4 text-cloud/60 transition-colors group-hover:text-aqua" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-sm text-cloud transition-colors group-hover:text-white">
+          {label}
+        </div>
+        {value && (
+          <div className="truncate text-xs text-cloud/50">{value}</div>
+        )}
+      </div>
+      <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-cloud/30" />
+    </a>
+  );
+}
+
+// ─── Member roster (§7.3) ────────────────────────────────────────────
+
+const PULSE_STATUS_LABEL: Record<RosterRow["pulse_status"], string> = {
+  current: "current",
+  pending: "pending",
+  late: "late",
+  at_risk: "at risk",
+};
+
+const PULSE_STATUS_COLOR: Record<RosterRow["pulse_status"], string> = {
+  current: "bg-teal/20 text-aqua",
+  pending: "bg-white/[0.06] text-cloud/70",
+  late: "bg-yellow-500/20 text-yellow-300",
+  at_risk: "bg-red-500/20 text-red-300",
+};
+
+const AI_LEVEL_LABEL: Record<string, string> = {
+  new: "New to AI",
+  consumer: "AI consumer",
+  builder: "AI builder",
+  shipper: "AI shipper",
+};
+
+function MemberRoster({ members }: { members: RosterRow[] }) {
+  const active = members.filter((m) => !m.is_inactive);
+  const inactive = members.filter((m) => m.is_inactive);
+
+  return (
+    <section>
+      <div className="mb-3 flex items-baseline justify-between">
+        <h2 className="text-lg font-semibold text-white">Members</h2>
+        <span className="text-xs text-cloud/60">
+          {active.length} active{inactive.length > 0 && ` · ${inactive.length} inactive (hidden)`}
+        </span>
+      </div>
+      <div className="overflow-hidden rounded-md border border-whisper">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-white/[0.02]">
+            <tr className="text-xs uppercase tracking-widest text-cloud/40">
+              <th className="px-4 py-3 font-medium">Member</th>
+              <th className="px-4 py-3 font-medium">AI level</th>
+              <th className="px-4 py-3 font-medium">Availability</th>
+              <th className="px-4 py-3 font-medium">Pulse</th>
+              <th className="px-4 py-3 font-medium">Last activity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {active.map((m) => (
+              <tr
+                key={m.participant_id}
+                className="border-t border-whisper text-cloud/85"
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <div className="grid h-8 w-8 place-items-center rounded-full bg-white/[0.08] text-xs font-semibold text-cloud">
+                      {m.initials}
+                    </div>
+                    <div className="font-medium text-white">{m.display_name}</div>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-cloud/70">
+                  {AI_LEVEL_LABEL[m.ai_experience_level] ?? m.ai_experience_level}
+                </td>
+                <td className="px-4 py-3 text-cloud/70">
+                  {m.availability_snippet ?? <span className="text-cloud/40">—</span>}
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${PULSE_STATUS_COLOR[m.pulse_status]}`}
+                  >
+                    {PULSE_STATUS_LABEL[m.pulse_status]}
+                  </span>
+                </td>
+                <td className="px-4 py-3 tabular-nums text-cloud/70">
+                  {m.last_activity_at
+                    ? `${daysAgo(m.last_activity_at)} days ago`
+                    : <span className="text-cloud/40">no pulse yet</span>}
+                </td>
+              </tr>
+            ))}
+            {active.length === 0 && (
+              <tr className="border-t border-whisper">
+                <td className="px-4 py-6 text-center text-cloud/60" colSpan={5}>
+                  No active members in this pod.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+// ─── Date helpers ────────────────────────────────────────────────────
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+function daysAgo(iso: string): number {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  return Math.max(0, Math.floor(diffMs / 86_400_000));
+}
+
+function daysUntil(iso: string): number {
+  const diffMs = new Date(iso).getTime() - Date.now();
+  return Math.ceil(diffMs / 86_400_000);
+}

--- a/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
@@ -5,7 +5,6 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { resolveUserRoles, isAdmin, isModeratorForPod } from "@/lib/auth/roles";
 import { StatusBadge } from "@/app/components/ui";
 import { getPodDetail, type PodDetail, type RosterRow } from "@/lib/moderator/pod-detail";
-import { phaseGuidance } from "@/lib/moderator/phase-guidance";
 import { getPodInsights } from "@/lib/moderator/pod-insights";
 import type { Band, Trend } from "@/lib/moderator/pulse-health";
 import { PodInsightsSection } from "./insights-section";
@@ -20,17 +19,18 @@ import { PodContentTabs } from "./pod-content-tabs";
 export const dynamic = "force-dynamic";
 
 /**
- * Per-pod view (PRD §7.1, §7.2, §7.3, §7.5, §7.6).
+ * Per-pod view (PRD §7.1, §7.2, §7.3).
  *
- * Composition:
+ * Composition (top → bottom):
  *   - status header (pod + cycle + phase + pulse-health + close timestamp)
  *   - at-risk nudge cards (read-only — dismiss action is chunk 8)
- *   - phase guidance copy (§7.5 plain-English + close-only timestamp)
- *   - member roster (server-rendered, sorted by last activity; filter/sort
- *     persistence is step 9)
+ *   - pulse insights (§7.9.2 + §7.10.3 AI summary)
+ *   - members / recent-pulses tab wrapper
  *
- * Pod Resources (§7.6) and the second "phase opened" deadline cell were
- * intentionally removed — see docs/PRD-moderator-dashboard.md §10.
+ * Pod Resources (§7.6), the second "phase opened" deadline cell, and
+ * the Phase Guidance prose panel (§7.5) were intentionally removed —
+ * the phase + close timestamp already live in the status header, and
+ * the prose was judged not decision-driving.
  */
 export default async function ModeratorPodPage({
   params,
@@ -113,15 +113,6 @@ export default async function ModeratorPodPage({
         />
       )}
 
-      <PhaseGuidance detail={detail} />
-
-      <PodContentTabs
-        members={detail.members}
-        podId={detail.id}
-        podName={detail.name ?? `Pod ${detail.id}`}
-        initialTab={initialTab}
-      />
-
       {fourWeeksInsights && fullCycleInsights && (
         <PodInsightsSection
           fourWeeks={fourWeeksInsights}
@@ -129,15 +120,26 @@ export default async function ModeratorPodPage({
           aiSummaryPrompt={aiSummaryPrompt}
         />
       )}
+
+      <PodContentTabs
+        members={detail.members}
+        podId={detail.id}
+        podName={detail.name ?? `Pod ${detail.id}`}
+        initialTab={initialTab}
+      />
     </div>
   );
 }
 
 function BackLink() {
+  // ?view=all is required: /moderator auto-redirects returning poderators
+  // back to their last-viewed pod, which is the very pod we're leaving.
+  // The query param flags this as an explicit "All pods" intent so the
+  // page skips the redirect.
   return (
     <Link
-      href="/moderator"
-      className="inline-flex items-center gap-1.5 text-xs text-cloud/60 transition-colors hover:text-cloud"
+      href="/moderator?view=all"
+      className="inline-flex items-center gap-1.5 text-xs text-cloud/75 transition-colors hover:text-cloud"
     >
       ← All pods
     </Link>
@@ -349,101 +351,6 @@ function AtRiskCard({
   );
 }
 
-// ─── Phase guidance (§7.5) ───────────────────────────────────────────
-
-function PhaseGuidance({ detail }: { detail: PodDetail }) {
-  const guidance = phaseGuidance(
-    detail.phase_num as Parameters<typeof phaseGuidance>[0]
-  );
-  return (
-    <div className="rounded-md border border-whisper bg-white/[0.02] p-6">
-      <ManagedTooltip
-        tooltipKey="phase_guidance_header"
-        content="What this phase asks of your pod. The copy is curated per phase; the deadlines come from the cycle schedule."
-      >
-        <div className="mb-1.5 text-xs uppercase tracking-widest text-teal">
-          Phase guidance
-        </div>
-      </ManagedTooltip>
-      <h3 className="mb-4 text-lg font-semibold text-white">
-        {detail.phase_display_name ?? "Between phases"}
-      </h3>
-
-      {guidance ? (
-        <>
-          <p className="mb-3 text-sm leading-relaxed text-cloud/85">
-            {guidance.description}
-          </p>
-          {guidance.watchFor && (
-            <p className="mb-5 text-sm leading-relaxed text-cloud/70">
-              {guidance.watchFor}
-            </p>
-          )}
-        </>
-      ) : (
-        <p className="mb-5 text-sm leading-relaxed text-cloud/70">
-          No active phase right now. Check in with your pod about what&apos;s next.
-        </p>
-      )}
-
-      <div className="border-t border-whisper pt-4">
-        <DeadlineCell
-          label={detail.phase_is_active ? "Current phase closes" : "Phase opens"}
-          when={
-            detail.phase_is_active
-              ? detail.phase_close_at
-              : detail.phase_open_at
-          }
-          accent={detail.phase_is_active ? "warning" : "muted"}
-        />
-      </div>
-    </div>
-  );
-}
-
-function DeadlineCell({
-  label,
-  when,
-  accent,
-}: {
-  label: string;
-  when: string | null;
-  accent: "warning" | "muted";
-}) {
-  if (!when) {
-    return (
-      <div>
-        <div className="mb-1.5 text-xs uppercase tracking-widest text-cloud/40">
-          {label}
-        </div>
-        <div className="text-sm text-cloud/60">—</div>
-      </div>
-    );
-  }
-  const days = daysUntil(when);
-  return (
-    <div>
-      <div className="mb-1.5 text-xs uppercase tracking-widest text-cloud/40">
-        {label}
-      </div>
-      <div className="text-sm tabular-nums text-cloud">{formatDateTime(when)}</div>
-      <div
-        className={`mt-1 text-xs ${
-          accent === "warning" && days >= 0 && days <= 2
-            ? "text-yellow-300"
-            : "text-cloud/60"
-        }`}
-      >
-        {days < 0
-          ? `${Math.abs(days)} day${Math.abs(days) === 1 ? "" : "s"} ago`
-          : days === 0
-            ? "today"
-            : `in ${days} day${days === 1 ? "" : "s"}`}
-      </div>
-    </div>
-  );
-}
-
 // ─── Date helpers ────────────────────────────────────────────────────
 
 function formatDateTime(iso: string): string {
@@ -461,9 +368,4 @@ function formatDateTime(iso: string): string {
 function daysAgo(iso: string): number {
   const diffMs = Date.now() - new Date(iso).getTime();
   return Math.max(0, Math.floor(diffMs / 86_400_000));
-}
-
-function daysUntil(iso: string): number {
-  const diffMs = new Date(iso).getTime() - Date.now();
-  return Math.ceil(diffMs / 86_400_000);
 }

--- a/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
@@ -14,8 +14,16 @@ import { resolveUserRoles, isAdmin, isModeratorForPod } from "@/lib/auth/roles";
 import { StatusBadge } from "@/app/components/ui";
 import { getPodDetail, type PodDetail, type RosterRow } from "@/lib/moderator/pod-detail";
 import { phaseGuidance } from "@/lib/moderator/phase-guidance";
+import { getPodInsights } from "@/lib/moderator/pod-insights";
 import type { Band, Trend } from "@/lib/moderator/pulse-health";
 import { RosterTable } from "./roster-table";
+import { PodInsightsSection } from "./insights-section";
+import { DismissButton } from "./dismiss-button";
+import { Switcher } from "../../switcher";
+import { PersistLastView } from "./persist-last-view";
+import { ManagedTooltip } from "../../tooltip-state";
+import { getPodsForUser } from "@/lib/moderator/pods-list";
+import { getUiState } from "@/lib/moderator/ui-state";
 
 export const dynamic = "force-dynamic";
 
@@ -56,21 +64,61 @@ export default async function ModeratorPodPage({
     redirect("/moderator");
   }
 
-  const detail = await getPodDetail(serviceClient, podId);
+  const [detail, switcherCards, uiState] = await Promise.all([
+    getPodDetail(serviceClient, podId, userRoles.participantId),
+    getPodsForUser(serviceClient, userRoles),
+    getUiState(serviceClient, userRoles.participantId),
+  ]);
   if (!detail) notFound();
+  // uiState is read here for symmetry with the All pods view; the
+  // client RosterTable will pick up filter/sort from /api/moderator/ui-state
+  // when the user actually opens the roster, so we don't need to pass it
+  // through props. (Future chunk wires server→client roster state.)
+  void uiState;
+
+  // §7.9.2 pod-level insights — pre-compute both ranges so the client
+  // toggle doesn't need a round-trip. Plus the AI-summary prompt for
+  // §7.10.3.
+  const [fourWeeksInsights, fullCycleInsights, aiPromptRow] = await Promise.all([
+    getPodInsights(serviceClient, podId, "4w"),
+    getPodInsights(serviceClient, podId, "full"),
+    serviceClient
+      .from("cycle_config")
+      .select("ai_summary_prompt")
+      .eq("cycle_id", detail.cycle_id)
+      .maybeSingle(),
+  ]);
+  const aiSummaryPrompt =
+    (aiPromptRow.data?.ai_summary_prompt as string | null) ?? null;
 
   const atRiskMembers = detail.members.filter(
-    (m) => m.pulse_status === "at_risk" && !m.is_inactive
+    (m) => m.pulse_status === "at_risk" && !m.is_inactive && !m.nudge_dismissed
   );
+
+  const switcherPods = switcherCards.map((c) => ({
+    id: c.id,
+    name: c.name ?? `Pod ${c.id}`,
+  }));
+  const showAllPodsEntry =
+    isAdmin(userRoles) || switcherCards.length > 1;
 
   return (
     <div className="space-y-8">
-      <BackLink />
+      <PersistLastView podId={detail.id} />
+      <div className="flex items-center gap-3">
+        <BackLink />
+        <Switcher
+          pods={switcherPods}
+          current={{ pod_id: detail.id }}
+          showAllPods={showAllPodsEntry}
+        />
+      </div>
       <StatusHeader detail={detail} />
 
       {atRiskMembers.length > 0 && (
         <AtRiskSection
           members={atRiskMembers}
+          podId={detail.id}
           podName={detail.name ?? `Pod ${detail.id}`}
           threshold={detail.at_risk_threshold}
         />
@@ -86,6 +134,14 @@ export default async function ModeratorPodPage({
         podId={detail.id}
         podName={detail.name ?? `Pod ${detail.id}`}
       />
+
+      {fourWeeksInsights && fullCycleInsights && (
+        <PodInsightsSection
+          fourWeeks={fourWeeksInsights}
+          fullCycle={fullCycleInsights}
+          aiSummaryPrompt={aiSummaryPrompt}
+        />
+      )}
     </div>
   );
 }
@@ -164,7 +220,12 @@ function StatusHeader({ detail }: { detail: PodDetail }) {
           )}
         </div>
         <div>
-          <div className="mb-1 text-xs text-cloud/60">Pulse this week</div>
+          <ManagedTooltip
+            tooltipKey="pod_health_indicator"
+            content="Count of active pod members who haven't submitted this week's pulse. Banded into healthy / warning / critical by cycle-configurable thresholds."
+          >
+            <div className="mb-1 text-xs text-cloud/60">Pulse this week</div>
+          </ManagedTooltip>
           <div className="flex items-baseline gap-1.5">
             <span
               className={`text-2xl font-bold tabular-nums ${BAND_TEXT[detail.band]}`}
@@ -172,9 +233,14 @@ function StatusHeader({ detail }: { detail: PodDetail }) {
               {detail.missing_this_week}
             </span>
             <span className="text-xs text-cloud/50">missing</span>
-            <span className={`ml-auto text-xs ${TREND_COLOR[detail.trend]}`}>
-              {TREND_ARROW[detail.trend]}
-            </span>
+            <ManagedTooltip
+              tooltipKey="trend_arrow"
+              content="Trend vs. the prior 3 weeks. ↑ rising completion, ↓ falling, → flat (within 5pp tolerance)."
+            >
+              <span className={`ml-auto text-xs ${TREND_COLOR[detail.trend]}`}>
+                {TREND_ARROW[detail.trend]}
+              </span>
+            </ManagedTooltip>
           </div>
           <div className="mt-1 text-xs text-cloud/50">
             band: {detail.band}
@@ -195,10 +261,12 @@ function StatusHeader({ detail }: { detail: PodDetail }) {
 
 function AtRiskSection({
   members,
+  podId,
   podName,
   threshold,
 }: {
   members: RosterRow[];
+  podId: number;
   podName: string;
   threshold: number;
 }) {
@@ -214,7 +282,12 @@ function AtRiskSection({
       </div>
       <div className="space-y-3">
         {members.map((m) => (
-          <AtRiskCard key={m.participant_id} member={m} podName={podName} />
+          <AtRiskCard
+            key={m.participant_id}
+            member={m}
+            podId={podId}
+            podName={podName}
+          />
         ))}
       </div>
     </section>
@@ -223,9 +296,11 @@ function AtRiskSection({
 
 function AtRiskCard({
   member,
+  podId,
   podName,
 }: {
   member: RosterRow;
+  podId: number;
   podName: string;
 }) {
   const lastActiveCopy = member.last_activity_at
@@ -253,7 +328,12 @@ function AtRiskCard({
           </div>
           <div className="mt-1.5 flex flex-wrap items-center gap-2 text-sm text-yellow-300">
             <AlertTriangle className="h-4 w-4 flex-shrink-0" />
-            <span className="font-medium">Missed consecutive pulses</span>
+            <ManagedTooltip
+              tooltipKey="at_risk_nudge_type"
+              content="At-risk nudge: fires when a member misses the configured consecutive-miss threshold. System flags only — you follow up via Slack or email."
+            >
+              <span className="font-medium">Missed consecutive pulses</span>
+            </ManagedTooltip>
             <span className="text-cloud/40">·</span>
             <span className="text-cloud/60">{lastActiveCopy}</span>
           </div>
@@ -264,14 +344,19 @@ function AtRiskCard({
             </span>
           </div>
         </div>
-        {member.email && (
-          <a
-            href={`mailto:${member.email}`}
-            className="rounded bg-teal/20 px-3 py-1.5 text-xs font-medium text-aqua transition-colors hover:bg-teal/30"
-          >
-            Email
-          </a>
-        )}
+        <div className="flex items-center gap-2">
+          {member.email && (
+            <a
+              href={`mailto:${member.email}`}
+              className="rounded bg-teal/20 px-3 py-1.5 text-xs font-medium text-aqua transition-colors hover:bg-teal/30"
+            >
+              Email
+            </a>
+          )}
+          {member.nudge_key && (
+            <DismissButton podId={podId} nudgeKey={member.nudge_key} />
+          )}
+        </div>
       </div>
     </div>
   );
@@ -285,9 +370,14 @@ function PhaseGuidance({ detail }: { detail: PodDetail }) {
   );
   return (
     <div className="rounded-md border border-whisper bg-white/[0.02] p-6 lg:col-span-2">
-      <div className="mb-1.5 text-xs uppercase tracking-widest text-teal">
-        Phase guidance
-      </div>
+      <ManagedTooltip
+        tooltipKey="phase_guidance_header"
+        content="What this phase asks of your pod. The copy is curated per phase; the deadlines come from the cycle schedule."
+      >
+        <div className="mb-1.5 text-xs uppercase tracking-widest text-teal">
+          Phase guidance
+        </div>
+      </ManagedTooltip>
       <h3 className="mb-4 text-lg font-semibold text-white">
         {detail.phase_display_name ?? "Between phases"}
       </h3>

--- a/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
@@ -15,6 +15,7 @@ import { StatusBadge } from "@/app/components/ui";
 import { getPodDetail, type PodDetail, type RosterRow } from "@/lib/moderator/pod-detail";
 import { phaseGuidance } from "@/lib/moderator/phase-guidance";
 import type { Band, Trend } from "@/lib/moderator/pulse-health";
+import { RosterTable } from "./roster-table";
 
 export const dynamic = "force-dynamic";
 
@@ -80,7 +81,11 @@ export default async function ModeratorPodPage({
         <PodResources resources={detail.resources} />
       </div>
 
-      <MemberRoster members={detail.members} />
+      <RosterTable
+        members={detail.members}
+        podId={detail.id}
+        podName={detail.name ?? `Pod ${detail.id}`}
+      />
     </div>
   );
 }
@@ -472,100 +477,6 @@ function ResourceLink({
       </div>
       <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 text-cloud/30" />
     </a>
-  );
-}
-
-// ─── Member roster (§7.3) ────────────────────────────────────────────
-
-const PULSE_STATUS_LABEL: Record<RosterRow["pulse_status"], string> = {
-  current: "current",
-  pending: "pending",
-  late: "late",
-  at_risk: "at risk",
-};
-
-const PULSE_STATUS_COLOR: Record<RosterRow["pulse_status"], string> = {
-  current: "bg-teal/20 text-aqua",
-  pending: "bg-white/[0.06] text-cloud/70",
-  late: "bg-yellow-500/20 text-yellow-300",
-  at_risk: "bg-red-500/20 text-red-300",
-};
-
-const AI_LEVEL_LABEL: Record<string, string> = {
-  new: "New to AI",
-  consumer: "AI consumer",
-  builder: "AI builder",
-  shipper: "AI shipper",
-};
-
-function MemberRoster({ members }: { members: RosterRow[] }) {
-  const active = members.filter((m) => !m.is_inactive);
-  const inactive = members.filter((m) => m.is_inactive);
-
-  return (
-    <section>
-      <div className="mb-3 flex items-baseline justify-between">
-        <h2 className="text-lg font-semibold text-white">Members</h2>
-        <span className="text-xs text-cloud/60">
-          {active.length} active{inactive.length > 0 && ` · ${inactive.length} inactive (hidden)`}
-        </span>
-      </div>
-      <div className="overflow-hidden rounded-md border border-whisper">
-        <table className="w-full text-left text-sm">
-          <thead className="bg-white/[0.02]">
-            <tr className="text-xs uppercase tracking-widest text-cloud/40">
-              <th className="px-4 py-3 font-medium">Member</th>
-              <th className="px-4 py-3 font-medium">AI level</th>
-              <th className="px-4 py-3 font-medium">Availability</th>
-              <th className="px-4 py-3 font-medium">Pulse</th>
-              <th className="px-4 py-3 font-medium">Last activity</th>
-            </tr>
-          </thead>
-          <tbody>
-            {active.map((m) => (
-              <tr
-                key={m.participant_id}
-                className="border-t border-whisper text-cloud/85"
-              >
-                <td className="px-4 py-3">
-                  <div className="flex items-center gap-3">
-                    <div className="grid h-8 w-8 place-items-center rounded-full bg-white/[0.08] text-xs font-semibold text-cloud">
-                      {m.initials}
-                    </div>
-                    <div className="font-medium text-white">{m.display_name}</div>
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-cloud/70">
-                  {AI_LEVEL_LABEL[m.ai_experience_level] ?? m.ai_experience_level}
-                </td>
-                <td className="px-4 py-3 text-cloud/70">
-                  {m.availability_snippet ?? <span className="text-cloud/40">—</span>}
-                </td>
-                <td className="px-4 py-3">
-                  <span
-                    className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${PULSE_STATUS_COLOR[m.pulse_status]}`}
-                  >
-                    {PULSE_STATUS_LABEL[m.pulse_status]}
-                  </span>
-                </td>
-                <td className="px-4 py-3 tabular-nums text-cloud/70">
-                  {m.last_activity_at
-                    ? `${daysAgo(m.last_activity_at)} days ago`
-                    : <span className="text-cloud/40">no pulse yet</span>}
-                </td>
-              </tr>
-            ))}
-            {active.length === 0 && (
-              <tr className="border-t border-whisper">
-                <td className="px-4 py-6 text-center text-cloud/60" colSpan={5}>
-                  No active members in this pod.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-    </section>
   );
 }
 

--- a/app/(dashboard)/moderator/pods/[pod_id]/persist-last-view.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/persist-last-view.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import * as React from "react";
+import { persistUiState } from "../../switcher";
+
+/**
+ * Side-effect-only Client Component. On mount, records this pod as the
+ * caller's last_view so a return to /moderator redirects them back.
+ *
+ * Fires once per mount. The PUT is best-effort; failure is silent.
+ */
+export function PersistLastView({ podId }: { podId: number }) {
+  React.useEffect(() => {
+    persistUiState({ last_view: String(podId) });
+  }, [podId]);
+  return null;
+}

--- a/app/(dashboard)/moderator/pods/[pod_id]/pod-content-tabs.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/pod-content-tabs.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+import type { RosterRow } from "@/lib/moderator/pod-detail";
+import type { PodTab } from "@/lib/moderator/ui-state";
+import { RosterTable } from "./roster-table";
+import { RecentPulsesFeed } from "./recent-pulses-feed";
+import { persistUiState } from "../../switcher";
+
+/**
+ * Tabbed wrapper for the per-pod page's main content area.
+ *
+ * Two tabs:
+ *   - Members         → the existing RosterTable + pulse-review side panel
+ *   - Recent pulses   → cross-member chronological feed (chunk B)
+ *
+ * Initial tab comes from the server (read from moderator_ui_state.last_pod_tab).
+ * Every tab change persists via PUT /api/moderator/ui-state so the next
+ * visit lands on the same tab.
+ */
+
+const TABS: { value: PodTab; label: string }[] = [
+  { value: "members", label: "Members" },
+  { value: "recent_pulses", label: "Recent pulses" },
+];
+
+export function PodContentTabs({
+  members,
+  podId,
+  podName,
+  initialTab,
+}: {
+  members: RosterRow[];
+  podId: number;
+  podName: string;
+  initialTab: PodTab;
+}) {
+  const [tab, setTab] = React.useState<PodTab>(initialTab);
+
+  const onSelect = (next: PodTab) => {
+    if (next === tab) return;
+    setTab(next);
+    persistUiState({ last_pod_tab: next });
+  };
+
+  return (
+    <section>
+      <div className="mb-3 flex items-center gap-1 border-b border-whisper">
+        {TABS.map((t) => {
+          const active = t.value === tab;
+          return (
+            <button
+              key={t.value}
+              onClick={() => onSelect(t.value)}
+              className={`relative -mb-px border-b-2 px-3 py-2 text-sm transition-colors ${
+                active
+                  ? "border-aqua text-white"
+                  : "border-transparent text-cloud/60 hover:text-cloud"
+              }`}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {tab === "members" && (
+        <RosterTable members={members} podId={podId} podName={podName} />
+      )}
+      {tab === "recent_pulses" && <RecentPulsesFeed podId={podId} />}
+    </section>
+  );
+}

--- a/app/(dashboard)/moderator/pods/[pod_id]/pulse-review-panel.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/pulse-review-panel.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import * as React from "react";
+import { Sheet } from "@/app/components/ui";
+import type { RosterRow } from "@/lib/moderator/pod-detail";
+import type {
+  PulseHistoryPayload,
+  PulseResponse,
+} from "@/lib/moderator/pulse-responses";
+
+/**
+ * Pulse review side panel (PRD §7.4 + §7.9.1 aggregate).
+ *
+ * Fetches the member's pulse history on open. Read-only — no mutations,
+ * no outreach from inside OLOS (per PRD §7.4). The Slack DM affordance
+ * is intentionally a deep link; OLOS does not send anything.
+ *
+ * Inactive state when no member is selected. Re-fetches whenever
+ * `member` changes (clicking a different roster row).
+ */
+
+const AI_LEVEL_LABEL: Record<string, string> = {
+  new: "New to AI",
+  consumer: "AI consumer",
+  builder: "AI builder",
+  shipper: "AI shipper",
+};
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; data: PulseHistoryPayload }
+  | { kind: "error"; message: string };
+
+export function PulseReviewPanel({
+  open,
+  onClose,
+  member,
+  podId,
+  podName,
+}: {
+  open: boolean;
+  onClose: () => void;
+  member: RosterRow | null;
+  podId: number;
+  podName: string;
+}) {
+  const [state, setState] = React.useState<LoadState>({ kind: "idle" });
+  const [showFullCycle, setShowFullCycle] = React.useState(false);
+
+  // Fetch whenever the selected member changes while the panel is open.
+  // The pre-fetch state resets (`loading`, `showFullCycle = false`) and
+  // the resolved state are all inside this effect; the React 19 lint
+  // rule against synchronous setState in effects is flagged because of
+  // those resets, but this is the canonical fetch-on-prop-change pattern
+  // for a controlled drawer and the alternatives (Suspense + use(),
+  // remount-via-key) are heavier than warranted here.
+  React.useEffect(() => {
+    if (!open || !member) return;
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState({ kind: "loading" });
+    setShowFullCycle(false);
+    fetch(
+      `/api/moderator/pods/${podId}/pulse-responses/${member.participant_id}`
+    )
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        return (await res.json()) as PulseHistoryPayload;
+      })
+      .then((data) => {
+        if (!cancelled) setState({ kind: "loaded", data });
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setState({ kind: "error", message: err.message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, member, podId]);
+
+  if (!member) return null;
+
+  const aiLevel = AI_LEVEL_LABEL[member.ai_experience_level] ?? member.ai_experience_level;
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title={member.display_name}
+      description={`${podName} · ${aiLevel}${member.availability_snippet ? ` · ${member.availability_snippet}` : ""}`}
+      footer={
+        <div className="flex items-center justify-between text-xs text-cloud/60">
+          <span>Read-only — OLOS doesn&apos;t send messages.</span>
+          {member.email && (
+            <a
+              href={`mailto:${member.email}`}
+              className="rounded bg-teal/20 px-3 py-1.5 text-xs font-medium text-aqua transition-colors hover:bg-teal/30"
+            >
+              Email member
+            </a>
+          )}
+        </div>
+      }
+    >
+      <div className="px-6 py-5">
+        {state.kind === "loading" && (
+          <div className="text-sm text-cloud/60">Loading pulse history…</div>
+        )}
+        {state.kind === "error" && (
+          <div className="rounded-md border border-red-500/30 bg-red-500/[0.06] p-4 text-sm text-red-300">
+            Couldn&apos;t load pulse history: {state.message}
+          </div>
+        )}
+        {state.kind === "loaded" && (
+          <PanelBody
+            data={state.data}
+            showFullCycle={showFullCycle}
+            onExpand={() => setShowFullCycle(true)}
+          />
+        )}
+      </div>
+    </Sheet>
+  );
+}
+
+function PanelBody({
+  data,
+  showFullCycle,
+  onExpand,
+}: {
+  data: PulseHistoryPayload;
+  showFullCycle: boolean;
+  onExpand: () => void;
+}) {
+  const fourWeeksAgo = new Date();
+  fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
+  const cutoff = fourWeeksAgo.toISOString().slice(0, 10);
+
+  const responses = showFullCycle
+    ? data.responses
+    : data.responses.filter((r) => r.scheduled_date >= cutoff);
+
+  const hiddenCount = data.responses.length - responses.length;
+
+  return (
+    <div className="space-y-6">
+      <IndividualAggregateBlock data={data} />
+
+      <section>
+        <h3 className="mb-3 text-xs font-medium uppercase tracking-widest text-cloud/40">
+          Responses
+        </h3>
+        {responses.length === 0 ? (
+          <div className="rounded-md border border-whisper bg-white/[0.02] p-4 text-sm text-cloud/60">
+            No pulses in this range.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {responses.map((r) => (
+              <ResponseCard key={r.scheduled_date} response={r} />
+            ))}
+          </div>
+        )}
+
+        {!showFullCycle && hiddenCount > 0 && (
+          <button
+            onClick={onExpand}
+            className="mt-3 text-xs text-aqua transition-colors hover:text-white"
+          >
+            Show full cycle history ({hiddenCount} more)
+          </button>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function IndividualAggregateBlock({ data }: { data: PulseHistoryPayload }) {
+  const { aggregate } = data;
+  return (
+    <section className="rounded-md border border-teal/20 bg-teal/[0.04] p-4">
+      <div className="mb-3 text-xs uppercase tracking-widest text-aqua/80">
+        Across this cycle
+      </div>
+
+      <div className="mb-4">
+        <div className="mb-1.5 text-xs text-cloud/60">Engagement trajectory</div>
+        {aggregate.trajectory.length === 0 ? (
+          <div className="text-xs text-cloud/50">No pulses yet.</div>
+        ) : (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {aggregate.trajectory.map((dot) => (
+              <span
+                key={dot.scheduled_date}
+                title={`${dot.scheduled_date}: ${dot.submitted ? "submitted" : "missed"}`}
+                className={`h-2.5 w-2.5 rounded-full ${
+                  dot.submitted
+                    ? "bg-aqua"
+                    : "border border-cloud/40 bg-transparent"
+                }`}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <div className="mb-1.5 text-xs text-cloud/60">Top AI tools</div>
+        {aggregate.topTools.length === 0 ? (
+          <div className="text-xs text-cloud/50">None reported.</div>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {aggregate.topTools.map((t) => (
+              <span
+                key={t.tool}
+                className="inline-flex items-center gap-1.5 rounded-full bg-teal/15 px-2.5 py-0.5 text-xs text-aqua"
+              >
+                {t.tool}
+                <span className="tabular-nums opacity-80">{t.count}</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ResponseCard({ response }: { response: PulseResponse }) {
+  const submitted = response.completed_at !== null;
+  const sr = (response.survey_responses ?? {}) as Record<string, unknown>;
+  return (
+    <div
+      className={`rounded-md border p-4 ${
+        submitted
+          ? "border-whisper bg-white/[0.02]"
+          : "border-yellow-500/20 bg-yellow-500/[0.04]"
+      }`}
+    >
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <div className="text-sm font-medium text-white tabular-nums">
+          {formatDate(response.scheduled_date)}
+        </div>
+        <div
+          className={`text-xs ${
+            submitted ? "text-aqua" : "text-yellow-300"
+          }`}
+        >
+          {submitted
+            ? `submitted ${formatTime(response.completed_at!)}`
+            : "missed"}
+        </div>
+      </div>
+
+      {submitted && <ResponseFields sr={sr} />}
+    </div>
+  );
+}
+
+function ResponseFields({ sr }: { sr: Record<string, unknown> }) {
+  return (
+    <dl className="space-y-2.5 text-xs">
+      <TextField sr={sr} keyName="accomplishment" label="What I did" />
+      <TextField sr={sr} keyName="highlight" label="Highlight" />
+      <TextField sr={sr} keyName="challenge" label="Challenge" />
+      <TextField sr={sr} keyName="blockers" label="Blockers" />
+      <TextField sr={sr} keyName="tailwinds" label="Tailwinds" />
+      <TextField sr={sr} keyName="mitigation_strategy" label="Mitigation" />
+      <TextField sr={sr} keyName="anything_else" label="Anything else" />
+      <ArrayField sr={sr} keyName="tools_used" label="Tools used" />
+    </dl>
+  );
+}
+
+function TextField({
+  sr,
+  keyName,
+  label,
+}: {
+  sr: Record<string, unknown>;
+  keyName: string;
+  label: string;
+}) {
+  const v = sr[keyName];
+  if (typeof v !== "string" || !v.trim()) return null;
+  return (
+    <div>
+      <dt className="mb-0.5 text-cloud/45 uppercase tracking-widest text-[10px]">
+        {label}
+      </dt>
+      <dd className="whitespace-pre-wrap text-cloud/85">{v}</dd>
+    </div>
+  );
+}
+
+function ArrayField({
+  sr,
+  keyName,
+  label,
+}: {
+  sr: Record<string, unknown>;
+  keyName: string;
+  label: string;
+}) {
+  const v = sr[keyName];
+  if (!Array.isArray(v) || v.length === 0) return null;
+  return (
+    <div>
+      <dt className="mb-0.5 text-cloud/45 uppercase tracking-widest text-[10px]">
+        {label}
+      </dt>
+      <dd className="flex flex-wrap gap-1.5">
+        {v
+          .filter((x): x is string => typeof x === "string" && !!x.trim())
+          .map((tool) => (
+            <span
+              key={tool}
+              className="rounded-full bg-white/[0.06] px-2 py-0.5 text-cloud/80"
+            >
+              {tool}
+            </span>
+          ))}
+      </dd>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/app/(dashboard)/moderator/pods/[pod_id]/pulse-review-panel.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/pulse-review-panel.tsx
@@ -3,10 +3,8 @@
 import * as React from "react";
 import { Sheet } from "@/app/components/ui";
 import type { RosterRow } from "@/lib/moderator/pod-detail";
-import type {
-  PulseHistoryPayload,
-  PulseResponse,
-} from "@/lib/moderator/pulse-responses";
+import type { PulseHistoryPayload } from "@/lib/moderator/pulse-responses";
+import { PulseResponseCard } from "../../_components/pulse-response-card";
 
 /**
  * Pulse review side panel (PRD §7.4 + §7.9.1 aggregate).
@@ -93,17 +91,16 @@ export function PulseReviewPanel({
       title={member.display_name}
       description={`${podName} · ${aiLevel}${member.availability_snippet ? ` · ${member.availability_snippet}` : ""}`}
       footer={
-        <div className="flex items-center justify-between text-xs text-cloud/60">
-          <span>Read-only — OLOS doesn&apos;t send messages.</span>
-          {member.email && (
+        member.email ? (
+          <div className="flex items-center justify-end text-xs text-cloud/60">
             <a
               href={`mailto:${member.email}`}
               className="rounded bg-teal/20 px-3 py-1.5 text-xs font-medium text-aqua transition-colors hover:bg-teal/30"
             >
               Email member
             </a>
-          )}
-        </div>
+          </div>
+        ) : null
       }
     >
       <div className="px-6 py-5">
@@ -161,7 +158,7 @@ function PanelBody({
         ) : (
           <div className="space-y-3">
             {responses.map((r) => (
-              <ResponseCard key={r.scheduled_date} response={r} />
+              <PulseResponseCard key={r.scheduled_date} response={r} />
             ))}
           </div>
         )}
@@ -230,120 +227,3 @@ function IndividualAggregateBlock({ data }: { data: PulseHistoryPayload }) {
   );
 }
 
-function ResponseCard({ response }: { response: PulseResponse }) {
-  const submitted = response.completed_at !== null;
-  const sr = (response.survey_responses ?? {}) as Record<string, unknown>;
-  return (
-    <div
-      className={`rounded-md border p-4 ${
-        submitted
-          ? "border-whisper bg-white/[0.02]"
-          : "border-yellow-500/20 bg-yellow-500/[0.04]"
-      }`}
-    >
-      <div className="mb-3 flex items-baseline justify-between gap-3">
-        <div className="text-sm font-medium text-white tabular-nums">
-          {formatDate(response.scheduled_date)}
-        </div>
-        <div
-          className={`text-xs ${
-            submitted ? "text-aqua" : "text-yellow-300"
-          }`}
-        >
-          {submitted
-            ? `submitted ${formatTime(response.completed_at!)}`
-            : "missed"}
-        </div>
-      </div>
-
-      {submitted && <ResponseFields sr={sr} />}
-    </div>
-  );
-}
-
-function ResponseFields({ sr }: { sr: Record<string, unknown> }) {
-  return (
-    <dl className="space-y-2.5 text-xs">
-      <TextField sr={sr} keyName="accomplishment" label="What I did" />
-      <TextField sr={sr} keyName="highlight" label="Highlight" />
-      <TextField sr={sr} keyName="challenge" label="Challenge" />
-      <TextField sr={sr} keyName="blockers" label="Blockers" />
-      <TextField sr={sr} keyName="tailwinds" label="Tailwinds" />
-      <TextField sr={sr} keyName="mitigation_strategy" label="Mitigation" />
-      <TextField sr={sr} keyName="anything_else" label="Anything else" />
-      <ArrayField sr={sr} keyName="tools_used" label="Tools used" />
-    </dl>
-  );
-}
-
-function TextField({
-  sr,
-  keyName,
-  label,
-}: {
-  sr: Record<string, unknown>;
-  keyName: string;
-  label: string;
-}) {
-  const v = sr[keyName];
-  if (typeof v !== "string" || !v.trim()) return null;
-  return (
-    <div>
-      <dt className="mb-0.5 text-cloud/45 uppercase tracking-widest text-[10px]">
-        {label}
-      </dt>
-      <dd className="whitespace-pre-wrap text-cloud/85">{v}</dd>
-    </div>
-  );
-}
-
-function ArrayField({
-  sr,
-  keyName,
-  label,
-}: {
-  sr: Record<string, unknown>;
-  keyName: string;
-  label: string;
-}) {
-  const v = sr[keyName];
-  if (!Array.isArray(v) || v.length === 0) return null;
-  return (
-    <div>
-      <dt className="mb-0.5 text-cloud/45 uppercase tracking-widest text-[10px]">
-        {label}
-      </dt>
-      <dd className="flex flex-wrap gap-1.5">
-        {v
-          .filter((x): x is string => typeof x === "string" && !!x.trim())
-          .map((tool) => (
-            <span
-              key={tool}
-              className="rounded-full bg-white/[0.06] px-2 py-0.5 text-cloud/80"
-            >
-              {tool}
-            </span>
-          ))}
-      </dd>
-    </div>
-  );
-}
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}

--- a/app/(dashboard)/moderator/pods/[pod_id]/recent-pulses-feed.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/recent-pulses-feed.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import * as React from "react";
+import type {
+  RecentPulse,
+  RecentPulsesPayload,
+} from "@/lib/moderator/recent-pulses";
+import { PulseResponseCard } from "../../_components/pulse-response-card";
+
+/**
+ * "Recent pulses" feed (PRD §7.4 — read-only access to pulse responses).
+ *
+ * Loads on first mount via /api/moderator/pods/[pod_id]/recent-pulses,
+ * shows newest-first. Cursor pagination via `Load older` — pushes the
+ * oldest visible completed_at back into the API.
+ *
+ * The feed is intentionally simple: no filtering by member here (the
+ * Members tab already lets you scope to one person via the side panel).
+ * If/when cross-member filtering matters, add a select above the list.
+ */
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; payload: RecentPulsesPayload; appending: boolean }
+  | { kind: "loading-more"; payload: RecentPulsesPayload }
+  | { kind: "error"; message: string };
+
+export function RecentPulsesFeed({ podId }: { podId: number }) {
+  const [state, setState] = React.useState<LoadState>({ kind: "idle" });
+
+  // Initial load.
+  React.useEffect(() => {
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState({ kind: "loading" });
+    fetch(`/api/moderator/pods/${podId}/recent-pulses`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        return (await res.json()) as RecentPulsesPayload;
+      })
+      .then((payload) => {
+        if (!cancelled)
+          setState({ kind: "loaded", payload, appending: false });
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setState({ kind: "error", message: err.message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [podId]);
+
+  const loadMore = async () => {
+    if (state.kind !== "loaded" || !state.payload.nextCursor) return;
+    const cursor = state.payload.nextCursor;
+    const prev = state.payload;
+    setState({ kind: "loading-more", payload: prev });
+    try {
+      const res = await fetch(
+        `/api/moderator/pods/${podId}/recent-pulses?before=${encodeURIComponent(cursor)}`
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      const next = (await res.json()) as RecentPulsesPayload;
+      setState({
+        kind: "loaded",
+        payload: {
+          ...next,
+          pulses: [...prev.pulses, ...next.pulses],
+        },
+        appending: true,
+      });
+    } catch (err) {
+      setState({ kind: "error", message: (err as Error).message });
+    }
+  };
+
+  if (state.kind === "loading") {
+    return <div className="text-sm text-cloud/60">Loading pulses…</div>;
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="rounded-md border border-red-500/30 bg-red-500/[0.06] p-4 text-sm text-red-300">
+        Couldn&apos;t load recent pulses: {state.message}
+      </div>
+    );
+  }
+  if (state.kind === "idle") return null;
+
+  const payload =
+    state.kind === "loading-more" ? state.payload : state.payload;
+  const isLoadingMore = state.kind === "loading-more";
+
+  if (payload.pulses.length === 0) {
+    return (
+      <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center text-sm text-cloud/60">
+        No submitted pulses in this pod yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {payload.pulses.map((p) => (
+        <FeedCard key={`${p.participant_id}:${p.completed_at}`} pulse={p} />
+      ))}
+
+      {payload.nextCursor && (
+        <button
+          onClick={loadMore}
+          disabled={isLoadingMore}
+          className="w-full rounded-md border border-whisper bg-white/[0.02] py-2 text-xs text-aqua transition-colors hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isLoadingMore ? "Loading…" : "Load older"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function FeedCard({ pulse }: { pulse: RecentPulse }) {
+  return (
+    <PulseResponseCard
+      response={{
+        scheduled_date: pulse.scheduled_date,
+        completed_at: pulse.completed_at,
+        survey_responses: pulse.survey_responses,
+      }}
+      header={
+        <div className="flex items-center gap-3">
+          <div className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-full bg-white/[0.08] text-xs font-semibold text-cloud">
+            {pulse.initials}
+          </div>
+          <div className="text-sm font-medium text-white">
+            {pulse.display_name}
+          </div>
+        </div>
+      }
+    />
+  );
+}

--- a/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
@@ -3,16 +3,18 @@
 import * as React from "react";
 import type { RosterRow } from "@/lib/moderator/pod-detail";
 import { PulseReviewPanel } from "./pulse-review-panel";
+import { persistUiState } from "../../switcher";
+import { ManagedTooltip } from "../../tooltip-state";
+import type { RosterFilters, RosterSort } from "@/lib/moderator/ui-state";
 
 /**
- * Roster table — Client Component wrapper so each row can open the
- * pulse review side panel (§7.4). The page passes the full roster +
- * pod metadata; row click sets the selected participant and the panel
- * fetches their pulse history on demand.
+ * Roster table — Client Component with filter/sort controls and a row
+ * click that opens the pulse review side panel (§7.4).
  *
- * Per PRD: inactive members are hidden by default. A "Show inactive"
- * toggle surfaces them. Filter/sort/search persistence is step 9 of
- * the build order — this component owns local toggle state only.
+ * Filter + sort state is loaded from /api/moderator/ui-state on mount
+ * (best-effort; failures fall back to defaults) and persisted on every
+ * user change. PRD §7.7: filter/sort persist per poderator across
+ * sessions.
  */
 
 const PULSE_STATUS_LABEL: Record<RosterRow["pulse_status"], string> = {
@@ -36,6 +38,34 @@ const AI_LEVEL_LABEL: Record<string, string> = {
   shipper: "AI shipper",
 };
 
+const AI_LEVELS = ["new", "consumer", "builder", "shipper"] as const;
+const PULSE_STATUSES = ["current", "pending", "late", "at_risk"] as const;
+
+const SORT_OPTIONS: { value: RosterSort; label: string }[] = [
+  { value: "joined_at_asc", label: "Joined (oldest)" },
+  { value: "joined_at_desc", label: "Joined (newest)" },
+  { value: "name_asc", label: "Name A→Z" },
+  { value: "name_desc", label: "Name Z→A" },
+  { value: "pulse_status", label: "Pulse (at-risk first)" },
+  { value: "last_activity_desc", label: "Last activity (recent)" },
+  { value: "last_activity_asc", label: "Last activity (stale)" },
+  { value: "ai_level", label: "AI level" },
+];
+
+const PULSE_RANK: Record<RosterRow["pulse_status"], number> = {
+  at_risk: 0,
+  late: 1,
+  pending: 2,
+  current: 3,
+};
+
+const AI_RANK: Record<string, number> = {
+  new: 0,
+  consumer: 1,
+  builder: 2,
+  shipper: 3,
+};
+
 export function RosterTable({
   members,
   podId,
@@ -45,12 +75,89 @@ export function RosterTable({
   podId: number;
   podName: string;
 }) {
-  const [showInactive, setShowInactive] = React.useState(false);
+  const [filters, setFilters] = React.useState<RosterFilters>({});
+  const [sort, setSort] = React.useState<RosterSort>("joined_at_asc");
   const [selected, setSelected] = React.useState<RosterRow | null>(null);
+  const initialLoadedRef = React.useRef(false);
 
-  const active = members.filter((m) => !m.is_inactive);
-  const inactive = members.filter((m) => m.is_inactive);
-  const visible = showInactive ? members : active;
+  // Load persisted state once on mount.
+  React.useEffect(() => {
+    let cancelled = false;
+    fetch("/api/moderator/ui-state")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        if (data.roster_filters && typeof data.roster_filters === "object") {
+          setFilters(data.roster_filters as RosterFilters);
+        }
+        if (typeof data.roster_sort === "string") {
+          setSort(data.roster_sort as RosterSort);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        initialLoadedRef.current = true;
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist filters whenever they change (skip the initial load round-trip).
+  React.useEffect(() => {
+    if (!initialLoadedRef.current) return;
+    persistUiState({ roster_filters: filters as Record<string, unknown> });
+  }, [filters]);
+
+  React.useEffect(() => {
+    if (!initialLoadedRef.current) return;
+    persistUiState({ roster_sort: sort });
+  }, [sort]);
+
+  const showInactive = filters.show_inactive === true;
+  const activeCount = members.filter((m) => !m.is_inactive).length;
+  const inactiveCount = members.length - activeCount;
+
+  const visible = React.useMemo(() => {
+    let rows = members.slice();
+    if (!showInactive) rows = rows.filter((r) => !r.is_inactive);
+    if (filters.status && filters.status.length > 0) {
+      const set = new Set(filters.status);
+      rows = rows.filter((r) => set.has(r.pulse_status));
+    }
+    if (filters.ai_level && filters.ai_level.length > 0) {
+      const set = new Set(filters.ai_level);
+      rows = rows.filter((r) => set.has(r.ai_experience_level));
+    }
+    if (filters.search && filters.search.trim()) {
+      const q = filters.search.trim().toLowerCase();
+      rows = rows.filter(
+        (r) =>
+          r.display_name.toLowerCase().includes(q) ||
+          (r.email ?? "").toLowerCase().includes(q) ||
+          (r.availability_snippet ?? "").toLowerCase().includes(q)
+      );
+    }
+    rows.sort(comparatorFor(sort));
+    return rows;
+  }, [members, filters, sort, showInactive]);
+
+  const toggleStatus = (s: string) => {
+    setFilters((f) => {
+      const current = new Set(f.status ?? []);
+      if (current.has(s)) current.delete(s);
+      else current.add(s);
+      return { ...f, status: Array.from(current) };
+    });
+  };
+  const toggleAi = (s: string) => {
+    setFilters((f) => {
+      const current = new Set(f.ai_level ?? []);
+      if (current.has(s)) current.delete(s);
+      else current.add(s);
+      return { ...f, ai_level: Array.from(current) };
+    });
+  };
 
   return (
     <section>
@@ -58,12 +165,14 @@ export function RosterTable({
         <h2 className="text-lg font-semibold text-white">Members</h2>
         <div className="flex items-center gap-3 text-xs text-cloud/60">
           <span>
-            {active.length} active
-            {inactive.length > 0 && ` · ${inactive.length} inactive`}
+            {activeCount} active
+            {inactiveCount > 0 && ` · ${inactiveCount} inactive`}
           </span>
-          {inactive.length > 0 && (
+          {inactiveCount > 0 && (
             <button
-              onClick={() => setShowInactive((v) => !v)}
+              onClick={() =>
+                setFilters((f) => ({ ...f, show_inactive: !showInactive }))
+              }
               className="text-aqua transition-colors hover:text-white focus-visible:outline-none focus-visible:underline"
             >
               {showInactive ? "Hide inactive" : "Show inactive"}
@@ -71,6 +180,15 @@ export function RosterTable({
           )}
         </div>
       </div>
+
+      <RosterControls
+        filters={filters}
+        sort={sort}
+        onSearch={(v) => setFilters((f) => ({ ...f, search: v }))}
+        onToggleStatus={toggleStatus}
+        onToggleAi={toggleAi}
+        onSort={setSort}
+      />
 
       <div className="overflow-hidden rounded-md border border-whisper">
         <table className="w-full text-left text-sm">
@@ -114,11 +232,16 @@ export function RosterTable({
                   )}
                 </td>
                 <td className="px-4 py-3">
-                  <span
-                    className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${PULSE_STATUS_COLOR[m.pulse_status]}`}
+                  <ManagedTooltip
+                    tooltipKey={`pulse_status_${m.pulse_status}`}
+                    content={pulseStatusTooltip(m.pulse_status)}
                   >
-                    {PULSE_STATUS_LABEL[m.pulse_status]}
-                  </span>
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${PULSE_STATUS_COLOR[m.pulse_status]}`}
+                    >
+                      {PULSE_STATUS_LABEL[m.pulse_status]}
+                    </span>
+                  </ManagedTooltip>
                 </td>
                 <td className="px-4 py-3 tabular-nums text-cloud/70">
                   {m.last_activity_at ? (
@@ -135,9 +258,7 @@ export function RosterTable({
                   className="px-4 py-6 text-center text-cloud/60"
                   colSpan={5}
                 >
-                  {active.length === 0
-                    ? "No active members in this pod."
-                    : "No members match the current filter."}
+                  No members match the current filter.
                 </td>
               </tr>
             )}
@@ -156,7 +277,140 @@ export function RosterTable({
   );
 }
 
+function RosterControls({
+  filters,
+  sort,
+  onSearch,
+  onToggleStatus,
+  onToggleAi,
+  onSort,
+}: {
+  filters: RosterFilters;
+  sort: RosterSort;
+  onSearch: (v: string) => void;
+  onToggleStatus: (s: string) => void;
+  onToggleAi: (s: string) => void;
+  onSort: (s: RosterSort) => void;
+}) {
+  return (
+    <div className="mb-3 flex flex-wrap items-center gap-3">
+      <input
+        type="text"
+        placeholder="Search by name, email, availability…"
+        value={filters.search ?? ""}
+        onChange={(e) => onSearch(e.target.value)}
+        className="min-w-[220px] flex-1 rounded-md border border-whisper bg-white/[0.02] px-3 py-1.5 text-sm text-cloud placeholder:text-cloud/40 focus-visible:border-teal focus-visible:outline-none"
+      />
+      <FilterGroup
+        label="Pulse"
+        options={PULSE_STATUSES.map((v) => ({ value: v, label: v.replace("_", " ") }))}
+        selected={filters.status ?? []}
+        onToggle={onToggleStatus}
+      />
+      <FilterGroup
+        label="AI"
+        options={AI_LEVELS.map((v) => ({ value: v, label: v }))}
+        selected={filters.ai_level ?? []}
+        onToggle={onToggleAi}
+      />
+      <label className="inline-flex items-center gap-2 text-xs text-cloud/60">
+        <span>Sort</span>
+        <select
+          value={sort}
+          onChange={(e) => onSort(e.target.value as RosterSort)}
+          className="rounded-md border border-whisper bg-white/[0.02] px-2 py-1 text-cloud focus-visible:border-teal focus-visible:outline-none"
+        >
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value} className="bg-midnight">
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}
+
+function FilterGroup({
+  label,
+  options,
+  selected,
+  onToggle,
+}: {
+  label: string;
+  options: { value: string; label: string }[];
+  selected: string[];
+  onToggle: (v: string) => void;
+}) {
+  return (
+    <div className="inline-flex items-center gap-1.5 text-xs">
+      <span className="text-cloud/60">{label}:</span>
+      {options.map((o) => {
+        const on = selected.includes(o.value);
+        return (
+          <button
+            key={o.value}
+            onClick={() => onToggle(o.value)}
+            className={`rounded-full px-2 py-0.5 transition-colors ${
+              on
+                ? "bg-teal/25 text-aqua"
+                : "bg-white/[0.04] text-cloud/60 hover:text-cloud"
+            }`}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function comparatorFor(sort: RosterSort) {
+  return (a: RosterRow, b: RosterRow): number => {
+    switch (sort) {
+      case "joined_at_asc":
+        return a.joined_at.localeCompare(b.joined_at);
+      case "joined_at_desc":
+        return b.joined_at.localeCompare(a.joined_at);
+      case "name_asc":
+        return a.display_name.localeCompare(b.display_name);
+      case "name_desc":
+        return b.display_name.localeCompare(a.display_name);
+      case "pulse_status":
+        return PULSE_RANK[a.pulse_status] - PULSE_RANK[b.pulse_status];
+      case "last_activity_desc":
+        return (b.last_activity_at ?? "").localeCompare(
+          a.last_activity_at ?? ""
+        );
+      case "last_activity_asc":
+        return (a.last_activity_at ?? "￿").localeCompare(
+          b.last_activity_at ?? "￿"
+        );
+      case "ai_level":
+        return (
+          (AI_RANK[a.ai_experience_level] ?? 99) -
+          (AI_RANK[b.ai_experience_level] ?? 99)
+        );
+      default:
+        return 0;
+    }
+  };
+}
+
 function daysAgo(iso: string): number {
   const diffMs = Date.now() - new Date(iso).getTime();
   return Math.max(0, Math.floor(diffMs / 86_400_000));
+}
+
+function pulseStatusTooltip(status: RosterRow["pulse_status"]): string {
+  switch (status) {
+    case "current":
+      return "Submitted the most recent pulse on time.";
+    case "pending":
+      return "Most recent pulse is still in its open window (≤7 days). Not late yet.";
+    case "late":
+      return "Most recent pulse missed and the window has closed.";
+    case "at_risk":
+      return "Missed the consecutive-pulse threshold. Surfaces in the at-risk nudge list.";
+  }
 }

--- a/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import * as React from "react";
+import type { RosterRow } from "@/lib/moderator/pod-detail";
+import { PulseReviewPanel } from "./pulse-review-panel";
+
+/**
+ * Roster table — Client Component wrapper so each row can open the
+ * pulse review side panel (§7.4). The page passes the full roster +
+ * pod metadata; row click sets the selected participant and the panel
+ * fetches their pulse history on demand.
+ *
+ * Per PRD: inactive members are hidden by default. A "Show inactive"
+ * toggle surfaces them. Filter/sort/search persistence is step 9 of
+ * the build order — this component owns local toggle state only.
+ */
+
+const PULSE_STATUS_LABEL: Record<RosterRow["pulse_status"], string> = {
+  current: "current",
+  pending: "pending",
+  late: "late",
+  at_risk: "at risk",
+};
+
+const PULSE_STATUS_COLOR: Record<RosterRow["pulse_status"], string> = {
+  current: "bg-teal/20 text-aqua",
+  pending: "bg-white/[0.06] text-cloud/70",
+  late: "bg-yellow-500/20 text-yellow-300",
+  at_risk: "bg-red-500/20 text-red-300",
+};
+
+const AI_LEVEL_LABEL: Record<string, string> = {
+  new: "New to AI",
+  consumer: "AI consumer",
+  builder: "AI builder",
+  shipper: "AI shipper",
+};
+
+export function RosterTable({
+  members,
+  podId,
+  podName,
+}: {
+  members: RosterRow[];
+  podId: number;
+  podName: string;
+}) {
+  const [showInactive, setShowInactive] = React.useState(false);
+  const [selected, setSelected] = React.useState<RosterRow | null>(null);
+
+  const active = members.filter((m) => !m.is_inactive);
+  const inactive = members.filter((m) => m.is_inactive);
+  const visible = showInactive ? members : active;
+
+  return (
+    <section>
+      <div className="mb-3 flex flex-wrap items-baseline justify-between gap-3">
+        <h2 className="text-lg font-semibold text-white">Members</h2>
+        <div className="flex items-center gap-3 text-xs text-cloud/60">
+          <span>
+            {active.length} active
+            {inactive.length > 0 && ` · ${inactive.length} inactive`}
+          </span>
+          {inactive.length > 0 && (
+            <button
+              onClick={() => setShowInactive((v) => !v)}
+              className="text-aqua transition-colors hover:text-white focus-visible:outline-none focus-visible:underline"
+            >
+              {showInactive ? "Hide inactive" : "Show inactive"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-md border border-whisper">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-white/[0.02]">
+            <tr className="text-xs uppercase tracking-widest text-cloud/40">
+              <th className="px-4 py-3 font-medium">Member</th>
+              <th className="px-4 py-3 font-medium">AI level</th>
+              <th className="px-4 py-3 font-medium">Availability</th>
+              <th className="px-4 py-3 font-medium">Pulse</th>
+              <th className="px-4 py-3 font-medium">Last activity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((m) => (
+              <tr
+                key={m.participant_id}
+                onClick={() => setSelected(m)}
+                className={`cursor-pointer border-t border-whisper transition-colors hover:bg-white/[0.03] ${
+                  m.is_inactive ? "opacity-60" : ""
+                }`}
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <div className="grid h-8 w-8 place-items-center rounded-full bg-white/[0.08] text-xs font-semibold text-cloud">
+                      {m.initials}
+                    </div>
+                    <div className="font-medium text-white">{m.display_name}</div>
+                    {m.is_inactive && (
+                      <span className="rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/60">
+                        inactive
+                      </span>
+                    )}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-cloud/70">
+                  {AI_LEVEL_LABEL[m.ai_experience_level] ?? m.ai_experience_level}
+                </td>
+                <td className="px-4 py-3 text-cloud/70">
+                  {m.availability_snippet ?? (
+                    <span className="text-cloud/40">—</span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${PULSE_STATUS_COLOR[m.pulse_status]}`}
+                  >
+                    {PULSE_STATUS_LABEL[m.pulse_status]}
+                  </span>
+                </td>
+                <td className="px-4 py-3 tabular-nums text-cloud/70">
+                  {m.last_activity_at ? (
+                    `${daysAgo(m.last_activity_at)} days ago`
+                  ) : (
+                    <span className="text-cloud/40">no pulse yet</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {visible.length === 0 && (
+              <tr className="border-t border-whisper">
+                <td
+                  className="px-4 py-6 text-center text-cloud/60"
+                  colSpan={5}
+                >
+                  {active.length === 0
+                    ? "No active members in this pod."
+                    : "No members match the current filter."}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <PulseReviewPanel
+        open={selected !== null}
+        onClose={() => setSelected(null)}
+        member={selected}
+        podId={podId}
+        podName={podName}
+      />
+    </section>
+  );
+}
+
+function daysAgo(iso: string): number {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  return Math.max(0, Math.floor(diffMs / 86_400_000));
+}

--- a/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
@@ -42,13 +42,11 @@ const AI_LEVELS = ["new", "consumer", "builder", "shipper"] as const;
 const PULSE_STATUSES = ["current", "pending", "late", "at_risk"] as const;
 
 const SORT_OPTIONS: { value: RosterSort; label: string }[] = [
-  { value: "joined_at_asc", label: "Joined (oldest)" },
-  { value: "joined_at_desc", label: "Joined (newest)" },
+  { value: "last_activity_desc", label: "Last activity (recent)" },
+  { value: "last_activity_asc", label: "Last activity (stale)" },
   { value: "name_asc", label: "Name A→Z" },
   { value: "name_desc", label: "Name Z→A" },
   { value: "pulse_status", label: "Pulse (at-risk first)" },
-  { value: "last_activity_desc", label: "Last activity (recent)" },
-  { value: "last_activity_asc", label: "Last activity (stale)" },
   { value: "ai_level", label: "AI level" },
 ];
 
@@ -76,7 +74,7 @@ export function RosterTable({
   podName: string;
 }) {
   const [filters, setFilters] = React.useState<RosterFilters>({});
-  const [sort, setSort] = React.useState<RosterSort>("joined_at_asc");
+  const [sort, setSort] = React.useState<RosterSort>("last_activity_desc");
   const [selected, setSelected] = React.useState<RosterRow | null>(null);
   const initialLoadedRef = React.useRef(false);
 
@@ -117,6 +115,9 @@ export function RosterTable({
   const showInactive = filters.show_inactive === true;
   const activeCount = members.filter((m) => !m.is_inactive).length;
   const inactiveCount = members.length - activeCount;
+  const trendingCount = members.filter(
+    (m) => m.is_trending_at_risk && !m.is_inactive
+  ).length;
 
   const visible = React.useMemo(() => {
     let rows = members.slice();
@@ -190,6 +191,14 @@ export function RosterTable({
         onSort={setSort}
       />
 
+      {trendingCount > 0 && (
+        <div className="mb-3 rounded-md border border-yellow-500/20 bg-yellow-500/[0.04] px-3 py-2 text-xs text-yellow-200/90">
+          {trendingCount === 1
+            ? "1 member trending — one miss from at-risk."
+            : `${trendingCount} members trending — one miss from at-risk.`}
+        </div>
+      )}
+
       <div className="overflow-hidden rounded-md border border-whisper">
         <table className="w-full text-left text-sm">
           <thead className="bg-white/[0.02]">
@@ -232,23 +241,50 @@ export function RosterTable({
                   )}
                 </td>
                 <td className="px-4 py-3">
-                  <ManagedTooltip
-                    tooltipKey={`pulse_status_${m.pulse_status}`}
-                    content={pulseStatusTooltip(m.pulse_status)}
-                  >
-                    <span
-                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${PULSE_STATUS_COLOR[m.pulse_status]}`}
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <ManagedTooltip
+                      tooltipKey={`pulse_status_${m.pulse_status}`}
+                      content={pulseStatusTooltip(m.pulse_status)}
                     >
-                      {PULSE_STATUS_LABEL[m.pulse_status]}
-                    </span>
-                  </ManagedTooltip>
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${PULSE_STATUS_COLOR[m.pulse_status]}`}
+                      >
+                        {PULSE_STATUS_LABEL[m.pulse_status]}
+                      </span>
+                    </ManagedTooltip>
+                    {m.is_trending_at_risk && (
+                      <ManagedTooltip
+                        tooltipKey="trending_at_risk"
+                        content="Trending toward at-risk: one more missed pulse and this member crosses the at-risk threshold."
+                      >
+                        <span className="inline-flex rounded-full bg-yellow-500/20 px-2 py-0.5 text-xs font-medium text-yellow-300">
+                          trending
+                        </span>
+                      </ManagedTooltip>
+                    )}
+                  </div>
                 </td>
                 <td className="px-4 py-3 tabular-nums text-cloud/70">
-                  {m.last_activity_at ? (
-                    `${daysAgo(m.last_activity_at)} days ago`
-                  ) : (
-                    <span className="text-cloud/40">no pulse yet</span>
-                  )}
+                  <div className="flex items-center gap-2">
+                    {m.last_activity_at ? (
+                      <span>{daysAgo(m.last_activity_at)} days ago</span>
+                    ) : (
+                      <span className="text-cloud/40">no pulse yet</span>
+                    )}
+                    {m.streak >= 2 && (
+                      <ManagedTooltip
+                        tooltipKey="streak_badge"
+                        content="Consecutive submitted pulses (looking back from the most recent scheduled date)."
+                      >
+                        <span
+                          className="inline-flex items-center gap-0.5 rounded-full bg-orange-500/15 px-1.5 py-0.5 text-[10px] font-medium text-orange-300"
+                          title={`${m.streak}-pulse streak`}
+                        >
+                          🔥 {m.streak}
+                        </span>
+                      </ManagedTooltip>
+                    )}
+                  </div>
                 </td>
               </tr>
             ))}
@@ -368,10 +404,6 @@ function FilterGroup({
 function comparatorFor(sort: RosterSort) {
   return (a: RosterRow, b: RosterRow): number => {
     switch (sort) {
-      case "joined_at_asc":
-        return a.joined_at.localeCompare(b.joined_at);
-      case "joined_at_desc":
-        return b.joined_at.localeCompare(a.joined_at);
       case "name_asc":
         return a.display_name.localeCompare(b.display_name);
       case "name_desc":

--- a/app/(dashboard)/moderator/switcher.tsx
+++ b/app/(dashboard)/moderator/switcher.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { ChevronDown } from "lucide-react";
+
+/**
+ * Switcher (PRD §7.7) — top-of-page nav between All pods + each
+ * assigned pod. Persists last selection via PUT /api/moderator/ui-state.
+ *
+ * Single-pod poderators see a switcher with one option; the All pods
+ * entry is suppressed by the caller (don't pass `showAllPods=false`).
+ */
+export type SwitcherPod = { id: number; name: string };
+
+export function Switcher({
+  pods,
+  current,
+  showAllPods,
+}: {
+  pods: SwitcherPod[];
+  current: "all_pods" | { pod_id: number };
+  showAllPods: boolean;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const router = useRouter();
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  const currentLabel =
+    current === "all_pods"
+      ? "All pods"
+      : pods.find((p) => p.id === (current as { pod_id: number }).pod_id)?.name ??
+        "Pod";
+
+  const persist = (last_view: string) => {
+    fetch("/api/moderator/ui-state", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ last_view }),
+    }).catch(() => {
+      // best-effort persistence — UI keeps working without it
+    });
+  };
+
+  const select = (last_view: string, href: string) => {
+    persist(last_view);
+    setOpen(false);
+    router.push(href);
+  };
+
+  return (
+    <div ref={rootRef} className="relative inline-block">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="inline-flex items-center gap-2 rounded-md border border-whisper bg-white/[0.02] px-3 py-1.5 text-sm text-cloud transition-colors hover:border-white/[0.12] hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+      >
+        <span className="text-xs uppercase tracking-widest text-cloud/40">
+          View
+        </span>
+        <span className="font-medium text-white">{currentLabel}</span>
+        <ChevronDown className="h-3.5 w-3.5 text-cloud/60" />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute left-0 top-full z-40 mt-1 min-w-[240px] overflow-hidden rounded-md border border-whisper bg-[rgba(11,16,22,0.98)] py-1 shadow-xl"
+        >
+          {showAllPods && (
+            <SwitcherItem
+              label="All pods"
+              selected={current === "all_pods"}
+              onClick={() => select("all_pods", "/moderator")}
+            />
+          )}
+          {pods.map((p) => (
+            <SwitcherItem
+              key={p.id}
+              label={p.name}
+              selected={
+                current !== "all_pods" &&
+                (current as { pod_id: number }).pod_id === p.id
+              }
+              onClick={() =>
+                select(String(p.id), `/moderator/pods/${p.id}`)
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SwitcherItem({
+  label,
+  selected,
+  onClick,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      role="option"
+      aria-selected={selected}
+      className={`flex w-full items-center justify-between px-3 py-1.5 text-left text-sm transition-colors hover:bg-white/[0.04] ${
+        selected ? "text-aqua" : "text-cloud/85"
+      }`}
+    >
+      <span className="truncate">{label}</span>
+      {selected && <span className="ml-3 text-xs">●</span>}
+    </button>
+  );
+}
+
+/**
+ * Fire-and-forget helper exported for non-switcher consumers (e.g.
+ * roster-table.tsx) that need to persist a partial UI state update.
+ */
+export function persistUiState(patch: {
+  last_view?: string;
+  roster_filters?: Record<string, unknown>;
+  roster_sort?: string;
+  tooltip_seen?: string[];
+}) {
+  fetch("/api/moderator/ui-state", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  }).catch(() => {});
+}
+

--- a/app/(dashboard)/moderator/switcher.tsx
+++ b/app/(dashboard)/moderator/switcher.tsx
@@ -136,6 +136,7 @@ export function persistUiState(patch: {
   roster_filters?: Record<string, unknown>;
   roster_sort?: string;
   tooltip_seen?: string[];
+  last_pod_tab?: "members" | "recent_pulses";
 }) {
   fetch("/api/moderator/ui-state", {
     method: "PUT",

--- a/app/(dashboard)/moderator/switcher.tsx
+++ b/app/(dashboard)/moderator/switcher.tsx
@@ -65,7 +65,7 @@ export function Switcher({
         aria-expanded={open}
         className="inline-flex items-center gap-2 rounded-md border border-whisper bg-white/[0.02] px-3 py-1.5 text-sm text-cloud transition-colors hover:border-white/[0.12] hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
       >
-        <span className="text-xs uppercase tracking-widest text-cloud/40">
+        <span className="text-xs uppercase tracking-widest text-cloud/60">
           View
         </span>
         <span className="font-medium text-white">{currentLabel}</span>
@@ -75,13 +75,13 @@ export function Switcher({
       {open && (
         <div
           role="listbox"
-          className="absolute left-0 top-full z-40 mt-1 min-w-[240px] overflow-hidden rounded-md border border-whisper bg-[rgba(11,16,22,0.98)] py-1 shadow-xl"
+          className="absolute left-0 top-full z-40 mt-1 min-w-[240px] overflow-hidden rounded-md border border-whisper bg-[rgba(42,49,66,0.98)] py-1 shadow-xl"
         >
           {showAllPods && (
             <SwitcherItem
               label="All pods"
               selected={current === "all_pods"}
-              onClick={() => select("all_pods", "/moderator")}
+              onClick={() => select("all_pods", "/moderator?view=all")}
             />
           )}
           {pods.map((p) => (

--- a/app/(dashboard)/moderator/tooltip-state.tsx
+++ b/app/(dashboard)/moderator/tooltip-state.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+import { persistUiState } from "./switcher";
+
+/**
+ * Tooltip auto-suppression state (PRD §7.8).
+ *
+ * Loads `tooltip_seen` from /api/moderator/ui-state on mount and
+ * exposes a hook for tooltip consumers to decide whether to auto-show
+ * and to mark a key as seen when they do.
+ *
+ * Each key auto-shows once (PRD says "1–2 views"; we pick 1 for v1).
+ * The "?" icon remains visible so the poderator can re-trigger on
+ * demand even after suppression.
+ */
+
+type Ctx = {
+  ready: boolean;
+  seen: Set<string>;
+  markSeen: (key: string) => void;
+};
+
+const TooltipCtx = React.createContext<Ctx>({
+  ready: false,
+  seen: new Set(),
+  markSeen: () => {},
+});
+
+export function TooltipStateProvider({ children }: { children: React.ReactNode }) {
+  const [ready, setReady] = React.useState(false);
+  const [seen, setSeen] = React.useState<Set<string>>(new Set());
+
+  React.useEffect(() => {
+    let cancelled = false;
+    fetch("/api/moderator/ui-state")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        const keys = (data?.tooltip_seen as string[] | null | undefined) ?? [];
+        setSeen(new Set(keys));
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setReady(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const markSeen = React.useCallback((key: string) => {
+    setSeen((current) => {
+      if (current.has(key)) return current;
+      const next = new Set(current);
+      next.add(key);
+      persistUiState({ tooltip_seen: Array.from(next) });
+      return next;
+    });
+  }, []);
+
+  const value = React.useMemo<Ctx>(
+    () => ({ ready, seen, markSeen }),
+    [ready, seen, markSeen]
+  );
+
+  return <TooltipCtx.Provider value={value}>{children}</TooltipCtx.Provider>;
+}
+
+export function useTooltipKey(key: string): {
+  autoShow: boolean;
+  markSeen: () => void;
+} {
+  const ctx = React.useContext(TooltipCtx);
+  const autoShow = ctx.ready && !ctx.seen.has(key);
+  const markSeen = React.useCallback(() => ctx.markSeen(key), [ctx, key]);
+  return { autoShow, markSeen };
+}
+
+/**
+ * Drop-in wrapper combining a tooltip-key with the existing Tooltip
+ * primitive. Consumers pass `tooltipKey` + the underlying tooltip
+ * `content` + children to wrap.
+ */
+import { Tooltip } from "@/app/components/ui";
+
+export function ManagedTooltip({
+  tooltipKey,
+  content,
+  children,
+  placement,
+}: {
+  tooltipKey: string;
+  content: React.ReactNode;
+  children: React.ReactNode;
+  placement?: "top" | "bottom";
+}) {
+  const { autoShow, markSeen } = useTooltipKey(tooltipKey);
+  return (
+    <Tooltip
+      content={content}
+      placement={placement}
+      autoShow={autoShow}
+      onAutoShown={markSeen}
+    >
+      {children}
+    </Tooltip>
+  );
+}

--- a/app/api/moderator/nudges/dismiss/route.ts
+++ b/app/api/moderator/nudges/dismiss/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse, NextRequest } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthenticatedRequest } from "@/lib/auth/middleware";
+import { isAdmin, isModeratorForPod } from "@/lib/auth/roles";
+
+/**
+ * POST /api/moderator/nudges/dismiss
+ *
+ * Records a per-poderator dismissal of a specific nudge instance.
+ *
+ * Body: { pod_id: number, nudge_key: string }
+ *
+ * Caller must be admin/owner or an active moderator for the pod. RLS
+ * on nudge_dismissals enforces the same predicate at the DB layer, so
+ * this is defence-in-depth for clearer error messages.
+ *
+ * Idempotent: re-dismissing an already-dismissed key returns 204
+ * without writing again (the UNIQUE constraint short-circuits in the
+ * upsert).
+ */
+const bodySchema = z.object({
+  pod_id: z.number().int().positive(),
+  nudge_key: z.string().min(1).max(200),
+});
+
+export const POST = withAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest) => {
+    const raw = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid body", issues: parsed.error.issues },
+        { status: 400 }
+      );
+    }
+    const { pod_id, nudge_key } = parsed.data;
+
+    if (!isAdmin(auth.user) && !isModeratorForPod(auth.user, pod_id)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (!auth.user.participantId) {
+      return NextResponse.json(
+        { error: "No participant record on caller" },
+        { status: 400 }
+      );
+    }
+
+    const { error } = await auth.supabase
+      .from("nudge_dismissals")
+      .upsert(
+        {
+          moderator_participant_id: auth.user.participantId,
+          pod_id,
+          nudge_key,
+        },
+        {
+          onConflict: "moderator_participant_id,pod_id,nudge_key",
+          ignoreDuplicates: true,
+        }
+      );
+
+    if (error) {
+      return NextResponse.json(
+        { error: "Failed to record dismissal" },
+        { status: 500 }
+      );
+    }
+    return new NextResponse(null, { status: 204 });
+  }
+);

--- a/app/api/moderator/pods/[pod_id]/pulse-responses/[participant_id]/route.ts
+++ b/app/api/moderator/pods/[pod_id]/pulse-responses/[participant_id]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAuth, type AuthenticatedRequest } from "@/lib/auth/middleware";
+import { requireModeratorForPod } from "@/lib/auth/moderator";
+import { parseIntParam } from "@/lib/api/params";
+import { getMemberPulseHistory } from "@/lib/moderator/pulse-responses";
+
+/**
+ * GET /api/moderator/pods/[pod_id]/pulse-responses/[participant_id]
+ *
+ * Backs the pulse review side panel (PRD §7.4 + §7.9.1 aggregate).
+ *
+ * Returns:
+ *   - aggregate: top AI tools + engagement trajectory (full cycle)
+ *   - responses: per-pulse rows, most recent first, with survey_responses
+ *
+ * Auth: caller must be admin/owner OR an active moderator for the pod.
+ * Additionally, the participant must be a (current or historical)
+ * member of the pod — without this an assigned poderator could read
+ * any participant's pulses via URL manipulation.
+ */
+export const GET = withAuth(
+  async (
+    _request: NextRequest,
+    auth: AuthenticatedRequest,
+    params: Record<string, string>
+  ) => {
+    const podId = parseIntParam(params.pod_id, "pod_id");
+    if (podId instanceof NextResponse) return podId;
+    const participantId = parseIntParam(params.participant_id, "participant_id");
+    if (participantId instanceof NextResponse) return participantId;
+
+    const guard = requireModeratorForPod(auth.user, podId);
+    if (guard) return guard;
+
+    const result = await getMemberPulseHistory(auth.supabase, podId, participantId);
+    if ("error" in result) {
+      if (result.error === "pod-not-found") {
+        return NextResponse.json({ error: "Pod not found" }, { status: 404 });
+      }
+      // not-pod-member → 403 (not 404, since the caller is authorized for
+      // the pod and we want to be explicit they are asking for someone
+      // they shouldn't be looking up via this surface).
+      return NextResponse.json(
+        { error: "Participant is not a member of this pod" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.json(result);
+  }
+);

--- a/app/api/moderator/pods/[pod_id]/recent-pulses/route.ts
+++ b/app/api/moderator/pods/[pod_id]/recent-pulses/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAuth, type AuthenticatedRequest } from "@/lib/auth/middleware";
+import { requireModeratorForPod } from "@/lib/auth/moderator";
+import { parseIntParam } from "@/lib/api/params";
+import {
+  getRecentPulses,
+  RECENT_PULSES_PAGE_SIZE,
+} from "@/lib/moderator/recent-pulses";
+
+/**
+ * GET /api/moderator/pods/[pod_id]/recent-pulses
+ *
+ * Backs the "Recent pulses" tab on the per-pod page (chunk B of the
+ * 2026-06 poderator-dashboard refinement).
+ *
+ * Query params:
+ *   - before  (optional ISO timestamp) — return pulses completed strictly
+ *             before this value, used for paging older.
+ *   - limit   (optional int) — page size; clamped to [1, 50].
+ *
+ * Auth: same as the other /api/moderator/pods/[pod_id]/* routes — admin
+ * or active moderator for the pod.
+ */
+export const GET = withAuth(
+  async (
+    request: NextRequest,
+    auth: AuthenticatedRequest,
+    params: Record<string, string>
+  ) => {
+    const podId = parseIntParam(params.pod_id, "pod_id");
+    if (podId instanceof NextResponse) return podId;
+
+    const guard = requireModeratorForPod(auth.user, podId);
+    if (guard) return guard;
+
+    const url = new URL(request.url);
+    const before = url.searchParams.get("before");
+    const limitParam = url.searchParams.get("limit");
+    const limit = limitParam
+      ? Number.parseInt(limitParam, 10)
+      : RECENT_PULSES_PAGE_SIZE;
+
+    const result = await getRecentPulses(auth.supabase, podId, {
+      before: before && before.length > 0 ? before : null,
+      limit: Number.isFinite(limit) ? limit : RECENT_PULSES_PAGE_SIZE,
+    });
+    if ("error" in result) {
+      return NextResponse.json({ error: "Pod not found" }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  }
+);

--- a/app/api/moderator/pods/[pod_id]/route.ts
+++ b/app/api/moderator/pods/[pod_id]/route.ts
@@ -2,64 +2,18 @@ import { NextResponse, NextRequest } from "next/server";
 import { withAuth, type AuthenticatedRequest } from "@/lib/auth/middleware";
 import { requireModeratorForPod } from "@/lib/auth/moderator";
 import { parseIntParam } from "@/lib/api/params";
-import { resolveCurrentPhase, type CycleConfigPhaseColumns } from "@/lib/moderator/phase";
-import { bandFor, trendOver3Weeks, type Band, type Trend, type PulseHealthCfg } from "@/lib/moderator/pulse-health";
+import { getPodDetail } from "@/lib/moderator/pod-detail";
 
 /**
  * GET /api/moderator/pods/[pod_id]
  *
  * Backs the Per-pod view (§7.1 status header + §7.3 member roster).
- *
- * Single endpoint by design — the page needs pod + cycle + phase +
- * pulse-health + roster in one render pass. Splitting into multiple
- * round-trips would burn an extra waterfall for no gain.
+ * The RSC at app/(dashboard)/moderator/pods/[pod_id]/page.tsx calls
+ * `getPodDetail` directly; this endpoint exists for client-side
+ * consumers (refresh actions, future polling).
  *
  * Pod-scoped: requires admin OR active moderator assignment for this pod.
  */
-
-type PulseStatus = "current" | "pending" | "late" | "at_risk";
-
-type RosterRow = {
-  participant_id: number;
-  initials: string;             // "L.P." — for privacy-light renderings
-  display_name: string;         // "Linda P." — first name + last initial
-  ai_experience_level: string;  // enum value
-  availability_snippet: string | null;
-  email: string | null;         // poderator can see, for Slack DM fallback
-  joined_at: string;
-  is_inactive: boolean;         // cycle_enrollments.status === 'inactive'
-  inactive_since: string | null;
-  pulse_status: PulseStatus;
-  last_activity_at: string | null;
-};
-
-type PodDetail = {
-  id: number;
-  name: string | null;
-  status: string;
-  cycle_id: number;
-  cycle_name: string | null;
-  phase_num: number | null;
-  phase_display_name: string | null;
-  phase_short_name: string | null;
-  phase_open_at: string | null;
-  phase_close_at: string | null;
-  phase_is_active: boolean;
-  active_member_count: number;
-  missing_this_week: number;
-  band: Band;
-  trend: Trend;
-  resources: {
-    slack_channel_id: string | null;
-    drive_folder_id: string | null;
-    github_repo_url: string | null;
-  };
-  members: RosterRow[];
-  at_risk_threshold: number;
-};
-
-const DEFAULT_AT_RISK_MISSES = 2;
-
 export const GET = withAuth(
   async (
     _request: NextRequest,
@@ -72,225 +26,10 @@ export const GET = withAuth(
     const guard = requireModeratorForPod(auth.user, podId);
     if (guard) return guard;
 
-    // 1. Pod + cycle.
-    const { data: pod, error: podErr } = await auth.supabase
-      .from("pods")
-      .select(`
-        id, name, status, cycle_id,
-        slack_channel_id, drive_folder_id, github_repo_url,
-        cycles (id, name)
-      `)
-      .eq("id", podId)
-      .single();
-
-    if (podErr || !pod) {
+    const detail = await getPodDetail(auth.supabase, podId);
+    if (!detail) {
       return NextResponse.json({ error: "Pod not found" }, { status: 404 });
     }
-
-    // 2. cycle_config.
-    const { data: cfg } = await auth.supabase
-      .from("cycle_config")
-      .select(
-        "problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close, pulse_band_warning_min, pulse_band_critical_min, at_risk_consecutive_misses"
-      )
-      .eq("cycle_id", pod.cycle_id)
-      .maybeSingle();
-
-    const phase = cfg ? resolveCurrentPhase(cfg as CycleConfigPhaseColumns) : null;
-    const atRiskThreshold =
-      (cfg as { at_risk_consecutive_misses?: number } | null)?.at_risk_consecutive_misses ??
-      DEFAULT_AT_RISK_MISSES;
-
-    // 3. Pod members.
-    const { data: memberRows, error: memErr } = await auth.supabase
-      .from("pod_memberships")
-      .select(`
-        participant_id, joined_at, inactive_at,
-        participants (
-          id, first_name, last_name, preferred_name, email,
-          ai_experience_level, availability_snippet
-        )
-      `)
-      .eq("pod_id", podId)
-      .order("joined_at");
-
-    if (memErr) {
-      return NextResponse.json({ error: "Failed to load roster" }, { status: 500 });
-    }
-
-    const memberIds = (memberRows ?? []).map((m) => m.participant_id);
-
-    // 4. cycle_enrollments for inactive-status flagging.
-    let enrollmentsByParticipant = new Map<number, { status: string }>();
-    if (memberIds.length > 0) {
-      const { data: enrolls } = await auth.supabase
-        .from("cycle_enrollments")
-        .select("participant_id, status")
-        .eq("cycle_id", pod.cycle_id)
-        .in("participant_id", memberIds);
-      enrollmentsByParticipant = new Map(
-        (enrolls ?? []).map((e) => [e.participant_id, { status: e.status }])
-      );
-    }
-
-    // 5. Recent pulses (last ~4 weeks worth) for status computation + trend.
-    const fourWeeksAgo = new Date();
-    fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
-
-    let pulseRows: { participant_id: number; scheduled_date: string; completed_at: string | null }[] = [];
-    if (memberIds.length > 0) {
-      const { data } = await auth.supabase
-        .from("pulse_checks")
-        .select("participant_id, scheduled_date, completed_at")
-        .in("participant_id", memberIds)
-        .eq("cycle_id", pod.cycle_id)
-        .gte("scheduled_date", fourWeeksAgo.toISOString().slice(0, 10))
-        .order("scheduled_date");
-      pulseRows = data ?? [];
-    }
-
-    // 6. Group pulses by member.
-    const pulsesByMember = new Map<number, typeof pulseRows>();
-    for (const p of pulseRows) {
-      const arr = pulsesByMember.get(p.participant_id) ?? [];
-      arr.push(p);
-      pulsesByMember.set(p.participant_id, arr);
-    }
-
-    // 7. Build roster rows.
-    const members: RosterRow[] = (memberRows ?? []).map((m) => {
-      const p = (m.participants as unknown) as {
-        id: number;
-        first_name: string;
-        last_name: string;
-        preferred_name: string | null;
-        email: string;
-        ai_experience_level: string;
-        availability_snippet: string | null;
-      } | null;
-
-      const first = p?.preferred_name ?? p?.first_name ?? "?";
-      const lastInitial = p?.last_name ? p.last_name[0].toUpperCase() : "";
-      const display = `${first} ${lastInitial}.`.trim();
-      const initials = `${first[0]}${lastInitial}`.toUpperCase();
-
-      const memberPulses = pulsesByMember.get(m.participant_id) ?? [];
-      const status = computePulseStatus(memberPulses, atRiskThreshold);
-      const lastCompleted = memberPulses
-        .filter((p) => p.completed_at)
-        .sort((a, b) => (b.completed_at ?? "").localeCompare(a.completed_at ?? ""))[0];
-
-      const enrollment = enrollmentsByParticipant.get(m.participant_id);
-      const isInactive = enrollment?.status === "inactive";
-
-      return {
-        participant_id: m.participant_id,
-        initials,
-        display_name: display,
-        ai_experience_level: p?.ai_experience_level ?? "new",
-        availability_snippet: p?.availability_snippet ?? null,
-        email: p?.email ?? null,
-        joined_at: m.joined_at,
-        is_inactive: isInactive,
-        inactive_since: m.inactive_at,
-        pulse_status: status,
-        last_activity_at: lastCompleted?.completed_at ?? null,
-      };
-    });
-
-    // 8. Pod-level pulse-health summary (matches pods/route.ts shape).
-    const activeMemberIds = (memberRows ?? [])
-      .filter((m) => m.inactive_at === null)
-      .map((m) => m.participant_id);
-    const activePulses = pulseRows.filter((p) => activeMemberIds.includes(p.participant_id));
-
-    const { missingThisWeek, weeklyRates } = bucketPulses(
-      activePulses,
-      activeMemberIds.length
-    );
-
-    const detail: PodDetail = {
-      id: pod.id,
-      name: pod.name,
-      status: pod.status,
-      cycle_id: pod.cycle_id,
-      cycle_name:
-        (pod.cycles as unknown as { name: string } | null)?.name ?? null,
-      phase_num: phase?.num ?? null,
-      phase_display_name: phase?.displayName ?? null,
-      phase_short_name: phase?.shortName ?? null,
-      phase_open_at: phase?.openAt ?? null,
-      phase_close_at: phase?.closeAt ?? null,
-      phase_is_active: phase?.isActive ?? false,
-      active_member_count: activeMemberIds.length,
-      missing_this_week: missingThisWeek,
-      band: bandFor(missingThisWeek, cfg as PulseHealthCfg | null),
-      trend: trendOver3Weeks(weeklyRates),
-      resources: {
-        slack_channel_id: pod.slack_channel_id,
-        drive_folder_id: pod.drive_folder_id,
-        github_repo_url: pod.github_repo_url,
-      },
-      members,
-      at_risk_threshold: atRiskThreshold,
-    };
-
     return NextResponse.json(detail);
   }
 );
-
-/** Determine the engagement bucket from a member's recent pulses. */
-function computePulseStatus(
-  pulses: { scheduled_date: string; completed_at: string | null }[],
-  atRiskThreshold: number
-): PulseStatus {
-  if (pulses.length === 0) return "pending";
-
-  // Sort newest-first for consecutive-miss counting.
-  const sorted = [...pulses].sort((a, b) =>
-    b.scheduled_date.localeCompare(a.scheduled_date)
-  );
-
-  // Consecutive misses from most recent backwards.
-  let consecutiveMisses = 0;
-  for (const p of sorted) {
-    if (p.completed_at) break;
-    consecutiveMisses += 1;
-  }
-  if (consecutiveMisses >= atRiskThreshold) return "at_risk";
-
-  const mostRecent = sorted[0];
-  if (mostRecent.completed_at) return "current";
-
-  // Most recent missed. If the scheduled_date is within the last 7 days,
-  // call it "pending" (window may still be open). Otherwise "late".
-  const scheduledMs = new Date(mostRecent.scheduled_date).getTime();
-  const ageDays = (Date.now() - scheduledMs) / 86_400_000;
-  return ageDays > 7 ? "late" : "pending";
-}
-
-/** Buckets pulse rows into weeks. Same logic as pods/route.ts. */
-function bucketPulses(
-  rows: { participant_id: number; scheduled_date: string; completed_at: string | null }[],
-  activeCount: number
-): { missingThisWeek: number; weeklyRates: number[] } {
-  if (rows.length === 0 || activeCount === 0) {
-    return { missingThisWeek: 0, weeklyRates: [] };
-  }
-  const byWeek = new Map<string, { completed: number; total: number }>();
-  for (const r of rows) {
-    const bucket = byWeek.get(r.scheduled_date) ?? { completed: 0, total: 0 };
-    bucket.total += 1;
-    if (r.completed_at) bucket.completed += 1;
-    byWeek.set(r.scheduled_date, bucket);
-  }
-  const weekKeys = Array.from(byWeek.keys()).sort();
-  const weeklyRates = weekKeys.map((k) => {
-    const b = byWeek.get(k)!;
-    return b.total === 0 ? 0 : b.completed / b.total;
-  });
-  const latestKey = weekKeys[weekKeys.length - 1];
-  const latest = byWeek.get(latestKey)!;
-  const missingThisWeek = Math.max(0, activeCount - latest.completed);
-  return { missingThisWeek, weeklyRates };
-}

--- a/app/api/moderator/pods/[pod_id]/route.ts
+++ b/app/api/moderator/pods/[pod_id]/route.ts
@@ -1,0 +1,296 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAuth, type AuthenticatedRequest } from "@/lib/auth/middleware";
+import { requireModeratorForPod } from "@/lib/auth/moderator";
+import { parseIntParam } from "@/lib/api/params";
+import { resolveCurrentPhase, type CycleConfigPhaseColumns } from "@/lib/moderator/phase";
+import { bandFor, trendOver3Weeks, type Band, type Trend, type PulseHealthCfg } from "@/lib/moderator/pulse-health";
+
+/**
+ * GET /api/moderator/pods/[pod_id]
+ *
+ * Backs the Per-pod view (§7.1 status header + §7.3 member roster).
+ *
+ * Single endpoint by design — the page needs pod + cycle + phase +
+ * pulse-health + roster in one render pass. Splitting into multiple
+ * round-trips would burn an extra waterfall for no gain.
+ *
+ * Pod-scoped: requires admin OR active moderator assignment for this pod.
+ */
+
+type PulseStatus = "current" | "pending" | "late" | "at_risk";
+
+type RosterRow = {
+  participant_id: number;
+  initials: string;             // "L.P." — for privacy-light renderings
+  display_name: string;         // "Linda P." — first name + last initial
+  ai_experience_level: string;  // enum value
+  availability_snippet: string | null;
+  email: string | null;         // poderator can see, for Slack DM fallback
+  joined_at: string;
+  is_inactive: boolean;         // cycle_enrollments.status === 'inactive'
+  inactive_since: string | null;
+  pulse_status: PulseStatus;
+  last_activity_at: string | null;
+};
+
+type PodDetail = {
+  id: number;
+  name: string | null;
+  status: string;
+  cycle_id: number;
+  cycle_name: string | null;
+  phase_num: number | null;
+  phase_display_name: string | null;
+  phase_short_name: string | null;
+  phase_open_at: string | null;
+  phase_close_at: string | null;
+  phase_is_active: boolean;
+  active_member_count: number;
+  missing_this_week: number;
+  band: Band;
+  trend: Trend;
+  resources: {
+    slack_channel_id: string | null;
+    drive_folder_id: string | null;
+    github_repo_url: string | null;
+  };
+  members: RosterRow[];
+  at_risk_threshold: number;
+};
+
+const DEFAULT_AT_RISK_MISSES = 2;
+
+export const GET = withAuth(
+  async (
+    _request: NextRequest,
+    auth: AuthenticatedRequest,
+    params: Record<string, string>
+  ) => {
+    const podId = parseIntParam(params.pod_id, "pod_id");
+    if (podId instanceof NextResponse) return podId;
+
+    const guard = requireModeratorForPod(auth.user, podId);
+    if (guard) return guard;
+
+    // 1. Pod + cycle.
+    const { data: pod, error: podErr } = await auth.supabase
+      .from("pods")
+      .select(`
+        id, name, status, cycle_id,
+        slack_channel_id, drive_folder_id, github_repo_url,
+        cycles (id, name)
+      `)
+      .eq("id", podId)
+      .single();
+
+    if (podErr || !pod) {
+      return NextResponse.json({ error: "Pod not found" }, { status: 404 });
+    }
+
+    // 2. cycle_config.
+    const { data: cfg } = await auth.supabase
+      .from("cycle_config")
+      .select(
+        "problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close, pulse_band_warning_min, pulse_band_critical_min, at_risk_consecutive_misses"
+      )
+      .eq("cycle_id", pod.cycle_id)
+      .maybeSingle();
+
+    const phase = cfg ? resolveCurrentPhase(cfg as CycleConfigPhaseColumns) : null;
+    const atRiskThreshold =
+      (cfg as { at_risk_consecutive_misses?: number } | null)?.at_risk_consecutive_misses ??
+      DEFAULT_AT_RISK_MISSES;
+
+    // 3. Pod members.
+    const { data: memberRows, error: memErr } = await auth.supabase
+      .from("pod_memberships")
+      .select(`
+        participant_id, joined_at, inactive_at,
+        participants (
+          id, first_name, last_name, preferred_name, email,
+          ai_experience_level, availability_snippet
+        )
+      `)
+      .eq("pod_id", podId)
+      .order("joined_at");
+
+    if (memErr) {
+      return NextResponse.json({ error: "Failed to load roster" }, { status: 500 });
+    }
+
+    const memberIds = (memberRows ?? []).map((m) => m.participant_id);
+
+    // 4. cycle_enrollments for inactive-status flagging.
+    let enrollmentsByParticipant = new Map<number, { status: string }>();
+    if (memberIds.length > 0) {
+      const { data: enrolls } = await auth.supabase
+        .from("cycle_enrollments")
+        .select("participant_id, status")
+        .eq("cycle_id", pod.cycle_id)
+        .in("participant_id", memberIds);
+      enrollmentsByParticipant = new Map(
+        (enrolls ?? []).map((e) => [e.participant_id, { status: e.status }])
+      );
+    }
+
+    // 5. Recent pulses (last ~4 weeks worth) for status computation + trend.
+    const fourWeeksAgo = new Date();
+    fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
+
+    let pulseRows: { participant_id: number; scheduled_date: string; completed_at: string | null }[] = [];
+    if (memberIds.length > 0) {
+      const { data } = await auth.supabase
+        .from("pulse_checks")
+        .select("participant_id, scheduled_date, completed_at")
+        .in("participant_id", memberIds)
+        .eq("cycle_id", pod.cycle_id)
+        .gte("scheduled_date", fourWeeksAgo.toISOString().slice(0, 10))
+        .order("scheduled_date");
+      pulseRows = data ?? [];
+    }
+
+    // 6. Group pulses by member.
+    const pulsesByMember = new Map<number, typeof pulseRows>();
+    for (const p of pulseRows) {
+      const arr = pulsesByMember.get(p.participant_id) ?? [];
+      arr.push(p);
+      pulsesByMember.set(p.participant_id, arr);
+    }
+
+    // 7. Build roster rows.
+    const members: RosterRow[] = (memberRows ?? []).map((m) => {
+      const p = (m.participants as unknown) as {
+        id: number;
+        first_name: string;
+        last_name: string;
+        preferred_name: string | null;
+        email: string;
+        ai_experience_level: string;
+        availability_snippet: string | null;
+      } | null;
+
+      const first = p?.preferred_name ?? p?.first_name ?? "?";
+      const lastInitial = p?.last_name ? p.last_name[0].toUpperCase() : "";
+      const display = `${first} ${lastInitial}.`.trim();
+      const initials = `${first[0]}${lastInitial}`.toUpperCase();
+
+      const memberPulses = pulsesByMember.get(m.participant_id) ?? [];
+      const status = computePulseStatus(memberPulses, atRiskThreshold);
+      const lastCompleted = memberPulses
+        .filter((p) => p.completed_at)
+        .sort((a, b) => (b.completed_at ?? "").localeCompare(a.completed_at ?? ""))[0];
+
+      const enrollment = enrollmentsByParticipant.get(m.participant_id);
+      const isInactive = enrollment?.status === "inactive";
+
+      return {
+        participant_id: m.participant_id,
+        initials,
+        display_name: display,
+        ai_experience_level: p?.ai_experience_level ?? "new",
+        availability_snippet: p?.availability_snippet ?? null,
+        email: p?.email ?? null,
+        joined_at: m.joined_at,
+        is_inactive: isInactive,
+        inactive_since: m.inactive_at,
+        pulse_status: status,
+        last_activity_at: lastCompleted?.completed_at ?? null,
+      };
+    });
+
+    // 8. Pod-level pulse-health summary (matches pods/route.ts shape).
+    const activeMemberIds = (memberRows ?? [])
+      .filter((m) => m.inactive_at === null)
+      .map((m) => m.participant_id);
+    const activePulses = pulseRows.filter((p) => activeMemberIds.includes(p.participant_id));
+
+    const { missingThisWeek, weeklyRates } = bucketPulses(
+      activePulses,
+      activeMemberIds.length
+    );
+
+    const detail: PodDetail = {
+      id: pod.id,
+      name: pod.name,
+      status: pod.status,
+      cycle_id: pod.cycle_id,
+      cycle_name:
+        (pod.cycles as unknown as { name: string } | null)?.name ?? null,
+      phase_num: phase?.num ?? null,
+      phase_display_name: phase?.displayName ?? null,
+      phase_short_name: phase?.shortName ?? null,
+      phase_open_at: phase?.openAt ?? null,
+      phase_close_at: phase?.closeAt ?? null,
+      phase_is_active: phase?.isActive ?? false,
+      active_member_count: activeMemberIds.length,
+      missing_this_week: missingThisWeek,
+      band: bandFor(missingThisWeek, cfg as PulseHealthCfg | null),
+      trend: trendOver3Weeks(weeklyRates),
+      resources: {
+        slack_channel_id: pod.slack_channel_id,
+        drive_folder_id: pod.drive_folder_id,
+        github_repo_url: pod.github_repo_url,
+      },
+      members,
+      at_risk_threshold: atRiskThreshold,
+    };
+
+    return NextResponse.json(detail);
+  }
+);
+
+/** Determine the engagement bucket from a member's recent pulses. */
+function computePulseStatus(
+  pulses: { scheduled_date: string; completed_at: string | null }[],
+  atRiskThreshold: number
+): PulseStatus {
+  if (pulses.length === 0) return "pending";
+
+  // Sort newest-first for consecutive-miss counting.
+  const sorted = [...pulses].sort((a, b) =>
+    b.scheduled_date.localeCompare(a.scheduled_date)
+  );
+
+  // Consecutive misses from most recent backwards.
+  let consecutiveMisses = 0;
+  for (const p of sorted) {
+    if (p.completed_at) break;
+    consecutiveMisses += 1;
+  }
+  if (consecutiveMisses >= atRiskThreshold) return "at_risk";
+
+  const mostRecent = sorted[0];
+  if (mostRecent.completed_at) return "current";
+
+  // Most recent missed. If the scheduled_date is within the last 7 days,
+  // call it "pending" (window may still be open). Otherwise "late".
+  const scheduledMs = new Date(mostRecent.scheduled_date).getTime();
+  const ageDays = (Date.now() - scheduledMs) / 86_400_000;
+  return ageDays > 7 ? "late" : "pending";
+}
+
+/** Buckets pulse rows into weeks. Same logic as pods/route.ts. */
+function bucketPulses(
+  rows: { participant_id: number; scheduled_date: string; completed_at: string | null }[],
+  activeCount: number
+): { missingThisWeek: number; weeklyRates: number[] } {
+  if (rows.length === 0 || activeCount === 0) {
+    return { missingThisWeek: 0, weeklyRates: [] };
+  }
+  const byWeek = new Map<string, { completed: number; total: number }>();
+  for (const r of rows) {
+    const bucket = byWeek.get(r.scheduled_date) ?? { completed: 0, total: 0 };
+    bucket.total += 1;
+    if (r.completed_at) bucket.completed += 1;
+    byWeek.set(r.scheduled_date, bucket);
+  }
+  const weekKeys = Array.from(byWeek.keys()).sort();
+  const weeklyRates = weekKeys.map((k) => {
+    const b = byWeek.get(k)!;
+    return b.total === 0 ? 0 : b.completed / b.total;
+  });
+  const latestKey = weekKeys[weekKeys.length - 1];
+  const latest = byWeek.get(latestKey)!;
+  const missingThisWeek = Math.max(0, activeCount - latest.completed);
+  return { missingThisWeek, weeklyRates };
+}

--- a/app/api/moderator/pods/route.ts
+++ b/app/api/moderator/pods/route.ts
@@ -1,0 +1,225 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAuth, type AuthenticatedRequest } from "@/lib/auth/middleware";
+import { isAdmin, isModerator } from "@/lib/auth/roles";
+import { resolveCurrentPhase, type CycleConfigPhaseColumns } from "@/lib/moderator/phase";
+import { bandFor, trendOver3Weeks, type Band, type Trend, type PulseHealthCfg } from "@/lib/moderator/pulse-health";
+
+/**
+ * GET /api/moderator/pods
+ *
+ * Backs the All pods view (§7.10.1 pod summary cards + §7.10.2 rollup).
+ *
+ * Returns one row per pod the caller can access:
+ *   - admin/owner → all pods, all cycles
+ *   - moderator → only pods with an active moderator_assignment
+ *
+ * Each row carries enough data to render the pod summary card:
+ *   - id, name, status, cycle name, cycle phase (number + display name)
+ *   - missingThisWeek + band (healthy/warning/critical)
+ *   - 3-week trend (up/down/flat)
+ *   - activeMemberCount
+ */
+
+type PodCard = {
+  id: number;
+  name: string | null;
+  status: string;
+  cycle_id: number;
+  cycle_name: string | null;
+  phase_num: number | null;
+  phase_display_name: string | null;
+  phase_open_at: string | null;
+  phase_close_at: string | null;
+  active_member_count: number;
+  missing_this_week: number;
+  band: Band;
+  trend: Trend;
+};
+
+export const GET = withAuth(
+  async (_request: NextRequest, auth: AuthenticatedRequest) => {
+    if (!isModerator(auth.user) && !isAdmin(auth.user)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const participantId = auth.user.participantId;
+    const admin = isAdmin(auth.user);
+
+    // 1. Determine which pod IDs the caller can see.
+    let podIds: number[];
+    if (admin) {
+      const { data, error } = await auth.supabase
+        .from("pods")
+        .select("id")
+        .order("created_at", { ascending: false });
+      if (error) {
+        return NextResponse.json({ error: "Failed to load pods" }, { status: 500 });
+      }
+      podIds = (data ?? []).map((r) => r.id);
+    } else {
+      if (!participantId) return NextResponse.json([]);
+      const { data, error } = await auth.supabase
+        .from("moderator_assignments")
+        .select("pod_id")
+        .eq("participant_id", participantId)
+        .is("removed_at", null);
+      if (error) {
+        return NextResponse.json({ error: "Failed to load assignments" }, { status: 500 });
+      }
+      podIds = (data ?? []).map((r) => r.pod_id);
+    }
+
+    if (podIds.length === 0) return NextResponse.json([]);
+
+    // 2. Fetch pod + cycle metadata in one round trip.
+    const { data: podRows, error: podsErr } = await auth.supabase
+      .from("pods")
+      .select("id, name, status, cycle_id, cycles (id, name)")
+      .in("id", podIds);
+
+    if (podsErr) {
+      return NextResponse.json({ error: "Failed to load pod details" }, { status: 500 });
+    }
+
+    const cycleIds = Array.from(new Set((podRows ?? []).map((p) => p.cycle_id)));
+
+    // 3. cycle_config (phase windows + pulse-health thresholds).
+    const { data: configRows } = await auth.supabase
+      .from("cycle_config")
+      .select(
+        "cycle_id, problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close, pulse_band_warning_min, pulse_band_critical_min"
+      )
+      .in("cycle_id", cycleIds);
+
+    const configByCycle = new Map<number, CycleConfigPhaseColumns & PulseHealthCfg>();
+    for (const row of configRows ?? []) {
+      configByCycle.set(row.cycle_id, row);
+    }
+
+    // 4. Active membership counts per pod.
+    const { data: membershipRows } = await auth.supabase
+      .from("pod_memberships")
+      .select("pod_id, participant_id")
+      .in("pod_id", podIds)
+      .is("inactive_at", null);
+
+    const membersByPod = new Map<number, number[]>();
+    for (const m of membershipRows ?? []) {
+      const arr = membersByPod.get(m.pod_id) ?? [];
+      arr.push(m.participant_id);
+      membersByPod.set(m.pod_id, arr);
+    }
+
+    // 5. Last 3 weeks of pulse data scoped to the union of pod members.
+    //    A pulse is "completed" when completed_at IS NOT NULL.
+    const threeWeeksAgo = new Date();
+    threeWeeksAgo.setDate(threeWeeksAgo.getDate() - 21);
+
+    const allParticipantIds = Array.from(
+      new Set(Array.from(membersByPod.values()).flat())
+    );
+
+    let pulseRows: {
+      participant_id: number;
+      cycle_id: number;
+      scheduled_date: string;
+      completed_at: string | null;
+    }[] = [];
+    if (allParticipantIds.length > 0 && cycleIds.length > 0) {
+      const { data } = await auth.supabase
+        .from("pulse_checks")
+        .select("participant_id, cycle_id, scheduled_date, completed_at")
+        .in("participant_id", allParticipantIds)
+        .in("cycle_id", cycleIds)
+        .gte("scheduled_date", threeWeeksAgo.toISOString().slice(0, 10));
+      pulseRows = data ?? [];
+    }
+
+    // 6. Compute per-pod health + trend.
+    const cards: PodCard[] = (podRows ?? []).map((pod) => {
+      const cfg = configByCycle.get(pod.cycle_id) ?? null;
+      const phase = cfg ? resolveCurrentPhase(cfg) : null;
+      const memberIds = membersByPod.get(pod.id) ?? [];
+
+      // Filter pulses by both cycle (avoid cross-cycle leak when a member
+      // appears in more than one cycle) and pod membership.
+      const memberIdSet = new Set(memberIds);
+      const podPulses = pulseRows.filter(
+        (p) => p.cycle_id === pod.cycle_id && memberIdSet.has(p.participant_id)
+      );
+      const { missingThisWeek, weeklyRates } = computeWeeklyRates(podPulses, memberIds.length);
+
+      const cycleName =
+        (pod.cycles as unknown as { name: string } | null)?.name ?? null;
+
+      return {
+        id: pod.id,
+        name: pod.name,
+        status: pod.status,
+        cycle_id: pod.cycle_id,
+        cycle_name: cycleName,
+        phase_num: phase?.num ?? null,
+        phase_display_name: phase?.displayName ?? null,
+        phase_open_at: phase?.openAt ?? null,
+        phase_close_at: phase?.closeAt ?? null,
+        active_member_count: memberIds.length,
+        missing_this_week: missingThisWeek,
+        band: bandFor(missingThisWeek, cfg),
+        trend: trendOver3Weeks(weeklyRates),
+      };
+    });
+
+    // Sort: pods with non-zero missing first (within those, descending by
+    // missing); then alphabetical by name (PRD §7.10.1).
+    cards.sort((a, b) => {
+      if ((a.missing_this_week > 0) !== (b.missing_this_week > 0)) {
+        return a.missing_this_week > 0 ? -1 : 1;
+      }
+      if (a.missing_this_week !== b.missing_this_week) {
+        return b.missing_this_week - a.missing_this_week;
+      }
+      return (a.name ?? "").localeCompare(b.name ?? "");
+    });
+
+    return NextResponse.json(cards);
+  }
+);
+
+/**
+ * Buckets pulse rows into weeks (using scheduled_date) and returns
+ * { missingThisWeek, weeklyRates } where weeklyRates is the completion
+ * rate (0..1) per week, oldest first.
+ *
+ * "This week" = the most recent week with at least one scheduled pulse
+ * row for this pod's members.
+ */
+function computeWeeklyRates(
+  rows: { participant_id: number; scheduled_date: string; completed_at: string | null }[],
+  activeCount: number
+): { missingThisWeek: number; weeklyRates: number[] } {
+  if (rows.length === 0 || activeCount === 0) {
+    return { missingThisWeek: 0, weeklyRates: [] };
+  }
+
+  // Group by scheduled_date (ISO yyyy-mm-dd).
+  const byWeek = new Map<string, { completed: number; total: number }>();
+  for (const r of rows) {
+    const bucket = byWeek.get(r.scheduled_date) ?? { completed: 0, total: 0 };
+    bucket.total += 1;
+    if (r.completed_at) bucket.completed += 1;
+    byWeek.set(r.scheduled_date, bucket);
+  }
+
+  const weekKeys = Array.from(byWeek.keys()).sort(); // oldest first
+  const weeklyRates = weekKeys.map((k) => {
+    const b = byWeek.get(k)!;
+    return b.total === 0 ? 0 : b.completed / b.total;
+  });
+
+  // "Missing this week" = active members who didn't complete the latest week's pulse.
+  const latestKey = weekKeys[weekKeys.length - 1];
+  const latest = byWeek.get(latestKey)!;
+  const missingThisWeek = Math.max(0, activeCount - latest.completed);
+
+  return { missingThisWeek, weeklyRates };
+}

--- a/app/api/moderator/pods/route.ts
+++ b/app/api/moderator/pods/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
 import { withAuth, type AuthenticatedRequest } from "@/lib/auth/middleware";
 import { isAdmin, isModerator } from "@/lib/auth/roles";
-import { resolveCurrentPhase, type CycleConfigPhaseColumns } from "@/lib/moderator/phase";
-import { bandFor, trendOver3Weeks, type Band, type Trend, type PulseHealthCfg } from "@/lib/moderator/pulse-health";
+import { getPodsForUser } from "@/lib/moderator/pods-list";
 
 /**
  * GET /api/moderator/pods
@@ -13,213 +12,16 @@ import { bandFor, trendOver3Weeks, type Band, type Trend, type PulseHealthCfg } 
  *   - admin/owner → all pods, all cycles
  *   - moderator → only pods with an active moderator_assignment
  *
- * Each row carries enough data to render the pod summary card:
- *   - id, name, status, cycle name, cycle phase (number + display name)
- *   - missingThisWeek + band (healthy/warning/critical)
- *   - 3-week trend (up/down/flat)
- *   - activeMemberCount
+ * Shape of each row is `PodCard` in lib/moderator/pods-list.ts. The RSC
+ * page calls `getPodsForUser` directly; this endpoint exists for
+ * client-side consumers (e.g. future polling or refresh actions).
  */
-
-type PodCard = {
-  id: number;
-  name: string | null;
-  status: string;
-  cycle_id: number;
-  cycle_name: string | null;
-  phase_num: number | null;
-  phase_display_name: string | null;
-  phase_open_at: string | null;
-  phase_close_at: string | null;
-  active_member_count: number;
-  missing_this_week: number;
-  band: Band;
-  trend: Trend;
-};
-
 export const GET = withAuth(
   async (_request: NextRequest, auth: AuthenticatedRequest) => {
     if (!isModerator(auth.user) && !isAdmin(auth.user)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-
-    const participantId = auth.user.participantId;
-    const admin = isAdmin(auth.user);
-
-    // 1. Determine which pod IDs the caller can see.
-    let podIds: number[];
-    if (admin) {
-      const { data, error } = await auth.supabase
-        .from("pods")
-        .select("id")
-        .order("created_at", { ascending: false });
-      if (error) {
-        return NextResponse.json({ error: "Failed to load pods" }, { status: 500 });
-      }
-      podIds = (data ?? []).map((r) => r.id);
-    } else {
-      if (!participantId) return NextResponse.json([]);
-      const { data, error } = await auth.supabase
-        .from("moderator_assignments")
-        .select("pod_id")
-        .eq("participant_id", participantId)
-        .is("removed_at", null);
-      if (error) {
-        return NextResponse.json({ error: "Failed to load assignments" }, { status: 500 });
-      }
-      podIds = (data ?? []).map((r) => r.pod_id);
-    }
-
-    if (podIds.length === 0) return NextResponse.json([]);
-
-    // 2. Fetch pod + cycle metadata in one round trip.
-    const { data: podRows, error: podsErr } = await auth.supabase
-      .from("pods")
-      .select("id, name, status, cycle_id, cycles (id, name)")
-      .in("id", podIds);
-
-    if (podsErr) {
-      return NextResponse.json({ error: "Failed to load pod details" }, { status: 500 });
-    }
-
-    const cycleIds = Array.from(new Set((podRows ?? []).map((p) => p.cycle_id)));
-
-    // 3. cycle_config (phase windows + pulse-health thresholds).
-    const { data: configRows } = await auth.supabase
-      .from("cycle_config")
-      .select(
-        "cycle_id, problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close, pulse_band_warning_min, pulse_band_critical_min"
-      )
-      .in("cycle_id", cycleIds);
-
-    const configByCycle = new Map<number, CycleConfigPhaseColumns & PulseHealthCfg>();
-    for (const row of configRows ?? []) {
-      configByCycle.set(row.cycle_id, row);
-    }
-
-    // 4. Active membership counts per pod.
-    const { data: membershipRows } = await auth.supabase
-      .from("pod_memberships")
-      .select("pod_id, participant_id")
-      .in("pod_id", podIds)
-      .is("inactive_at", null);
-
-    const membersByPod = new Map<number, number[]>();
-    for (const m of membershipRows ?? []) {
-      const arr = membersByPod.get(m.pod_id) ?? [];
-      arr.push(m.participant_id);
-      membersByPod.set(m.pod_id, arr);
-    }
-
-    // 5. Last 3 weeks of pulse data scoped to the union of pod members.
-    //    A pulse is "completed" when completed_at IS NOT NULL.
-    const threeWeeksAgo = new Date();
-    threeWeeksAgo.setDate(threeWeeksAgo.getDate() - 21);
-
-    const allParticipantIds = Array.from(
-      new Set(Array.from(membersByPod.values()).flat())
-    );
-
-    let pulseRows: {
-      participant_id: number;
-      cycle_id: number;
-      scheduled_date: string;
-      completed_at: string | null;
-    }[] = [];
-    if (allParticipantIds.length > 0 && cycleIds.length > 0) {
-      const { data } = await auth.supabase
-        .from("pulse_checks")
-        .select("participant_id, cycle_id, scheduled_date, completed_at")
-        .in("participant_id", allParticipantIds)
-        .in("cycle_id", cycleIds)
-        .gte("scheduled_date", threeWeeksAgo.toISOString().slice(0, 10));
-      pulseRows = data ?? [];
-    }
-
-    // 6. Compute per-pod health + trend.
-    const cards: PodCard[] = (podRows ?? []).map((pod) => {
-      const cfg = configByCycle.get(pod.cycle_id) ?? null;
-      const phase = cfg ? resolveCurrentPhase(cfg) : null;
-      const memberIds = membersByPod.get(pod.id) ?? [];
-
-      // Filter pulses by both cycle (avoid cross-cycle leak when a member
-      // appears in more than one cycle) and pod membership.
-      const memberIdSet = new Set(memberIds);
-      const podPulses = pulseRows.filter(
-        (p) => p.cycle_id === pod.cycle_id && memberIdSet.has(p.participant_id)
-      );
-      const { missingThisWeek, weeklyRates } = computeWeeklyRates(podPulses, memberIds.length);
-
-      const cycleName =
-        (pod.cycles as unknown as { name: string } | null)?.name ?? null;
-
-      return {
-        id: pod.id,
-        name: pod.name,
-        status: pod.status,
-        cycle_id: pod.cycle_id,
-        cycle_name: cycleName,
-        phase_num: phase?.num ?? null,
-        phase_display_name: phase?.displayName ?? null,
-        phase_open_at: phase?.openAt ?? null,
-        phase_close_at: phase?.closeAt ?? null,
-        active_member_count: memberIds.length,
-        missing_this_week: missingThisWeek,
-        band: bandFor(missingThisWeek, cfg),
-        trend: trendOver3Weeks(weeklyRates),
-      };
-    });
-
-    // Sort: pods with non-zero missing first (within those, descending by
-    // missing); then alphabetical by name (PRD §7.10.1).
-    cards.sort((a, b) => {
-      if ((a.missing_this_week > 0) !== (b.missing_this_week > 0)) {
-        return a.missing_this_week > 0 ? -1 : 1;
-      }
-      if (a.missing_this_week !== b.missing_this_week) {
-        return b.missing_this_week - a.missing_this_week;
-      }
-      return (a.name ?? "").localeCompare(b.name ?? "");
-    });
-
+    const cards = await getPodsForUser(auth.supabase, auth.user);
     return NextResponse.json(cards);
   }
 );
-
-/**
- * Buckets pulse rows into weeks (using scheduled_date) and returns
- * { missingThisWeek, weeklyRates } where weeklyRates is the completion
- * rate (0..1) per week, oldest first.
- *
- * "This week" = the most recent week with at least one scheduled pulse
- * row for this pod's members.
- */
-function computeWeeklyRates(
-  rows: { participant_id: number; scheduled_date: string; completed_at: string | null }[],
-  activeCount: number
-): { missingThisWeek: number; weeklyRates: number[] } {
-  if (rows.length === 0 || activeCount === 0) {
-    return { missingThisWeek: 0, weeklyRates: [] };
-  }
-
-  // Group by scheduled_date (ISO yyyy-mm-dd).
-  const byWeek = new Map<string, { completed: number; total: number }>();
-  for (const r of rows) {
-    const bucket = byWeek.get(r.scheduled_date) ?? { completed: 0, total: 0 };
-    bucket.total += 1;
-    if (r.completed_at) bucket.completed += 1;
-    byWeek.set(r.scheduled_date, bucket);
-  }
-
-  const weekKeys = Array.from(byWeek.keys()).sort(); // oldest first
-  const weeklyRates = weekKeys.map((k) => {
-    const b = byWeek.get(k)!;
-    return b.total === 0 ? 0 : b.completed / b.total;
-  });
-
-  // "Missing this week" = active members who didn't complete the latest week's pulse.
-  const latestKey = weekKeys[weekKeys.length - 1];
-  const latest = byWeek.get(latestKey)!;
-  const missingThisWeek = Math.max(0, activeCount - latest.completed);
-
-  return { missingThisWeek, weeklyRates };
-}

--- a/app/api/moderator/ui-state/route.ts
+++ b/app/api/moderator/ui-state/route.ts
@@ -24,6 +24,7 @@ type Row = {
   roster_filters: Record<string, unknown> | null;
   roster_sort: string | null;
   tooltip_seen: string[] | null;
+  last_pod_tab: string | null;
 };
 
 const EMPTY_STATE: Row = {
@@ -31,6 +32,7 @@ const EMPTY_STATE: Row = {
   roster_filters: {},
   roster_sort: null,
   tooltip_seen: [],
+  last_pod_tab: null,
 };
 
 export const GET = withAuth(
@@ -46,7 +48,7 @@ export const GET = withAuth(
 
     const { data, error } = await auth.supabase
       .from("moderator_ui_state")
-      .select("last_view, roster_filters, roster_sort, tooltip_seen")
+      .select("last_view, roster_filters, roster_sort, tooltip_seen, last_pod_tab")
       .eq("participant_id", participantId)
       .maybeSingle();
 
@@ -83,11 +85,13 @@ export const PUT = withAuth(
     if (parsed.roster_sort !== undefined) patch.roster_sort = parsed.roster_sort;
     if (parsed.tooltip_seen !== undefined)
       patch.tooltip_seen = parsed.tooltip_seen;
+    if (parsed.last_pod_tab !== undefined)
+      patch.last_pod_tab = parsed.last_pod_tab;
 
     const { data, error } = await auth.supabase
       .from("moderator_ui_state")
       .upsert(patch, { onConflict: "participant_id" })
-      .select("last_view, roster_filters, roster_sort, tooltip_seen")
+      .select("last_view, roster_filters, roster_sort, tooltip_seen, last_pod_tab")
       .single();
 
     if (error) {

--- a/app/api/moderator/ui-state/route.ts
+++ b/app/api/moderator/ui-state/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAuth, type AuthenticatedRequest } from "@/lib/auth/middleware";
+import { isAdmin, isModerator } from "@/lib/auth/roles";
+import { parseBody } from "@/lib/api/request";
+import { uiStatePutSchema, type UiStatePutInput } from "@/lib/validations/moderator";
+
+/**
+ * /api/moderator/ui-state — per-poderator dashboard state.
+ *
+ * GET  — returns the caller's row, or a default empty state if no row yet.
+ * PUT  — partial upsert. Fields not present in the body are left unchanged
+ *        on existing rows. On first PUT (no row exists), the row is created
+ *        with the provided fields and defaults from the migration.
+ *
+ * Allowed callers: moderators (any assignment) + admins/owners. PRD §10
+ * explicitly states admins receive ui_state rows like poderators.
+ */
+
+const FORBIDDEN = () =>
+  NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+type Row = {
+  last_view: string | null;
+  roster_filters: Record<string, unknown> | null;
+  roster_sort: string | null;
+  tooltip_seen: string[] | null;
+};
+
+const EMPTY_STATE: Row = {
+  last_view: null,
+  roster_filters: {},
+  roster_sort: null,
+  tooltip_seen: [],
+};
+
+export const GET = withAuth(
+  async (_request: NextRequest, auth: AuthenticatedRequest) => {
+    if (!isModerator(auth.user) && !isAdmin(auth.user)) return FORBIDDEN();
+
+    const participantId = auth.user.participantId;
+    if (!participantId) {
+      // Should not happen for an authenticated moderator/admin, but
+      // protect against null participantId rather than throwing.
+      return NextResponse.json(EMPTY_STATE);
+    }
+
+    const { data, error } = await auth.supabase
+      .from("moderator_ui_state")
+      .select("last_view, roster_filters, roster_sort, tooltip_seen")
+      .eq("participant_id", participantId)
+      .maybeSingle();
+
+    if (error) {
+      return NextResponse.json(
+        { error: "Failed to load UI state" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json((data ?? EMPTY_STATE) satisfies Row);
+  }
+);
+
+export const PUT = withAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest) => {
+    if (!isModerator(auth.user) && !isAdmin(auth.user)) return FORBIDDEN();
+
+    const participantId = auth.user.participantId;
+    if (!participantId) return FORBIDDEN();
+
+    const parsed = await parseBody<UiStatePutInput>(request, uiStatePutSchema);
+    if (parsed instanceof NextResponse) return parsed;
+
+    // Build the upsert payload, including only fields the caller sent.
+    // This lets a switcher change avoid clobbering tooltip_seen, etc.
+    const patch: Record<string, unknown> = {
+      participant_id: participantId,
+      updated_at: new Date().toISOString(),
+    };
+    if (parsed.last_view !== undefined) patch.last_view = parsed.last_view;
+    if (parsed.roster_filters !== undefined)
+      patch.roster_filters = parsed.roster_filters;
+    if (parsed.roster_sort !== undefined) patch.roster_sort = parsed.roster_sort;
+    if (parsed.tooltip_seen !== undefined)
+      patch.tooltip_seen = parsed.tooltip_seen;
+
+    const { data, error } = await auth.supabase
+      .from("moderator_ui_state")
+      .upsert(patch, { onConflict: "participant_id" })
+      .select("last_view, roster_filters, roster_sort, tooltip_seen")
+      .single();
+
+    if (error) {
+      return NextResponse.json(
+        { error: "Failed to persist UI state" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(data satisfies Row);
+  }
+);

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -7,3 +7,5 @@ export { EmptyState } from "./empty-state";
 export { Spinner } from "./spinner";
 export { Field, Input, Textarea, Select } from "./form";
 export type { FieldProps, InputProps, TextareaProps, SelectProps } from "./form";
+export { Sheet } from "./sheet";
+export { Tooltip, TooltipIcon } from "./tooltip";

--- a/app/components/ui/sheet.tsx
+++ b/app/components/ui/sheet.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+
+/**
+ * Right-side drawer (a.k.a. sheet) used by the pulse review side panel
+ * (PRD §7.4) and any future drill-in surface that shouldn't navigate
+ * away from the underlying page.
+ *
+ * Controlled component: parent owns `open` and `onClose`. Closes on
+ * Esc, on backdrop click, and via the explicit close button in the
+ * header (if a title is provided) or rendered by the caller.
+ *
+ * Width defaults to a comfortable reading column; override via
+ * `widthClass` for wider/narrower content.
+ */
+
+export function Sheet({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  widthClass = "w-full sm:w-[560px]",
+  footer,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+  widthClass?: string;
+  footer?: React.ReactNode;
+}) {
+  // Close on Esc
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // Lock body scroll while open
+  React.useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[60]"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? "sheet-title" : undefined}
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity"
+        onClick={onClose}
+        aria-hidden
+      />
+
+      {/* Panel */}
+      <div
+        className={`absolute right-0 top-0 flex h-full ${widthClass} flex-col border-l border-whisper bg-[rgba(11,16,22,0.98)] shadow-[-12px_0_32px_rgba(0,0,0,0.5)]`}
+      >
+        {/* Header — only renders if a title is supplied */}
+        {(title || description) && (
+          <div className="flex items-start justify-between gap-4 border-b border-whisper px-6 py-4">
+            <div className="min-w-0">
+              {title && (
+                <h2
+                  id="sheet-title"
+                  className="text-base font-semibold tracking-tight text-white"
+                >
+                  {title}
+                </h2>
+              )}
+              {description && (
+                <p className="mt-1 text-xs text-cloud/60">{description}</p>
+              )}
+            </div>
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="rounded-md p-1 text-cloud/60 transition-colors duration-150 hover:bg-white/[0.04] hover:text-cloud focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2 focus-visible:ring-offset-midnight"
+            >
+              <X className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        )}
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto">{children}</div>
+
+        {/* Footer — sticky at bottom if provided */}
+        {footer && (
+          <div className="border-t border-whisper bg-[rgba(11,16,22,0.98)] px-6 py-4">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ui/sheet.tsx
+++ b/app/components/ui/sheet.tsx
@@ -71,7 +71,7 @@ export function Sheet({
 
       {/* Panel */}
       <div
-        className={`absolute right-0 top-0 flex h-full ${widthClass} flex-col border-l border-whisper bg-[rgba(11,16,22,0.98)] shadow-[-12px_0_32px_rgba(0,0,0,0.5)]`}
+        className={`absolute right-0 top-0 flex h-full ${widthClass} flex-col border-l border-whisper bg-[rgba(42,49,66,0.98)] shadow-[-12px_0_32px_rgba(0,0,0,0.5)]`}
       >
         {/* Header — only renders if a title is supplied */}
         {(title || description) && (
@@ -104,7 +104,7 @@ export function Sheet({
 
         {/* Footer — sticky at bottom if provided */}
         {footer && (
-          <div className="border-t border-whisper bg-[rgba(11,16,22,0.98)] px-6 py-4">
+          <div className="border-t border-whisper bg-[rgba(42,49,66,0.98)] px-6 py-4">
             {footer}
           </div>
         )}

--- a/app/components/ui/tooltip.tsx
+++ b/app/components/ui/tooltip.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as React from "react";
+import { HelpCircle } from "lucide-react";
+
+/**
+ * Tooltip primitive — hover/focus reveal.
+ *
+ * Two usage modes:
+ *
+ * 1. Wrap content with a trigger:
+ *
+ *      <Tooltip content="Explains the badge">
+ *        <StatusBadge variant="active">Active</StatusBadge>
+ *      </Tooltip>
+ *
+ * 2. Standalone "?" icon:
+ *
+ *      <TooltipIcon content="Explains the metric" />
+ *
+ * Auto-suppress wiring (PRD §7.8) — read the prop `autoShow` and pair
+ * with `onAutoShown` to persist "seen" state to moderator_ui_state.
+ * Without those props, the tooltip is hover-only.
+ *
+ * Positioning is intentionally minimal (top, centered). For the dashboard
+ * scope, the rendering containers have enough room — if a tooltip ever
+ * gets clipped, switch the consumer to a different `placement`.
+ */
+
+type Placement = "top" | "bottom";
+
+export function Tooltip({
+  content,
+  children,
+  placement = "top",
+  autoShow = false,
+  onAutoShown,
+}: {
+  content: React.ReactNode;
+  children: React.ReactNode;
+  placement?: Placement;
+  /** When true and the tooltip hasn't been auto-shown yet, reveal on mount briefly. */
+  autoShow?: boolean;
+  /** Called once the auto-show flashes (so the parent can persist "seen"). */
+  onAutoShown?: () => void;
+}) {
+  const [hovered, setHovered] = React.useState(false);
+  const [autoVisible, setAutoVisible] = React.useState(false);
+  const autoNotified = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!autoShow) return;
+    setAutoVisible(true);
+    const t = setTimeout(() => {
+      setAutoVisible(false);
+      if (!autoNotified.current) {
+        autoNotified.current = true;
+        onAutoShown?.();
+      }
+    }, 4000);
+    return () => clearTimeout(t);
+  }, [autoShow, onAutoShown]);
+
+  const visible = hovered || autoVisible;
+
+  return (
+    <span
+      className="relative inline-flex"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onFocus={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
+    >
+      {children}
+      {visible && (
+        <span
+          role="tooltip"
+          className={`pointer-events-none absolute left-1/2 z-[70] w-max max-w-xs -translate-x-1/2 rounded-md border border-whisper bg-[rgba(11,16,22,0.98)] px-2.5 py-1.5 text-xs text-cloud shadow-lg ${
+            placement === "top" ? "bottom-full mb-2" : "top-full mt-2"
+          }`}
+        >
+          {content}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Standalone "?" icon with a tooltip. Use when there's no natural anchor
+ * element to wrap — e.g. next to a section header or band label.
+ */
+export function TooltipIcon({
+  content,
+  placement,
+  className,
+  autoShow,
+  onAutoShown,
+}: {
+  content: React.ReactNode;
+  placement?: Placement;
+  className?: string;
+  autoShow?: boolean;
+  onAutoShown?: () => void;
+}) {
+  return (
+    <Tooltip
+      content={content}
+      placement={placement}
+      autoShow={autoShow}
+      onAutoShown={onAutoShown}
+    >
+      <span
+        className={`inline-flex items-center text-cloud/40 transition-colors duration-150 hover:text-cloud/80 ${className ?? ""}`}
+        aria-label="More info"
+        role="img"
+      >
+        <HelpCircle className="h-3.5 w-3.5" aria-hidden />
+      </span>
+    </Tooltip>
+  );
+}

--- a/app/components/ui/tooltip.tsx
+++ b/app/components/ui/tooltip.tsx
@@ -75,7 +75,7 @@ export function Tooltip({
       {visible && (
         <span
           role="tooltip"
-          className={`pointer-events-none absolute left-1/2 z-[70] w-max max-w-xs -translate-x-1/2 rounded-md border border-whisper bg-[rgba(11,16,22,0.98)] px-2.5 py-1.5 text-xs text-cloud shadow-lg ${
+          className={`pointer-events-none absolute left-1/2 z-[70] w-max max-w-xs -translate-x-1/2 rounded-md border border-whisper bg-[rgba(42,49,66,0.98)] px-2.5 py-1.5 text-xs text-cloud shadow-lg ${
             placement === "top" ? "bottom-full mb-2" : "top-full mt-2"
           }`}
         >

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,14 @@
 @import "tailwindcss";
 
 @theme inline {
-  /* Brand surfaces */
-  --color-midnight: #0b1016;
-  --color-ink: #0e1520;
+  /* Brand surfaces — lifted from #0b1016/#0e1520 on 2026-06-02 (style/lighter-theme)
+     to ease the heavy near-black feel while keeping the dark-UI aesthetic.
+     Layered transparencies (bg-white/[0.02..0.08]) and text/border tokens
+     auto-adjust against the new base. Hardcoded rgba(28,34,48,X)
+     overlays in layout.tsx / sheet.tsx / tooltip.tsx / switcher.tsx /
+     globals.css :: dialog::backdrop are kept in sync with this value. */
+  --color-midnight: #2a3142;
+  --color-ink: #343c4e;
 
   /* Brand colors */
   --color-teal: #0094a0;
@@ -70,7 +75,7 @@ label[for] {
 
 /* Native modal backdrop per design system */
 dialog::backdrop {
-  background: rgba(11, 16, 22, 0.8);
+  background: rgba(42, 49, 66, 0.8);
   backdrop-filter: blur(8px) saturate(140%);
   -webkit-backdrop-filter: blur(8px) saturate(140%);
 }

--- a/docs/PRD-moderator-dashboard-mockups.html
+++ b/docs/PRD-moderator-dashboard-mockups.html
@@ -407,10 +407,6 @@ tailwind.config = {
             <button class="rounded-full px-3 py-1 font-medium bg-teal/20 text-aqua">Last 4 weeks</button>
             <button class="rounded-full px-3 py-1 font-medium text-cloud/60 hover:text-cloud transition-colors">Full cycle</button>
           </div>
-          <button class="inline-flex items-center gap-1.5 rounded-md border border-whisper bg-white/[0.04] px-3 py-1 text-xs text-cloud/85 hover:bg-white/[0.08] hover:text-white transition-colors" title="Copies a summary of your pod data. You'll paste it into your own AI tool — OLOS doesn't send anything.">
-            <i data-lucide="copy" class="h-3 w-3"></i>
-            Copy summary prompt
-          </button>
         </div>
       </div>
 
@@ -456,101 +452,46 @@ tailwind.config = {
           </div>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 pt-4 border-t border-teal/15">
-          <div>
-            <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Top AI tools</div>
-            <div class="flex flex-wrap gap-1.5">
-              <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs text-aqua">ChatGPT <span class="tabular-nums opacity-80">16</span></span>
-              <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/15 px-2.5 py-0.5 text-xs text-aqua/90">Claude <span class="tabular-nums opacity-80">13</span></span>
-              <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/10 px-2.5 py-0.5 text-xs text-aqua/80">Cursor <span class="tabular-nums opacity-80">8</span></span>
-              <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2.5 py-0.5 text-xs text-cloud/70">v0 <span class="tabular-nums opacity-80">3</span></span>
-            </div>
-          </div>
-          <div>
-            <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Top stuck-on themes</div>
-            <ol class="text-xs text-cloud/85 space-y-1 list-decimal list-inside marker:text-cloud/40">
-              <li>Confusion about proposal scope <span class="text-cloud/40 tabular-nums">· 7</span></li>
-              <li>Time pressure on pulse window <span class="text-cloud/40 tabular-nums">· 4</span></li>
-              <li>Tool setup friction <span class="text-cloud/40 tabular-nums">· 3</span></li>
-            </ol>
-          </div>
-          <div>
-            <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Top help requests</div>
-            <ol class="text-xs text-cloud/85 space-y-1 list-decimal list-inside marker:text-cloud/40">
-              <li>Pairing with a technical pod-mate <span class="text-cloud/40 tabular-nums">· 5</span></li>
-              <li>Non-technical proposal examples <span class="text-cloud/40 tabular-nums">· 4</span></li>
-              <li>Office-hours or staff time <span class="text-cloud/40 tabular-nums">· 2</span></li>
-            </ol>
+        <div class="pt-4 border-t border-teal/15">
+          <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Top AI tools — all your pods combined</div>
+          <div class="flex flex-wrap gap-1.5">
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs text-aqua">ChatGPT <span class="tabular-nums opacity-80">16</span></span>
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/15 px-2.5 py-0.5 text-xs text-aqua/90">Claude <span class="tabular-nums opacity-80">13</span></span>
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/10 px-2.5 py-0.5 text-xs text-aqua/80">Cursor <span class="tabular-nums opacity-80">8</span></span>
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2.5 py-0.5 text-xs text-cloud/70">v0 <span class="tabular-nums opacity-80">3</span></span>
           </div>
         </div>
       </div>
 
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
 
-        <!-- Patterns across pods -->
-        <div class="lg:col-span-2 rounded-md border border-whisper bg-white/[0.02] p-5">
-          <div class="flex items-center justify-between mb-4">
-            <div class="text-xs uppercase tracking-widest text-cloud/40">Patterns showing up in more than one pod</div>
-            <button class="text-cloud/40 hover:text-cloud transition-colors p-1" title="How themes are generated">
-              <i data-lucide="help-circle" class="h-4 w-4"></i>
-            </button>
+        <!-- AI-assisted summary block (§7.10.3) -->
+        <div class="lg:col-span-2 rounded-md border border-teal/25 bg-teal/[0.04] p-5">
+          <div class="flex items-start justify-between gap-3 mb-3">
+            <div>
+              <div class="text-xs uppercase tracking-widest text-aqua/80 mb-1">AI-assisted summary</div>
+              <div class="text-sm text-cloud/85">Bundle recent pulse comments with a ready-to-use prompt and paste into ChatGPT, Claude, or your AI tool of choice.</div>
+            </div>
+            <i data-lucide="sparkles" class="h-5 w-5 text-aqua/70 flex-shrink-0 mt-0.5"></i>
           </div>
 
-          <div class="space-y-3">
-            <div class="rounded-md border border-whisper bg-white/[0.01] p-4 hover:bg-white/[0.03] transition-colors cursor-pointer">
-              <div class="flex items-start justify-between gap-3 mb-2">
-                <div class="text-sm font-semibold text-cloud">Confusion about solution proposal scope</div>
-                <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">7 members</span>
-              </div>
-              <div class="flex flex-wrap items-center gap-1.5">
-                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
-                  <i data-lucide="users" class="h-3 w-3"></i>
-                  Health Systems Access
-                </span>
-                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
-                  <i data-lucide="users" class="h-3 w-3"></i>
-                  Medical Records Consolidation
-                </span>
-                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
-                  <i data-lucide="users" class="h-3 w-3"></i>
-                  Energy Grid Resilience
-                </span>
-              </div>
+          <div class="rounded-md bg-ink/40 border border-whisper p-4 mb-3 max-h-48 overflow-y-auto">
+            <div class="text-[10px] uppercase tracking-widest text-cloud/40 mb-2">Pulse comments included · last 4 weeks · 27 responses across 3 pods</div>
+            <div class="space-y-2.5 text-xs text-cloud/80">
+              <div><span class="text-cloud/45">[LP · Health · week 4]</span> I don't really understand what a "solution proposal" is supposed to look like. The example was technical and I'm not sure how to scope something I could actually contribute to.</div>
+              <div><span class="text-cloud/45">[SK · Medical · week 4]</span> Pulse window keeps closing while I'm in meetings — would love a longer evening window.</div>
+              <div><span class="text-cloud/45">[JR · Energy · week 4]</span> Stuck on Cursor setup — keep getting auth errors. Anyone got a working config?</div>
+              <div><span class="text-cloud/45">[MW · Health · week 3]</span> Would love to pair with someone more technical — happy to bring policy framing.</div>
+              <div class="text-cloud/45 italic">…23 more comments included in the copy</div>
             </div>
+          </div>
 
-            <div class="rounded-md border border-whisper bg-white/[0.01] p-4 hover:bg-white/[0.03] transition-colors cursor-pointer">
-              <div class="flex items-start justify-between gap-3 mb-2">
-                <div class="text-sm font-semibold text-cloud">Wanting to pair with a more technical pod-mate</div>
-                <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">5 members</span>
-              </div>
-              <div class="flex flex-wrap items-center gap-1.5">
-                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
-                  <i data-lucide="users" class="h-3 w-3"></i>
-                  Health Systems Access
-                </span>
-                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
-                  <i data-lucide="users" class="h-3 w-3"></i>
-                  Medical Records Consolidation
-                </span>
-              </div>
-            </div>
-
-            <div class="rounded-md border border-whisper bg-white/[0.01] p-4 hover:bg-white/[0.03] transition-colors cursor-pointer">
-              <div class="flex items-start justify-between gap-3 mb-2">
-                <div class="text-sm font-semibold text-cloud">Time pressure on weekday pulse window</div>
-                <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">4 members</span>
-              </div>
-              <div class="flex flex-wrap items-center gap-1.5">
-                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
-                  <i data-lucide="users" class="h-3 w-3"></i>
-                  Medical Records Consolidation
-                </span>
-                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
-                  <i data-lucide="users" class="h-3 w-3"></i>
-                  Energy Grid Resilience
-                </span>
-              </div>
-            </div>
+          <div class="flex items-center justify-between gap-3">
+            <span class="text-xs text-cloud/50">OLOS doesn't send anything. You'll paste this into your own AI tool.</span>
+            <button class="inline-flex items-center gap-2 rounded-md bg-teal/80 hover:bg-teal px-4 py-2 text-sm font-medium text-white transition-colors shadow-[0_1px_4px_rgba(0,148,160,0.2)]">
+              <i data-lucide="copy" class="h-4 w-4"></i>
+              Copy prompt + responses
+            </button>
           </div>
         </div>
 
@@ -1048,68 +989,33 @@ tailwind.config = {
 
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
 
-        <!-- Top stuck-on + help themes -->
-        <div class="lg:col-span-2 rounded-md border border-whisper bg-white/[0.02] p-5">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <!-- AI-assisted summary block (§7.10.3) — per-pod scope -->
+        <div class="lg:col-span-2 rounded-md border border-teal/25 bg-teal/[0.04] p-5">
+          <div class="flex items-start justify-between gap-3 mb-3">
             <div>
-              <div class="flex items-center justify-between mb-3">
-                <div class="text-xs uppercase tracking-widest text-cloud/40">What members are stuck on</div>
-                <i data-lucide="help-circle" class="h-3.5 w-3.5 text-cloud/30"></i>
-              </div>
-              <div class="space-y-2">
-                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
-                  <div class="flex items-start justify-between gap-2 mb-1">
-                    <div class="text-sm text-cloud">Confusion about proposal scope</div>
-                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">4 members</span>
-                  </div>
-                  <div class="text-xs text-cloud/50">Linda P., Sarah K., Aisha M., Diane R.</div>
-                </div>
-                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
-                  <div class="flex items-start justify-between gap-2 mb-1">
-                    <div class="text-sm text-cloud">Cursor setup &amp; first run</div>
-                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">2 members</span>
-                  </div>
-                  <div class="text-xs text-cloud/50">Priya S., Aisha M.</div>
-                </div>
-                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
-                  <div class="flex items-start justify-between gap-2 mb-1">
-                    <div class="text-sm text-cloud">Time pressure on weekday pulse</div>
-                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">2 members</span>
-                  </div>
-                  <div class="text-xs text-cloud/50">Linda P., Eli T.</div>
-                </div>
-              </div>
+              <div class="text-xs uppercase tracking-widest text-aqua/80 mb-1">AI-assisted summary</div>
+              <div class="text-sm text-cloud/85">Bundle this pod's recent pulse comments with a ready-to-use prompt. Paste into ChatGPT, Claude, or your AI tool of choice for analysis.</div>
             </div>
+            <i data-lucide="sparkles" class="h-5 w-5 text-aqua/70 flex-shrink-0 mt-0.5"></i>
+          </div>
 
-            <div>
-              <div class="flex items-center justify-between mb-3">
-                <div class="text-xs uppercase tracking-widest text-cloud/40">Help members are asking for</div>
-                <i data-lucide="help-circle" class="h-3.5 w-3.5 text-cloud/30"></i>
-              </div>
-              <div class="space-y-2">
-                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
-                  <div class="flex items-start justify-between gap-2 mb-1">
-                    <div class="text-sm text-cloud">Pair with a technical pod-mate</div>
-                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">3 members</span>
-                  </div>
-                  <div class="text-xs text-cloud/50">Linda P., Sarah K., Diane R.</div>
-                </div>
-                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
-                  <div class="flex items-start justify-between gap-2 mb-1">
-                    <div class="text-sm text-cloud">Non-technical proposal examples</div>
-                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">2 members</span>
-                  </div>
-                  <div class="text-xs text-cloud/50">Linda P., Aisha M.</div>
-                </div>
-                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
-                  <div class="flex items-start justify-between gap-2 mb-1">
-                    <div class="text-sm text-cloud">Office-hours with staff</div>
-                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">2 members</span>
-                  </div>
-                  <div class="text-xs text-cloud/50">Priya S., Sarah K.</div>
-                </div>
-              </div>
+          <div class="rounded-md bg-ink/40 border border-whisper p-4 mb-3 max-h-48 overflow-y-auto">
+            <div class="text-[10px] uppercase tracking-widest text-cloud/40 mb-2">Pulse comments included · last 4 weeks · 12 responses</div>
+            <div class="space-y-2.5 text-xs text-cloud/80">
+              <div><span class="text-cloud/45">[LP · week 4]</span> I don't really understand what a "solution proposal" is supposed to look like. The example was technical and I'm not sure how to scope something I could actually contribute to.</div>
+              <div><span class="text-cloud/45">[SK · week 4]</span> Would love to pair with someone more technical — happy to bring policy framing.</div>
+              <div><span class="text-cloud/45">[PS · week 4]</span> Cursor install hit auth errors — spent 2 hours on it before giving up. Need a known-good config.</div>
+              <div><span class="text-cloud/45">[AM · week 3]</span> Non-technical examples would help — most of what's been shared looks like a software project.</div>
+              <div class="text-cloud/45 italic">…8 more comments included in the copy</div>
             </div>
+          </div>
+
+          <div class="flex items-center justify-between gap-3">
+            <span class="text-xs text-cloud/50">OLOS doesn't send anything. You'll paste this into your own AI tool.</span>
+            <button class="inline-flex items-center gap-2 rounded-md bg-teal/80 hover:bg-teal px-4 py-2 text-sm font-medium text-white transition-colors shadow-[0_1px_4px_rgba(0,148,160,0.2)]">
+              <i data-lucide="copy" class="h-4 w-4"></i>
+              Copy prompt + responses
+            </button>
           </div>
         </div>
 
@@ -1407,39 +1313,11 @@ tailwind.config = {
           </div>
 
           <!-- Aggregation grid -->
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-5 pt-4 border-t border-teal/15">
-            <div>
-              <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Tools she's used</div>
-              <div class="flex flex-wrap gap-1.5">
-                <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs text-aqua">ChatGPT <span class="tabular-nums opacity-80">3</span></span>
-                <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/15 px-2.5 py-0.5 text-xs text-aqua/90">Claude <span class="tabular-nums opacity-80">2</span></span>
-              </div>
-            </div>
-            <div>
-              <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Recurring stuck-on themes</div>
-              <ul class="text-xs text-cloud/85 space-y-1">
-                <li class="flex items-center justify-between gap-2 hover:text-aqua transition-colors cursor-pointer">
-                  <span>Confusion about proposal scope</span>
-                  <span class="text-cloud/40 tabular-nums">2</span>
-                </li>
-                <li class="flex items-center justify-between gap-2 hover:text-aqua transition-colors cursor-pointer">
-                  <span>Feeling behind technically</span>
-                  <span class="text-cloud/40 tabular-nums">2</span>
-                </li>
-              </ul>
-            </div>
-            <div class="sm:col-span-2 pt-4 border-t border-teal/15">
-              <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Help she's asked for</div>
-              <ul class="text-xs text-cloud/85 space-y-1">
-                <li class="flex items-center justify-between gap-2 hover:text-aqua transition-colors cursor-pointer">
-                  <span>Pair with a more technical pod-mate</span>
-                  <span class="text-cloud/40 tabular-nums">2 weeks</span>
-                </li>
-                <li class="flex items-center justify-between gap-2 hover:text-aqua transition-colors cursor-pointer">
-                  <span>Non-technical proposal examples</span>
-                  <span class="text-cloud/40 tabular-nums">1 week</span>
-                </li>
-              </ul>
+          <div class="pt-4 border-t border-teal/15">
+            <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Tools she's used</div>
+            <div class="flex flex-wrap gap-1.5">
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs text-aqua">ChatGPT <span class="tabular-nums opacity-80">3</span></span>
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/15 px-2.5 py-0.5 text-xs text-aqua/90">Claude <span class="tabular-nums opacity-80">2</span></span>
             </div>
           </div>
         </div>

--- a/docs/PRD-moderator-dashboard-mockups.html
+++ b/docs/PRD-moderator-dashboard-mockups.html
@@ -98,7 +98,7 @@ tailwind.config = {
       <span class="text-sm text-cloud/60">Poderator Dashboard</span>
     </div>
     <div class="flex items-center gap-1 rounded-full bg-white/[0.04] p-1">
-      <button onclick="showScreen('all-pods')" id="tab-all-pods" class="rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-150 mock-tab-active">All Pods</button>
+      <button onclick="showScreen('all-pods')" id="tab-all-pods" class="rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-150 mock-tab-active">All pods</button>
       <button onclick="showScreen('per-pod')" id="tab-per-pod" class="rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-150 mock-tab-inactive">Per-pod</button>
       <button onclick="showScreen('pulse')" id="tab-pulse" class="rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-150 mock-tab-inactive">Pulse Review</button>
     </div>
@@ -117,7 +117,6 @@ tailwind.config = {
         <span class="text-sm font-semibold tracking-wide text-white">OLOS</span>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a href="#" class="text-cloud/60 hover:text-aqua transition-colors">Cycles</a>
-          <a href="#" class="text-white">Pods</a>
           <a href="#" class="text-cloud/60 hover:text-aqua transition-colors">Members</a>
         </nav>
       </div>
@@ -139,7 +138,7 @@ tailwind.config = {
         <!-- Pod switcher -->
         <div class="inline-flex items-center gap-2 rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-sm">
           <i data-lucide="layers" class="h-4 w-4 text-cloud/60"></i>
-          <span class="text-cloud">All Pods</span>
+          <span class="text-cloud">All pods</span>
           <span class="text-cloud/40">·</span>
           <span class="text-cloud/60 tabular-nums">3 pods</span>
           <i data-lucide="chevron-down" class="h-4 w-4 text-cloud/40 ml-1"></i>
@@ -164,11 +163,14 @@ tailwind.config = {
               <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                 <span class="text-sm font-semibold text-white">Sarah K.</span>
                 <span class="text-xs text-cloud/50">·</span>
-                <span class="text-xs text-cloud/60">Policy analyst, Federal · evenings + weekends</span>
+                <span class="text-xs text-cloud/60">Policy analyst · Federal · evenings + weekends</span>
               </div>
               <div class="mt-1.5 flex items-center gap-2 text-sm text-yellow-300">
                 <i data-lucide="alert-triangle" class="h-4 w-4 flex-shrink-0"></i>
                 <span class="font-medium">Missed 2 consecutive pulses</span>
+                <button class="text-yellow-300/60 hover:text-yellow-300 transition-colors" title="At-risk nudge: fires when a member misses the configured consecutive-miss threshold (default 2). System flags; you follow up via Slack.">
+                  <i data-lucide="help-circle" class="h-3 w-3"></i>
+                </button>
                 <span class="text-cloud/40">·</span>
                 <span class="text-cloud/60">last active 11 days ago</span>
               </div>
@@ -187,6 +189,9 @@ tailwind.config = {
                 <i data-lucide="message-square" class="h-3.5 w-3.5"></i>
                 Slack DM
               </button>
+              <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud/70 transition-colors" aria-label="Dismiss" title="Dismiss this nudge">
+                <i data-lucide="x" class="h-4 w-4"></i>
+              </button>
             </div>
           </div>
         </div>
@@ -199,11 +204,14 @@ tailwind.config = {
               <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                 <span class="text-sm font-semibold text-white">Jamal R.</span>
                 <span class="text-xs text-cloud/50">·</span>
-                <span class="text-xs text-cloud/60">Program analyst, Contractor · weekday lunches</span>
+                <span class="text-xs text-cloud/60">Program analyst · Contractor · weekday lunches</span>
               </div>
               <div class="mt-1.5 flex items-center gap-2 text-sm text-yellow-300">
                 <i data-lucide="alert-triangle" class="h-4 w-4 flex-shrink-0"></i>
                 <span class="font-medium">Missed 2 consecutive pulses</span>
+                <button class="text-yellow-300/60 hover:text-yellow-300 transition-colors" title="At-risk nudge: fires when a member misses the configured consecutive-miss threshold (default 2). System flags; you follow up via Slack.">
+                  <i data-lucide="help-circle" class="h-3 w-3"></i>
+                </button>
                 <span class="text-cloud/40">·</span>
                 <span class="text-cloud/60">last active 9 days ago</span>
               </div>
@@ -222,6 +230,9 @@ tailwind.config = {
                 <i data-lucide="message-square" class="h-3.5 w-3.5"></i>
                 Slack DM
               </button>
+              <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud/70 transition-colors" aria-label="Dismiss" title="Dismiss this nudge">
+                <i data-lucide="x" class="h-4 w-4"></i>
+              </button>
             </div>
           </div>
         </div>
@@ -234,11 +245,14 @@ tailwind.config = {
               <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                 <span class="text-sm font-semibold text-white">Linda P.</span>
                 <span class="text-xs text-cloud/50">·</span>
-                <span class="text-xs text-cloud/60">Researcher, NGO · weekends only</span>
+                <span class="text-xs text-cloud/60">Researcher · NGO · weekends only</span>
               </div>
               <div class="mt-1.5 flex items-center gap-2 text-sm text-yellow-300">
                 <i data-lucide="alert-triangle" class="h-4 w-4 flex-shrink-0"></i>
                 <span class="font-medium">Missed 3 consecutive pulses</span>
+                <button class="text-yellow-300/60 hover:text-yellow-300 transition-colors" title="At-risk nudge: fires when a member misses the configured consecutive-miss threshold (default 2). System flags; you follow up via Slack.">
+                  <i data-lucide="help-circle" class="h-3 w-3"></i>
+                </button>
                 <span class="text-cloud/40">·</span>
                 <span class="text-cloud/60">last active 19 days ago</span>
               </div>
@@ -256,6 +270,9 @@ tailwind.config = {
               <button class="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium text-cloud/70 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud transition-colors">
                 <i data-lucide="message-square" class="h-3.5 w-3.5"></i>
                 Slack DM
+              </button>
+              <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud/70 transition-colors" aria-label="Dismiss" title="Dismiss this nudge">
+                <i data-lucide="x" class="h-4 w-4"></i>
               </button>
             </div>
           </div>
@@ -390,6 +407,10 @@ tailwind.config = {
             <button class="rounded-full px-3 py-1 font-medium bg-teal/20 text-aqua">Last 4 weeks</button>
             <button class="rounded-full px-3 py-1 font-medium text-cloud/60 hover:text-cloud transition-colors">Full cycle</button>
           </div>
+          <button class="inline-flex items-center gap-1.5 rounded-md border border-whisper bg-white/[0.04] px-3 py-1 text-xs text-cloud/85 hover:bg-white/[0.08] hover:text-white transition-colors" title="Copies a summary of your pod data. You'll paste it into your own AI tool — OLOS doesn't send anything.">
+            <i data-lucide="copy" class="h-3 w-3"></i>
+            Copy summary prompt
+          </button>
         </div>
       </div>
 
@@ -564,10 +585,6 @@ tailwind.config = {
             </div>
           </div>
 
-          <div class="mt-5 pt-4 border-t border-whisper text-xs text-cloud/60">
-            <i data-lucide="lightbulb" class="inline h-3 w-3 text-aqua mr-1"></i>
-            Health is heavy on ChatGPT; Medical Records is leaning into Cursor. Worth a cross-pod intro.
-          </div>
         </div>
 
       </div>
@@ -636,7 +653,6 @@ tailwind.config = {
         <span class="text-sm font-semibold tracking-wide text-white">OLOS</span>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a href="#" class="text-cloud/60 hover:text-aqua transition-colors">Cycles</a>
-          <a href="#" class="text-white">Pods</a>
           <a href="#" class="text-cloud/60 hover:text-aqua transition-colors">Members</a>
         </nav>
       </div>
@@ -665,6 +681,8 @@ tailwind.config = {
         <div class="inline-flex items-center gap-2 rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-sm">
           <i data-lucide="layers" class="h-4 w-4 text-cloud/60"></i>
           <span class="text-cloud">Health Systems Access</span>
+          <span class="text-cloud/40">·</span>
+          <span class="text-cloud/60 tabular-nums">3 pods</span>
           <i data-lucide="chevron-down" class="h-4 w-4 text-cloud/40 ml-1"></i>
         </div>
       </div>
@@ -689,24 +707,36 @@ tailwind.config = {
         <div class="rounded-md border border-whisper bg-white/[0.02] p-5">
           <div class="text-xs uppercase tracking-widest text-cloud/40 mb-2">Current phase</div>
           <div class="text-base font-semibold text-white">Phase 4 · Solution Proposals</div>
-          <div class="mt-2 flex items-center gap-2 text-xs">
-            <span class="inline-flex items-center gap-1.5 text-yellow-300">
+          <div class="mt-2 space-y-1 text-xs">
+            <div class="flex items-center gap-1.5 text-cloud/60">
+              <span class="text-cloud/40">Opened</span>
+              <span class="tabular-nums">May 15</span>
+            </div>
+            <div class="flex items-center gap-1.5 text-yellow-300">
               <i data-lucide="clock" class="h-3.5 w-3.5"></i>
-              Closes in 2 days
-            </span>
-            <span class="text-cloud/40 tabular-nums">May 22</span>
+              <span>Closes May 22</span>
+              <span class="text-cloud/40">· in 2 days</span>
+            </div>
           </div>
         </div>
 
         <!-- Pulse this week -->
         <div class="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-5">
-          <div class="text-xs uppercase tracking-widest text-yellow-300/80 mb-2">Pulse this week</div>
+          <div class="flex items-center justify-between mb-2">
+            <div class="text-xs uppercase tracking-widest text-yellow-300/80">Pulse this week</div>
+            <button class="text-cloud/40 hover:text-cloud transition-colors" title="Count of pod members who haven't submitted this week's pulse. Banded into healthy / warning / critical by cycle-configurable thresholds.">
+              <i data-lucide="help-circle" class="h-3.5 w-3.5"></i>
+            </button>
+          </div>
           <div class="flex items-baseline gap-2">
             <span class="text-3xl font-bold tabular-nums text-yellow-300">1</span>
             <span class="text-sm text-cloud/70">missing</span>
-            <span class="trend-down text-base ml-auto" title="Falling vs last 3 weeks">↓</span>
+            <button class="trend-down text-base ml-auto inline-flex items-center gap-1" title="Falling vs last 3 weeks. Click ? to learn how the trend is calculated.">
+              ↓
+              <i data-lucide="help-circle" class="h-3 w-3 text-cloud/40"></i>
+            </button>
           </div>
-          <div class="mt-2.5 text-xs text-cloud/60">Healthy: 0 · Warning: 1–2 · Critical: 3+</div>
+          <div class="mt-2.5 text-xs text-cloud/60">Healthy: 0 · Warning: 1–2 · Critical: 3+ <span class="text-cloud/40">(cycle defaults)</span></div>
         </div>
 
         <!-- Members -->
@@ -775,7 +805,14 @@ tailwind.config = {
             <tr>
               <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">Member</th>
               <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60 hidden md:table-cell">Background</th>
-              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">Pulse</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
+                <span class="inline-flex items-center gap-1">
+                  Pulse
+                  <button class="text-cloud/40 hover:text-cloud transition-colors" title="Current = pulsed this week. Pending = window open, no submission yet. Late = window closed, no submission. At risk = hit consecutive-miss threshold.">
+                    <i data-lucide="help-circle" class="h-3 w-3"></i>
+                  </button>
+                </span>
+              </th>
               <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60 hidden md:table-cell">Last active</th>
               <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-cloud/60"></th>
             </tr>
@@ -803,7 +840,7 @@ tailwind.config = {
               <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">19 days ago</td>
               <td class="px-4 py-3 text-right">
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
-                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                  <i data-lucide="clipboard-list" class="h-4 w-4"></i>
                 </button>
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
                   <i data-lucide="message-square" class="h-4 w-4"></i>
@@ -832,7 +869,7 @@ tailwind.config = {
               <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">8 days ago</td>
               <td class="px-4 py-3 text-right">
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
-                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                  <i data-lucide="clipboard-list" class="h-4 w-4"></i>
                 </button>
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
                   <i data-lucide="message-square" class="h-4 w-4"></i>
@@ -847,7 +884,7 @@ tailwind.config = {
                   <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">PS</div>
                   <div>
                     <div class="text-sm font-medium text-white">Priya S.</div>
-                    <div class="text-xs text-cloud/50">Built one Streamlit app · weekday evenings</div>
+                    <div class="text-xs text-cloud/50">Has built with AI · weekday evenings</div>
                   </div>
                 </div>
               </td>
@@ -861,7 +898,7 @@ tailwind.config = {
               <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">2 days ago</td>
               <td class="px-4 py-3 text-right">
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
-                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                  <i data-lucide="clipboard-list" class="h-4 w-4"></i>
                 </button>
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
                   <i data-lucide="message-square" class="h-4 w-4"></i>
@@ -876,7 +913,7 @@ tailwind.config = {
                   <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">MW</div>
                   <div>
                     <div class="text-sm font-medium text-white">Marcus W.</div>
-                    <div class="text-xs text-cloud/50">Ships side projects · flexible</div>
+                    <div class="text-xs text-cloud/50">Ships AI projects · flexible</div>
                   </div>
                 </div>
               </td>
@@ -890,7 +927,7 @@ tailwind.config = {
               <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">Yesterday</td>
               <td class="px-4 py-3 text-right">
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
-                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                  <i data-lucide="clipboard-list" class="h-4 w-4"></i>
                 </button>
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
                   <i data-lucide="message-square" class="h-4 w-4"></i>
@@ -919,7 +956,7 @@ tailwind.config = {
               <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">2 days ago</td>
               <td class="px-4 py-3 text-right">
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
-                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                  <i data-lucide="clipboard-list" class="h-4 w-4"></i>
                 </button>
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
                   <i data-lucide="message-square" class="h-4 w-4"></i>
@@ -934,7 +971,7 @@ tailwind.config = {
                   <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">ET</div>
                   <div>
                     <div class="text-sm font-medium text-white">Eli T.</div>
-                    <div class="text-xs text-cloud/50">Returning upskiller · evenings</div>
+                    <div class="text-xs text-cloud/50">Has built with AI · evenings</div>
                   </div>
                 </div>
               </td>
@@ -948,7 +985,7 @@ tailwind.config = {
               <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">3 days ago</td>
               <td class="px-4 py-3 text-right">
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
-                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                  <i data-lucide="clipboard-list" class="h-4 w-4"></i>
                 </button>
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
                   <i data-lucide="message-square" class="h-4 w-4"></i>
@@ -977,7 +1014,7 @@ tailwind.config = {
               <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">Today</td>
               <td class="px-4 py-3 text-right">
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
-                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                  <i data-lucide="clipboard-list" class="h-4 w-4"></i>
                 </button>
                 <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
                   <i data-lucide="message-square" class="h-4 w-4"></i>
@@ -1002,6 +1039,10 @@ tailwind.config = {
             <button class="rounded-full px-3 py-1 font-medium bg-teal/20 text-aqua">Last 4 weeks</button>
             <button class="rounded-full px-3 py-1 font-medium text-cloud/60 hover:text-cloud transition-colors">Full cycle</button>
           </div>
+          <button class="inline-flex items-center gap-1.5 rounded-md border border-whisper bg-white/[0.04] px-3 py-1 text-xs text-cloud/85 hover:bg-white/[0.08] hover:text-white transition-colors" title="Copies a summary of this pod's data. You'll paste it into your own AI tool — OLOS doesn't send anything.">
+            <i data-lucide="copy" class="h-3 w-3"></i>
+            Copy summary prompt
+          </button>
         </div>
       </div>
 
@@ -1157,8 +1198,30 @@ tailwind.config = {
             <span class="text-sm text-cloud/60">of 9 members have submitted</span>
           </div>
           <!-- Inline mini-progress -->
-          <div class="h-1.5 rounded-full bg-white/[0.06] overflow-hidden">
+          <div class="h-1.5 rounded-full bg-white/[0.06] overflow-hidden mb-4">
             <div class="h-full bg-teal" style="width: 44%"></div>
+          </div>
+          <!-- Submitter identities (PRD §7.5) -->
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
+            <div>
+              <div class="text-cloud/40 uppercase tracking-widest text-[10px] mb-1.5">Submitted</div>
+              <ul class="space-y-1 text-cloud/85">
+                <li class="flex items-center gap-2"><span class="inline-flex h-1.5 w-1.5 rounded-full bg-aqua"></span>Sarah K.</li>
+                <li class="flex items-center gap-2"><span class="inline-flex h-1.5 w-1.5 rounded-full bg-aqua"></span>Priya S.</li>
+                <li class="flex items-center gap-2"><span class="inline-flex h-1.5 w-1.5 rounded-full bg-aqua"></span>Marcus T.</li>
+                <li class="flex items-center gap-2"><span class="inline-flex h-1.5 w-1.5 rounded-full bg-aqua"></span>James W.</li>
+              </ul>
+            </div>
+            <div>
+              <div class="text-cloud/40 uppercase tracking-widest text-[10px] mb-1.5">Not yet</div>
+              <ul class="space-y-1 text-cloud/70">
+                <li class="flex items-center gap-2"><span class="inline-flex h-1.5 w-1.5 rounded-full bg-white/[0.15]"></span>Linda P.</li>
+                <li class="flex items-center gap-2"><span class="inline-flex h-1.5 w-1.5 rounded-full bg-white/[0.15]"></span>David L.</li>
+                <li class="flex items-center gap-2"><span class="inline-flex h-1.5 w-1.5 rounded-full bg-white/[0.15]"></span>Nina O.</li>
+                <li class="flex items-center gap-2"><span class="inline-flex h-1.5 w-1.5 rounded-full bg-white/[0.15]"></span>Ravi M.</li>
+                <li class="flex items-center gap-2"><span class="inline-flex h-1.5 w-1.5 rounded-full bg-white/[0.15]"></span>Elena V.</li>
+              </ul>
+            </div>
           </div>
         </div>
 
@@ -1201,16 +1264,19 @@ tailwind.config = {
             </div>
             <i data-lucide="external-link" class="h-3.5 w-3.5 text-cloud/30 flex-shrink-0"></i>
           </a>
-          <a href="#" class="flex items-center gap-3 rounded-md px-3 py-2.5 -mx-2 hover:bg-white/[0.04] transition-colors group">
-            <div class="h-8 w-8 rounded bg-white/[0.06] grid place-items-center flex-shrink-0">
-              <i data-lucide="github" class="h-4 w-4 text-cloud/60 group-hover:text-aqua transition-colors"></i>
+          <!-- Missing-resource state (PRD §7.6) — example of the failed-to-provision affordance -->
+          <div class="flex items-center gap-3 rounded-md px-3 py-2.5 -mx-2 bg-yellow-500/[0.06] border border-yellow-500/20">
+            <div class="h-8 w-8 rounded bg-white/[0.04] grid place-items-center flex-shrink-0">
+              <i data-lucide="github" class="h-4 w-4 text-cloud/40"></i>
             </div>
             <div class="flex-1 min-w-0">
-              <div class="text-sm text-cloud group-hover:text-white transition-colors">GitHub repo</div>
-              <div class="text-xs text-cloud/50 truncate">tul/pod-health-systems-access</div>
+              <div class="text-sm text-cloud/70">GitHub repo</div>
+              <div class="text-xs text-yellow-300/90 flex items-center gap-1.5">
+                <i data-lucide="alert-triangle" class="h-3 w-3"></i>
+                Missing — contact staff
+              </div>
             </div>
-            <i data-lucide="external-link" class="h-3.5 w-3.5 text-cloud/30 flex-shrink-0"></i>
-          </a>
+          </div>
           <a href="#" class="flex items-center gap-3 rounded-md px-3 py-2.5 -mx-2 hover:bg-white/[0.04] transition-colors group">
             <div class="h-8 w-8 rounded bg-white/[0.06] grid place-items-center flex-shrink-0">
               <i data-lucide="mail" class="h-4 w-4 text-cloud/60 group-hover:text-aqua transition-colors"></i>
@@ -1473,12 +1539,10 @@ tailwind.config = {
       <!-- Footer actions -->
       <div class="sticky bottom-0 bg-ink border-t border-whisper px-6 py-4">
         <div class="flex items-center justify-between gap-3">
-          <button class="inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium text-cloud/70 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud transition-colors">
+          <span class="text-xs text-cloud/50">Read-only · OLOS doesn't send messages</span>
+          <button class="inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium text-cloud/85 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-white transition-colors">
             <i data-lucide="message-square" class="h-4 w-4"></i>
-            Slack DM
-          </button>
-          <button class="rounded-md bg-teal px-4 py-2 text-sm font-medium text-white hover:bg-teal/80 transition-colors shadow-[0_1px_4px_rgba(0,148,160,0.2)]">
-            Reach out
+            Open Slack DM
           </button>
         </div>
       </div>

--- a/docs/PRD-moderator-dashboard-mockups.html
+++ b/docs/PRD-moderator-dashboard-mockups.html
@@ -1,0 +1,1514 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Poderator Dashboard — Mid-fi Mockups</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geologica:wght@300;400;600;700&display=swap" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://unpkg.com/lucide@latest"></script>
+<script>
+tailwind.config = {
+  theme: {
+    extend: {
+      colors: {
+        midnight: '#0b1016',
+        ink: '#0e1520',
+        teal: '#0094a0',
+        aqua: '#4dbbc2',
+        'shadow-teal': '#006b73',
+        red: '#ee1c25',
+        crimson: '#7a0f14',
+        cloud: '#e6e6e6',
+        ghost: '#ffffff',
+        whisper: 'rgba(255,255,255,0.07)',
+      },
+      fontFamily: {
+        sans: ['Geologica', '-apple-system', 'BlinkMacSystemFont', 'SF Pro Text', 'Helvetica Neue', 'sans-serif']
+      },
+      transitionTimingFunction: {
+        'spring': 'cubic-bezier(0.32, 0.72, 0, 1)',
+        'out-soft': 'cubic-bezier(0.25, 0.1, 0.25, 1)',
+      }
+    }
+  }
+}
+</script>
+<style>
+  html, body { background: #0b1016; }
+  body {
+    font-family: 'Geologica', -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    background-color: #0b1016;
+    background-image:
+      radial-gradient(ellipse 80% 50% at 50% 0%, rgba(0, 148, 160, 0.10), transparent 70%),
+      radial-gradient(ellipse 60% 50% at 100% 100%, rgba(77, 187, 194, 0.04), transparent 60%);
+    color: #e6e6e6;
+    min-height: 100vh;
+  }
+  .tabular-nums { font-variant-numeric: tabular-nums; }
+  *::-webkit-tap-highlight-color { background: transparent; }
+  .screen { display: none; }
+  .screen.active { display: block; }
+  .mock-tab-active {
+    background: rgba(0, 148, 160, 0.20);
+    color: #4dbbc2;
+  }
+  .mock-tab-inactive {
+    color: rgba(230, 230, 230, 0.6);
+  }
+  .mock-tab-inactive:hover {
+    background: rgba(255, 255, 255, 0.04);
+    color: #e6e6e6;
+  }
+  /* Live pulse dot */
+  @keyframes ping-soft {
+    75%, 100% { transform: scale(2); opacity: 0; }
+  }
+  .pulse-dot::before {
+    content: ''; position: absolute; inset: 0;
+    border-radius: 9999px; background: #0094a0;
+    animation: ping-soft 1.6s cubic-bezier(0,0,0.2,1) infinite;
+    opacity: 0.6;
+  }
+  /* Trend arrow */
+  .trend-up { color: #f6b56d; }
+  .trend-down { color: #4dbbc2; }
+  .trend-flat { color: rgba(230,230,230,0.5); }
+  /* Side panel backdrop */
+  .panel-backdrop {
+    background: rgba(11, 16, 22, 0.65);
+    backdrop-filter: blur(6px) saturate(140%);
+  }
+</style>
+</head>
+<body class="font-sans antialiased">
+
+<!-- ===================================================================== -->
+<!-- MOCKUP REVIEWER TOP BAR (not part of product) -->
+<!-- ===================================================================== -->
+<div class="sticky top-0 z-50 border-b border-white/[0.07] bg-[rgba(11,16,22,0.97)] backdrop-blur-sm">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-2.5 flex items-center justify-between gap-3">
+    <div class="flex items-center gap-3">
+      <span class="text-xs uppercase tracking-[0.25em] text-teal font-semibold">OLOS · Mockups</span>
+      <span class="text-cloud/30">/</span>
+      <span class="text-sm text-cloud/60">Poderator Dashboard</span>
+    </div>
+    <div class="flex items-center gap-1 rounded-full bg-white/[0.04] p-1">
+      <button onclick="showScreen('all-pods')" id="tab-all-pods" class="rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-150 mock-tab-active">All Pods</button>
+      <button onclick="showScreen('per-pod')" id="tab-per-pod" class="rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-150 mock-tab-inactive">Per-pod</button>
+      <button onclick="showScreen('pulse')" id="tab-pulse" class="rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-150 mock-tab-inactive">Pulse Review</button>
+    </div>
+  </div>
+</div>
+
+<!-- ===================================================================== -->
+<!-- SCREEN 1 — ALL PODS VIEW -->
+<!-- ===================================================================== -->
+<section id="screen-all-pods" class="screen active">
+
+  <!-- Product nav -->
+  <header class="border-b border-white/[0.07] bg-[rgba(11,16,22,0.97)] backdrop-blur-sm">
+    <div class="mx-auto flex h-[60px] max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+      <div class="flex items-center gap-8">
+        <span class="text-sm font-semibold tracking-wide text-white">OLOS</span>
+        <nav class="hidden md:flex items-center gap-6 text-sm">
+          <a href="#" class="text-cloud/60 hover:text-aqua transition-colors">Cycles</a>
+          <a href="#" class="text-white">Pods</a>
+          <a href="#" class="text-cloud/60 hover:text-aqua transition-colors">Members</a>
+        </nav>
+      </div>
+      <div class="flex items-center gap-3">
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-blue-500/15 px-2.5 py-0.5 text-xs font-medium text-blue-300">Poderator</span>
+        <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud">MJ</div>
+      </div>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-8 pb-16">
+
+    <!-- Page header + switcher -->
+    <div class="mb-8 space-y-3">
+      <div class="text-xs uppercase tracking-widest text-cloud/40">Energy &amp; Climate · Q3 2026</div>
+      <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+        <h1 class="text-2xl font-bold tracking-tight text-white">Your pods</h1>
+
+        <!-- Pod switcher -->
+        <div class="inline-flex items-center gap-2 rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-sm">
+          <i data-lucide="layers" class="h-4 w-4 text-cloud/60"></i>
+          <span class="text-cloud">All Pods</span>
+          <span class="text-cloud/40">·</span>
+          <span class="text-cloud/60 tabular-nums">3 pods</span>
+          <i data-lucide="chevron-down" class="h-4 w-4 text-cloud/40 ml-1"></i>
+        </div>
+      </div>
+    </div>
+
+    <!-- Members needing attention -->
+    <section class="mb-10">
+      <div class="mb-3 flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-white">Members needing attention</h2>
+        <span class="text-xs text-cloud/40 tabular-nums">3 across your pods</span>
+      </div>
+
+      <div class="space-y-3">
+
+        <!-- Nudge 1 -->
+        <div class="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-4">
+          <div class="flex items-start gap-4">
+            <div class="h-10 w-10 rounded-full bg-white/[0.08] grid place-items-center text-sm font-semibold text-cloud flex-shrink-0">SK</div>
+            <div class="flex-1 min-w-0">
+              <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span class="text-sm font-semibold text-white">Sarah K.</span>
+                <span class="text-xs text-cloud/50">·</span>
+                <span class="text-xs text-cloud/60">Policy analyst, Federal · evenings + weekends</span>
+              </div>
+              <div class="mt-1.5 flex items-center gap-2 text-sm text-yellow-300">
+                <i data-lucide="alert-triangle" class="h-4 w-4 flex-shrink-0"></i>
+                <span class="font-medium">Missed 2 consecutive pulses</span>
+                <span class="text-cloud/40">·</span>
+                <span class="text-cloud/60">last active 11 days ago</span>
+              </div>
+              <div class="mt-3 flex items-center gap-2 text-xs">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Medical Records Consolidation
+                </span>
+              </div>
+            </div>
+            <div class="flex flex-col sm:flex-row items-end sm:items-center gap-2 flex-shrink-0">
+              <button class="rounded bg-teal/20 px-3 py-1.5 text-xs font-medium text-aqua hover:bg-teal/30 transition-colors">
+                Open pod
+              </button>
+              <button class="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium text-cloud/70 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud transition-colors">
+                <i data-lucide="message-square" class="h-3.5 w-3.5"></i>
+                Slack DM
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Nudge 2 -->
+        <div class="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-4">
+          <div class="flex items-start gap-4">
+            <div class="h-10 w-10 rounded-full bg-white/[0.08] grid place-items-center text-sm font-semibold text-cloud flex-shrink-0">JR</div>
+            <div class="flex-1 min-w-0">
+              <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span class="text-sm font-semibold text-white">Jamal R.</span>
+                <span class="text-xs text-cloud/50">·</span>
+                <span class="text-xs text-cloud/60">Program analyst, Contractor · weekday lunches</span>
+              </div>
+              <div class="mt-1.5 flex items-center gap-2 text-sm text-yellow-300">
+                <i data-lucide="alert-triangle" class="h-4 w-4 flex-shrink-0"></i>
+                <span class="font-medium">Missed 2 consecutive pulses</span>
+                <span class="text-cloud/40">·</span>
+                <span class="text-cloud/60">last active 9 days ago</span>
+              </div>
+              <div class="mt-3 flex items-center gap-2 text-xs">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Energy Grid Resilience
+                </span>
+              </div>
+            </div>
+            <div class="flex flex-col sm:flex-row items-end sm:items-center gap-2 flex-shrink-0">
+              <button class="rounded bg-teal/20 px-3 py-1.5 text-xs font-medium text-aqua hover:bg-teal/30 transition-colors">
+                Open pod
+              </button>
+              <button class="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium text-cloud/70 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud transition-colors">
+                <i data-lucide="message-square" class="h-3.5 w-3.5"></i>
+                Slack DM
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Nudge 3 -->
+        <div class="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-4">
+          <div class="flex items-start gap-4">
+            <div class="h-10 w-10 rounded-full bg-white/[0.08] grid place-items-center text-sm font-semibold text-cloud flex-shrink-0">LP</div>
+            <div class="flex-1 min-w-0">
+              <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span class="text-sm font-semibold text-white">Linda P.</span>
+                <span class="text-xs text-cloud/50">·</span>
+                <span class="text-xs text-cloud/60">Researcher, NGO · weekends only</span>
+              </div>
+              <div class="mt-1.5 flex items-center gap-2 text-sm text-yellow-300">
+                <i data-lucide="alert-triangle" class="h-4 w-4 flex-shrink-0"></i>
+                <span class="font-medium">Missed 3 consecutive pulses</span>
+                <span class="text-cloud/40">·</span>
+                <span class="text-cloud/60">last active 19 days ago</span>
+              </div>
+              <div class="mt-3 flex items-center gap-2 text-xs">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Health Systems Access
+                </span>
+              </div>
+            </div>
+            <div class="flex flex-col sm:flex-row items-end sm:items-center gap-2 flex-shrink-0">
+              <button class="rounded bg-teal/20 px-3 py-1.5 text-xs font-medium text-aqua hover:bg-teal/30 transition-colors">
+                Open pod
+              </button>
+              <button class="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium text-cloud/70 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud transition-colors">
+                <i data-lucide="message-square" class="h-3.5 w-3.5"></i>
+                Slack DM
+              </button>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- Your pods at a glance -->
+    <section class="mb-10">
+      <div class="mb-3 flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-white">Your pods at a glance</h2>
+        <span class="text-xs text-cloud/40 tabular-nums">Week 6 of 13</span>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+
+        <!-- Pod card 1 -->
+        <a href="#" class="block rounded-md border border-whisper bg-white/[0.02] p-5 hover:border-white/[0.12] hover:bg-white/[0.04] transition-colors">
+          <div class="flex items-start justify-between gap-3 mb-4">
+            <div>
+              <div class="text-xs uppercase tracking-widest text-cloud/40 mb-1.5">Pod</div>
+              <div class="text-base font-semibold text-white">Health Systems Access</div>
+            </div>
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs font-medium text-aqua">
+              <span class="h-1.5 w-1.5 rounded-full bg-aqua"></span>
+              Active
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-3 mt-5">
+            <div>
+              <div class="text-xs text-cloud/60 mb-1">Pulse this week</div>
+              <div class="flex items-baseline gap-1.5">
+                <span class="text-2xl font-bold tabular-nums text-yellow-300">1</span>
+                <span class="text-xs text-cloud/50">missing</span>
+                <span class="trend-down text-xs ml-auto">↓</span>
+              </div>
+            </div>
+            <div>
+              <div class="text-xs text-cloud/60 mb-1">Members</div>
+              <div class="flex items-baseline gap-1.5">
+                <span class="text-2xl font-bold tabular-nums text-white">9</span>
+                <span class="text-xs text-cloud/50">active</span>
+              </div>
+            </div>
+          </div>
+          <div class="mt-5 pt-4 border-t border-whisper text-xs text-cloud/60">
+            <span class="text-cloud/40">Phase 4</span> · Solution Proposals · closes in 2d
+          </div>
+        </a>
+
+        <!-- Pod card 2 -->
+        <a href="#" class="block rounded-md border border-whisper bg-white/[0.02] p-5 hover:border-white/[0.12] hover:bg-white/[0.04] transition-colors">
+          <div class="flex items-start justify-between gap-3 mb-4">
+            <div>
+              <div class="text-xs uppercase tracking-widest text-cloud/40 mb-1.5">Pod</div>
+              <div class="text-base font-semibold text-white">Medical Records Consolidation</div>
+            </div>
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs font-medium text-aqua">
+              <span class="h-1.5 w-1.5 rounded-full bg-aqua"></span>
+              Active
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-3 mt-5">
+            <div>
+              <div class="text-xs text-cloud/60 mb-1">Pulse this week</div>
+              <div class="flex items-baseline gap-1.5">
+                <span class="text-2xl font-bold tabular-nums text-yellow-300">1</span>
+                <span class="text-xs text-cloud/50">missing</span>
+                <span class="trend-flat text-xs ml-auto">→</span>
+              </div>
+            </div>
+            <div>
+              <div class="text-xs text-cloud/60 mb-1">Members</div>
+              <div class="flex items-baseline gap-1.5">
+                <span class="text-2xl font-bold tabular-nums text-white">8</span>
+                <span class="text-xs text-cloud/50">active</span>
+              </div>
+            </div>
+          </div>
+          <div class="mt-5 pt-4 border-t border-whisper text-xs text-cloud/60">
+            <span class="text-cloud/40">Phase 4</span> · Solution Proposals · closes in 2d
+          </div>
+        </a>
+
+        <!-- Pod card 3 -->
+        <a href="#" class="block rounded-md border border-whisper bg-white/[0.02] p-5 hover:border-white/[0.12] hover:bg-white/[0.04] transition-colors">
+          <div class="flex items-start justify-between gap-3 mb-4">
+            <div>
+              <div class="text-xs uppercase tracking-widest text-cloud/40 mb-1.5">Pod</div>
+              <div class="text-base font-semibold text-white">Energy Grid Resilience</div>
+            </div>
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs font-medium text-aqua">
+              <span class="h-1.5 w-1.5 rounded-full bg-aqua"></span>
+              Active
+            </span>
+          </div>
+          <div class="grid grid-cols-2 gap-3 mt-5">
+            <div>
+              <div class="text-xs text-cloud/60 mb-1">Pulse this week</div>
+              <div class="flex items-baseline gap-1.5">
+                <span class="text-2xl font-bold tabular-nums text-white">0</span>
+                <span class="text-xs text-cloud/50">missing</span>
+                <span class="trend-down text-xs ml-auto">↓</span>
+              </div>
+            </div>
+            <div>
+              <div class="text-xs text-cloud/60 mb-1">Members</div>
+              <div class="flex items-baseline gap-1.5">
+                <span class="text-2xl font-bold tabular-nums text-white">7</span>
+                <span class="text-xs text-cloud/50">active</span>
+              </div>
+            </div>
+          </div>
+          <div class="mt-5 pt-4 border-t border-whisper text-xs text-cloud/60">
+            <span class="text-cloud/40">Phase 4</span> · Solution Proposals · closes in 2d
+          </div>
+        </a>
+
+      </div>
+    </section>
+
+    <!-- Cross-pod pulse insights (§7.9.3) -->
+    <section>
+      <div class="mb-3 flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-teal mb-1.5">Across your pods</div>
+          <h2 class="text-lg font-semibold text-white">Pulse insights</h2>
+        </div>
+        <div class="flex items-center gap-2">
+          <div class="inline-flex items-center gap-1 rounded-full bg-white/[0.04] p-1 text-xs">
+            <button class="rounded-full px-3 py-1 font-medium bg-teal/20 text-aqua">Last 4 weeks</button>
+            <button class="rounded-full px-3 py-1 font-medium text-cloud/60 hover:text-cloud transition-colors">Full cycle</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Combined all-pods rollup -->
+      <div class="rounded-md border border-teal/20 bg-teal/[0.04] p-5 mb-4">
+        <div class="flex items-center justify-between mb-4">
+          <div class="text-xs uppercase tracking-widest text-aqua/80">All your pods combined</div>
+          <span class="text-xs text-cloud/50 tabular-nums">24 members across 3 pods</span>
+        </div>
+
+        <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-5">
+          <div>
+            <div class="text-xs text-cloud/60 mb-1.5">Pulsing this week</div>
+            <div class="flex items-baseline gap-2">
+              <span class="text-2xl font-bold tabular-nums text-white">22</span>
+              <span class="text-xs text-cloud/60">of 24</span>
+            </div>
+            <div class="mt-1 text-xs text-cloud/50 tabular-nums">92%</div>
+          </div>
+          <div>
+            <div class="text-xs text-cloud/60 mb-1.5">At risk</div>
+            <div class="flex items-baseline gap-2">
+              <span class="text-2xl font-bold tabular-nums text-yellow-300">3</span>
+              <span class="text-xs text-cloud/60">members</span>
+            </div>
+            <div class="mt-1 text-xs text-cloud/50">2 pods affected</div>
+          </div>
+          <div>
+            <div class="text-xs text-cloud/60 mb-1.5">Pulses this period</div>
+            <div class="flex items-baseline gap-2">
+              <span class="text-2xl font-bold tabular-nums text-white">81</span>
+              <span class="text-xs text-cloud/60">submitted</span>
+            </div>
+            <div class="mt-1 text-xs text-cloud/50 tabular-nums">of 96 possible</div>
+          </div>
+          <div>
+            <div class="text-xs text-cloud/60 mb-1.5">Engagement trend</div>
+            <div class="flex items-baseline gap-2">
+              <span class="text-2xl font-bold tabular-nums text-white">85%</span>
+              <span class="trend-down text-base">↓</span>
+            </div>
+            <div class="mt-1 text-xs text-cloud/50">down from 92% last week</div>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 pt-4 border-t border-teal/15">
+          <div>
+            <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Top AI tools</div>
+            <div class="flex flex-wrap gap-1.5">
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs text-aqua">ChatGPT <span class="tabular-nums opacity-80">16</span></span>
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/15 px-2.5 py-0.5 text-xs text-aqua/90">Claude <span class="tabular-nums opacity-80">13</span></span>
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/10 px-2.5 py-0.5 text-xs text-aqua/80">Cursor <span class="tabular-nums opacity-80">8</span></span>
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2.5 py-0.5 text-xs text-cloud/70">v0 <span class="tabular-nums opacity-80">3</span></span>
+            </div>
+          </div>
+          <div>
+            <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Top stuck-on themes</div>
+            <ol class="text-xs text-cloud/85 space-y-1 list-decimal list-inside marker:text-cloud/40">
+              <li>Confusion about proposal scope <span class="text-cloud/40 tabular-nums">· 7</span></li>
+              <li>Time pressure on pulse window <span class="text-cloud/40 tabular-nums">· 4</span></li>
+              <li>Tool setup friction <span class="text-cloud/40 tabular-nums">· 3</span></li>
+            </ol>
+          </div>
+          <div>
+            <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Top help requests</div>
+            <ol class="text-xs text-cloud/85 space-y-1 list-decimal list-inside marker:text-cloud/40">
+              <li>Pairing with a technical pod-mate <span class="text-cloud/40 tabular-nums">· 5</span></li>
+              <li>Non-technical proposal examples <span class="text-cloud/40 tabular-nums">· 4</span></li>
+              <li>Office-hours or staff time <span class="text-cloud/40 tabular-nums">· 2</span></li>
+            </ol>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+
+        <!-- Patterns across pods -->
+        <div class="lg:col-span-2 rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div class="flex items-center justify-between mb-4">
+            <div class="text-xs uppercase tracking-widest text-cloud/40">Patterns showing up in more than one pod</div>
+            <button class="text-cloud/40 hover:text-cloud transition-colors p-1" title="How themes are generated">
+              <i data-lucide="help-circle" class="h-4 w-4"></i>
+            </button>
+          </div>
+
+          <div class="space-y-3">
+            <div class="rounded-md border border-whisper bg-white/[0.01] p-4 hover:bg-white/[0.03] transition-colors cursor-pointer">
+              <div class="flex items-start justify-between gap-3 mb-2">
+                <div class="text-sm font-semibold text-cloud">Confusion about solution proposal scope</div>
+                <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">7 members</span>
+              </div>
+              <div class="flex flex-wrap items-center gap-1.5">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Health Systems Access
+                </span>
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Medical Records Consolidation
+                </span>
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Energy Grid Resilience
+                </span>
+              </div>
+            </div>
+
+            <div class="rounded-md border border-whisper bg-white/[0.01] p-4 hover:bg-white/[0.03] transition-colors cursor-pointer">
+              <div class="flex items-start justify-between gap-3 mb-2">
+                <div class="text-sm font-semibold text-cloud">Wanting to pair with a more technical pod-mate</div>
+                <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">5 members</span>
+              </div>
+              <div class="flex flex-wrap items-center gap-1.5">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Health Systems Access
+                </span>
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Medical Records Consolidation
+                </span>
+              </div>
+            </div>
+
+            <div class="rounded-md border border-whisper bg-white/[0.01] p-4 hover:bg-white/[0.03] transition-colors cursor-pointer">
+              <div class="flex items-start justify-between gap-3 mb-2">
+                <div class="text-sm font-semibold text-cloud">Time pressure on weekday pulse window</div>
+                <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">4 members</span>
+              </div>
+              <div class="flex flex-wrap items-center gap-1.5">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Medical Records Consolidation
+                </span>
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2 py-0.5 text-xs text-cloud/70">
+                  <i data-lucide="users" class="h-3 w-3"></i>
+                  Energy Grid Resilience
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- AI tool adoption by pod -->
+        <div class="rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div class="text-xs uppercase tracking-widest text-cloud/40 mb-4">Top AI tools by pod</div>
+
+          <div class="space-y-4">
+            <div>
+              <div class="text-xs text-cloud/60 mb-1.5 truncate">Health Systems Access</div>
+              <div class="flex flex-wrap gap-1">
+                <span class="inline-flex items-center gap-1 rounded-full bg-teal/15 px-2 py-0.5 text-[11px] text-aqua">ChatGPT <span class="tabular-nums opacity-70">7</span></span>
+                <span class="inline-flex items-center gap-1 rounded-full bg-teal/10 px-2 py-0.5 text-[11px] text-aqua/80">Claude <span class="tabular-nums opacity-70">5</span></span>
+                <span class="inline-flex items-center gap-1 rounded-full bg-white/[0.06] px-2 py-0.5 text-[11px] text-cloud/70">Cursor <span class="tabular-nums opacity-70">2</span></span>
+              </div>
+            </div>
+            <div>
+              <div class="text-xs text-cloud/60 mb-1.5 truncate">Medical Records Consolidation</div>
+              <div class="flex flex-wrap gap-1">
+                <span class="inline-flex items-center gap-1 rounded-full bg-teal/15 px-2 py-0.5 text-[11px] text-aqua">Cursor <span class="tabular-nums opacity-70">6</span></span>
+                <span class="inline-flex items-center gap-1 rounded-full bg-teal/10 px-2 py-0.5 text-[11px] text-aqua/80">ChatGPT <span class="tabular-nums opacity-70">5</span></span>
+                <span class="inline-flex items-center gap-1 rounded-full bg-white/[0.06] px-2 py-0.5 text-[11px] text-cloud/70">v0 <span class="tabular-nums opacity-70">3</span></span>
+              </div>
+            </div>
+            <div>
+              <div class="text-xs text-cloud/60 mb-1.5 truncate">Energy Grid Resilience</div>
+              <div class="flex flex-wrap gap-1">
+                <span class="inline-flex items-center gap-1 rounded-full bg-teal/15 px-2 py-0.5 text-[11px] text-aqua">Claude <span class="tabular-nums opacity-70">5</span></span>
+                <span class="inline-flex items-center gap-1 rounded-full bg-teal/10 px-2 py-0.5 text-[11px] text-aqua/80">ChatGPT <span class="tabular-nums opacity-70">4</span></span>
+                <span class="inline-flex items-center gap-1 rounded-full bg-white/[0.06] px-2 py-0.5 text-[11px] text-cloud/70">Replit <span class="tabular-nums opacity-70">2</span></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-5 pt-4 border-t border-whisper text-xs text-cloud/60">
+            <i data-lucide="lightbulb" class="inline h-3 w-3 text-aqua mr-1"></i>
+            Health is heavy on ChatGPT; Medical Records is leaning into Cursor. Worth a cross-pod intro.
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Engagement comparison -->
+      <div class="mt-4 rounded-md border border-whisper bg-white/[0.02] p-5">
+        <div class="flex items-center justify-between mb-4">
+          <div class="text-xs uppercase tracking-widest text-cloud/40">Pulse completion trend · last 4 weeks</div>
+          <div class="text-xs text-cloud/40 tabular-nums">% of members pulsing</div>
+        </div>
+
+        <div class="space-y-3">
+          <!-- Pod A -->
+          <div class="flex items-center gap-4">
+            <div class="w-44 text-sm text-cloud truncate">Health Systems Access</div>
+            <div class="flex-1 flex items-end gap-1.5 h-10">
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 100%;"></div>
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 88%;"></div>
+              <div class="flex-1 rounded-t bg-teal/30" style="height: 77%;"></div>
+              <div class="flex-1 rounded-t bg-yellow-500/40" style="height: 66%;"></div>
+            </div>
+            <div class="text-sm tabular-nums text-yellow-300 w-12 text-right">66%</div>
+            <div class="trend-down w-4 text-center">↓</div>
+          </div>
+          <!-- Pod B -->
+          <div class="flex items-center gap-4">
+            <div class="w-44 text-sm text-cloud truncate">Medical Records Consolidation</div>
+            <div class="flex-1 flex items-end gap-1.5 h-10">
+              <div class="flex-1 rounded-t bg-teal/30" style="height: 75%;"></div>
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 88%;"></div>
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 88%;"></div>
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 88%;"></div>
+            </div>
+            <div class="text-sm tabular-nums text-aqua w-12 text-right">88%</div>
+            <div class="trend-flat w-4 text-center">→</div>
+          </div>
+          <!-- Pod C -->
+          <div class="flex items-center gap-4">
+            <div class="w-44 text-sm text-cloud truncate">Energy Grid Resilience</div>
+            <div class="flex-1 flex items-end gap-1.5 h-10">
+              <div class="flex-1 rounded-t bg-teal/30" style="height: 71%;"></div>
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 86%;"></div>
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 100%;"></div>
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 100%;"></div>
+            </div>
+            <div class="text-sm tabular-nums text-aqua w-12 text-right">100%</div>
+            <div class="trend-down w-4 text-center">↓</div>
+          </div>
+        </div>
+      </div>
+
+    </section>
+
+  </main>
+</section>
+
+<!-- ===================================================================== -->
+<!-- SCREEN 2 — PER-POD DASHBOARD -->
+<!-- ===================================================================== -->
+<section id="screen-per-pod" class="screen">
+
+  <!-- Product nav -->
+  <header class="border-b border-white/[0.07] bg-[rgba(11,16,22,0.97)] backdrop-blur-sm">
+    <div class="mx-auto flex h-[60px] max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+      <div class="flex items-center gap-8">
+        <span class="text-sm font-semibold tracking-wide text-white">OLOS</span>
+        <nav class="hidden md:flex items-center gap-6 text-sm">
+          <a href="#" class="text-cloud/60 hover:text-aqua transition-colors">Cycles</a>
+          <a href="#" class="text-white">Pods</a>
+          <a href="#" class="text-cloud/60 hover:text-aqua transition-colors">Members</a>
+        </nav>
+      </div>
+      <div class="flex items-center gap-3">
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-blue-500/15 px-2.5 py-0.5 text-xs font-medium text-blue-300">Poderator</span>
+        <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud">MJ</div>
+      </div>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-6 pb-16">
+
+    <!-- Back link / breadcrumb -->
+    <a href="#" onclick="showScreen('all-pods'); return false;" class="inline-flex items-center gap-1.5 text-sm text-cloud/60 hover:text-aqua transition-colors mb-5">
+      <i data-lucide="chevron-left" class="h-4 w-4"></i>
+      All pods
+    </a>
+
+    <!-- Page header + switcher -->
+    <div class="mb-8 space-y-3">
+      <div class="text-xs uppercase tracking-widest text-cloud/40">Energy &amp; Climate · Q3 2026 · Week 6</div>
+      <div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+        <h1 class="text-2xl font-bold tracking-tight text-white">Health Systems Access</h1>
+
+        <!-- Pod switcher -->
+        <div class="inline-flex items-center gap-2 rounded-md border border-whisper bg-white/[0.04] px-3 py-2 text-sm">
+          <i data-lucide="layers" class="h-4 w-4 text-cloud/60"></i>
+          <span class="text-cloud">Health Systems Access</span>
+          <i data-lucide="chevron-down" class="h-4 w-4 text-cloud/40 ml-1"></i>
+        </div>
+      </div>
+    </div>
+
+    <!-- SECTION 1 — Pod status header -->
+    <section class="mb-8">
+      <div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
+        <!-- Status -->
+        <div class="rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div class="text-xs uppercase tracking-widest text-cloud/40 mb-2">Status</div>
+          <div class="flex items-center gap-2">
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs font-medium text-aqua">
+              <span class="h-1.5 w-1.5 rounded-full bg-aqua"></span>
+              Active
+            </span>
+          </div>
+          <div class="mt-3 text-xs text-cloud/60">9 active members</div>
+        </div>
+
+        <!-- Current phase -->
+        <div class="rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div class="text-xs uppercase tracking-widest text-cloud/40 mb-2">Current phase</div>
+          <div class="text-base font-semibold text-white">Phase 4 · Solution Proposals</div>
+          <div class="mt-2 flex items-center gap-2 text-xs">
+            <span class="inline-flex items-center gap-1.5 text-yellow-300">
+              <i data-lucide="clock" class="h-3.5 w-3.5"></i>
+              Closes in 2 days
+            </span>
+            <span class="text-cloud/40 tabular-nums">May 22</span>
+          </div>
+        </div>
+
+        <!-- Pulse this week -->
+        <div class="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-5">
+          <div class="text-xs uppercase tracking-widest text-yellow-300/80 mb-2">Pulse this week</div>
+          <div class="flex items-baseline gap-2">
+            <span class="text-3xl font-bold tabular-nums text-yellow-300">1</span>
+            <span class="text-sm text-cloud/70">missing</span>
+            <span class="trend-down text-base ml-auto" title="Falling vs last 3 weeks">↓</span>
+          </div>
+          <div class="mt-2.5 text-xs text-cloud/60">Healthy: 0 · Warning: 1–2 · Critical: 3+</div>
+        </div>
+
+        <!-- Members -->
+        <div class="rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div class="text-xs uppercase tracking-widest text-cloud/40 mb-2">Members</div>
+          <div class="flex items-baseline gap-2">
+            <span class="text-3xl font-bold tabular-nums text-white">9</span>
+            <span class="text-sm text-cloud/60">active</span>
+          </div>
+          <div class="mt-2.5 text-xs text-cloud/60">0 pending invites</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- SECTION 2 — At-risk nudge -->
+    <section class="mb-8">
+      <div class="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-4">
+        <div class="flex items-start gap-4">
+          <i data-lucide="alert-triangle" class="h-5 w-5 text-yellow-300 flex-shrink-0 mt-0.5"></i>
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-semibold text-yellow-300">Linda P. has missed 3 consecutive pulses.</div>
+            <div class="mt-1 text-sm text-cloud/80">Last active 19 days ago. Consider reaching out before they fully disengage.</div>
+          </div>
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <button class="rounded bg-teal/20 px-3 py-1.5 text-xs font-medium text-aqua hover:bg-teal/30 transition-colors">View responses</button>
+            <button class="inline-flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium text-cloud/70 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud transition-colors">
+              <i data-lucide="message-square" class="h-3.5 w-3.5"></i>
+              Slack DM
+            </button>
+            <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud/70 transition-colors" aria-label="Dismiss">
+              <i data-lucide="x" class="h-4 w-4"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- SECTION 3 — Member roster -->
+    <section class="mb-8">
+
+      <div class="mb-3 flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+        <h2 class="text-lg font-semibold text-white">Pod members</h2>
+        <div class="flex items-center gap-2">
+          <!-- Search -->
+          <div class="relative">
+            <i data-lucide="search" class="h-4 w-4 text-cloud/40 absolute left-2.5 top-1/2 -translate-y-1/2"></i>
+            <input type="text" placeholder="Search name" class="rounded-md border border-white/[0.10] bg-white/[0.04] pl-8 pr-3 py-1.5 text-sm text-white placeholder:text-cloud/40 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal w-44">
+          </div>
+          <!-- Status filter -->
+          <button class="inline-flex items-center gap-1.5 rounded-md border border-white/[0.10] bg-white/[0.04] px-3 py-1.5 text-sm text-cloud hover:bg-white/[0.06] transition-colors">
+            <i data-lucide="filter" class="h-3.5 w-3.5 text-cloud/60"></i>
+            All statuses
+            <i data-lucide="chevron-down" class="h-3.5 w-3.5 text-cloud/40"></i>
+          </button>
+          <!-- Show inactive toggle -->
+          <label class="inline-flex items-center gap-2 text-xs text-cloud/60 ml-1">
+            <input type="checkbox" class="h-4 w-4 rounded border-white/[0.20] bg-white/[0.04] text-teal focus:ring-teal focus:ring-offset-0">
+            Show inactive
+          </label>
+        </div>
+      </div>
+
+      <div class="overflow-hidden rounded-md border border-whisper">
+        <table class="w-full text-sm">
+          <thead class="bg-white/[0.04]">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">Member</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60 hidden md:table-cell">Background</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">Pulse</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60 hidden md:table-cell">Last active</th>
+              <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-cloud/60"></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-whisper">
+
+            <!-- Row: at-risk -->
+            <tr class="hover:bg-white/[0.02] transition-colors">
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-3">
+                  <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">LP</div>
+                  <div>
+                    <div class="text-sm font-medium text-white">Linda P.</div>
+                    <div class="text-xs text-cloud/50">New to building · weekends only</div>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3 text-cloud/70 hidden md:table-cell">Researcher · NGO</td>
+              <td class="px-4 py-3">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-yellow-500/20 px-2.5 py-0.5 text-xs font-medium text-yellow-300">
+                  <i data-lucide="alert-triangle" class="h-3 w-3"></i>
+                  At risk
+                </span>
+              </td>
+              <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">19 days ago</td>
+              <td class="px-4 py-3 text-right">
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
+                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                </button>
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
+                  <i data-lucide="message-square" class="h-4 w-4"></i>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row: late -->
+            <tr class="hover:bg-white/[0.02] transition-colors">
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-3">
+                  <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">SK</div>
+                  <div>
+                    <div class="text-sm font-medium text-white">Sarah K.</div>
+                    <div class="text-xs text-cloud/50">Consumer of AI tools · evenings + weekends</div>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3 text-cloud/70 hidden md:table-cell">Policy analyst · Federal</td>
+              <td class="px-4 py-3">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-yellow-500/10 px-2.5 py-0.5 text-xs font-medium text-yellow-300">
+                  <span class="h-1.5 w-1.5 rounded-full bg-yellow-300"></span>
+                  Late
+                </span>
+              </td>
+              <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">8 days ago</td>
+              <td class="px-4 py-3 text-right">
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
+                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                </button>
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
+                  <i data-lucide="message-square" class="h-4 w-4"></i>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row: pending -->
+            <tr class="hover:bg-white/[0.02] transition-colors">
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-3">
+                  <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">PS</div>
+                  <div>
+                    <div class="text-sm font-medium text-white">Priya S.</div>
+                    <div class="text-xs text-cloud/50">Built one Streamlit app · weekday evenings</div>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3 text-cloud/70 hidden md:table-cell">Data scientist · Federal</td>
+              <td class="px-4 py-3">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-2.5 py-0.5 text-xs font-medium text-cloud/70">
+                  <span class="h-1.5 w-1.5 rounded-full bg-cloud/60"></span>
+                  Pending
+                </span>
+              </td>
+              <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">2 days ago</td>
+              <td class="px-4 py-3 text-right">
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
+                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                </button>
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
+                  <i data-lucide="message-square" class="h-4 w-4"></i>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row: current -->
+            <tr class="hover:bg-white/[0.02] transition-colors">
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-3">
+                  <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">MW</div>
+                  <div>
+                    <div class="text-sm font-medium text-white">Marcus W.</div>
+                    <div class="text-xs text-cloud/50">Ships side projects · flexible</div>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3 text-cloud/70 hidden md:table-cell">Tech lead · Contractor</td>
+              <td class="px-4 py-3">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs font-medium text-aqua">
+                  <i data-lucide="check" class="h-3 w-3"></i>
+                  Current
+                </span>
+              </td>
+              <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">Yesterday</td>
+              <td class="px-4 py-3 text-right">
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
+                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                </button>
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
+                  <i data-lucide="message-square" class="h-4 w-4"></i>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row: current -->
+            <tr class="hover:bg-white/[0.02] transition-colors">
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-3">
+                  <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">AM</div>
+                  <div>
+                    <div class="text-sm font-medium text-white">Aisha M.</div>
+                    <div class="text-xs text-cloud/50">Consumer of AI tools · weekday lunches</div>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3 text-cloud/70 hidden md:table-cell">Communications · Federal</td>
+              <td class="px-4 py-3">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs font-medium text-aqua">
+                  <i data-lucide="check" class="h-3 w-3"></i>
+                  Current
+                </span>
+              </td>
+              <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">2 days ago</td>
+              <td class="px-4 py-3 text-right">
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
+                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                </button>
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
+                  <i data-lucide="message-square" class="h-4 w-4"></i>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row: current -->
+            <tr class="hover:bg-white/[0.02] transition-colors">
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-3">
+                  <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">ET</div>
+                  <div>
+                    <div class="text-sm font-medium text-white">Eli T.</div>
+                    <div class="text-xs text-cloud/50">Returning upskiller · evenings</div>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3 text-cloud/70 hidden md:table-cell">Program manager · NGO</td>
+              <td class="px-4 py-3">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs font-medium text-aqua">
+                  <i data-lucide="check" class="h-3 w-3"></i>
+                  Current
+                </span>
+              </td>
+              <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">3 days ago</td>
+              <td class="px-4 py-3 text-right">
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
+                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                </button>
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
+                  <i data-lucide="message-square" class="h-4 w-4"></i>
+                </button>
+              </td>
+            </tr>
+
+            <!-- Row: current -->
+            <tr class="hover:bg-white/[0.02] transition-colors">
+              <td class="px-4 py-3">
+                <div class="flex items-center gap-3">
+                  <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud flex-shrink-0">DR</div>
+                  <div>
+                    <div class="text-sm font-medium text-white">Diane R.</div>
+                    <div class="text-xs text-cloud/50">Consumer of AI tools · evenings + weekends</div>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3 text-cloud/70 hidden md:table-cell">Health policy · Federal</td>
+              <td class="px-4 py-3">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs font-medium text-aqua">
+                  <i data-lucide="check" class="h-3 w-3"></i>
+                  Current
+                </span>
+              </td>
+              <td class="px-4 py-3 text-cloud/60 hidden md:table-cell tabular-nums">Today</td>
+              <td class="px-4 py-3 text-right">
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="View pulse responses" onclick="showScreen('pulse')">
+                  <i data-lucide="message-circle" class="h-4 w-4"></i>
+                </button>
+                <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" title="Slack DM">
+                  <i data-lucide="message-square" class="h-4 w-4"></i>
+                </button>
+              </td>
+            </tr>
+
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- SECTION 3.5 — Pod-level pulse insights (§7.9.2) -->
+    <section class="mb-8">
+      <div class="mb-3 flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2">
+        <div>
+          <div class="text-xs uppercase tracking-widest text-teal mb-1.5">This pod</div>
+          <h2 class="text-lg font-semibold text-white">Pulse insights</h2>
+        </div>
+        <div class="flex items-center gap-2">
+          <div class="inline-flex items-center gap-1 rounded-full bg-white/[0.04] p-1 text-xs">
+            <button class="rounded-full px-3 py-1 font-medium bg-teal/20 text-aqua">Last 4 weeks</button>
+            <button class="rounded-full px-3 py-1 font-medium text-cloud/60 hover:text-cloud transition-colors">Full cycle</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+
+        <!-- Top stuck-on + help themes -->
+        <div class="lg:col-span-2 rounded-md border border-whisper bg-white/[0.02] p-5">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+            <div>
+              <div class="flex items-center justify-between mb-3">
+                <div class="text-xs uppercase tracking-widest text-cloud/40">What members are stuck on</div>
+                <i data-lucide="help-circle" class="h-3.5 w-3.5 text-cloud/30"></i>
+              </div>
+              <div class="space-y-2">
+                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
+                  <div class="flex items-start justify-between gap-2 mb-1">
+                    <div class="text-sm text-cloud">Confusion about proposal scope</div>
+                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">4 members</span>
+                  </div>
+                  <div class="text-xs text-cloud/50">Linda P., Sarah K., Aisha M., Diane R.</div>
+                </div>
+                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
+                  <div class="flex items-start justify-between gap-2 mb-1">
+                    <div class="text-sm text-cloud">Cursor setup &amp; first run</div>
+                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">2 members</span>
+                  </div>
+                  <div class="text-xs text-cloud/50">Priya S., Aisha M.</div>
+                </div>
+                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
+                  <div class="flex items-start justify-between gap-2 mb-1">
+                    <div class="text-sm text-cloud">Time pressure on weekday pulse</div>
+                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">2 members</span>
+                  </div>
+                  <div class="text-xs text-cloud/50">Linda P., Eli T.</div>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <div class="flex items-center justify-between mb-3">
+                <div class="text-xs uppercase tracking-widest text-cloud/40">Help members are asking for</div>
+                <i data-lucide="help-circle" class="h-3.5 w-3.5 text-cloud/30"></i>
+              </div>
+              <div class="space-y-2">
+                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
+                  <div class="flex items-start justify-between gap-2 mb-1">
+                    <div class="text-sm text-cloud">Pair with a technical pod-mate</div>
+                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">3 members</span>
+                  </div>
+                  <div class="text-xs text-cloud/50">Linda P., Sarah K., Diane R.</div>
+                </div>
+                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
+                  <div class="flex items-start justify-between gap-2 mb-1">
+                    <div class="text-sm text-cloud">Non-technical proposal examples</div>
+                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">2 members</span>
+                  </div>
+                  <div class="text-xs text-cloud/50">Linda P., Aisha M.</div>
+                </div>
+                <div class="rounded border border-whisper bg-white/[0.01] p-3 hover:bg-white/[0.03] transition-colors cursor-pointer">
+                  <div class="flex items-start justify-between gap-2 mb-1">
+                    <div class="text-sm text-cloud">Office-hours with staff</div>
+                    <span class="text-xs text-cloud/40 tabular-nums whitespace-nowrap">2 members</span>
+                  </div>
+                  <div class="text-xs text-cloud/50">Priya S., Sarah K.</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Top AI tools + completion trend -->
+        <div class="rounded-md border border-whisper bg-white/[0.02] p-5 flex flex-col gap-5">
+          <div>
+            <div class="text-xs uppercase tracking-widest text-cloud/40 mb-3">Top AI tools this pod</div>
+            <div class="space-y-2">
+              <div class="flex items-center gap-3">
+                <div class="text-xs text-cloud w-20">ChatGPT</div>
+                <div class="flex-1 h-2 rounded-full bg-white/[0.06] overflow-hidden">
+                  <div class="h-full bg-teal" style="width: 78%;"></div>
+                </div>
+                <div class="text-xs text-cloud/60 tabular-nums w-6 text-right">7</div>
+              </div>
+              <div class="flex items-center gap-3">
+                <div class="text-xs text-cloud w-20">Claude</div>
+                <div class="flex-1 h-2 rounded-full bg-white/[0.06] overflow-hidden">
+                  <div class="h-full bg-teal" style="width: 56%;"></div>
+                </div>
+                <div class="text-xs text-cloud/60 tabular-nums w-6 text-right">5</div>
+              </div>
+              <div class="flex items-center gap-3">
+                <div class="text-xs text-cloud w-20">Cursor</div>
+                <div class="flex-1 h-2 rounded-full bg-white/[0.06] overflow-hidden">
+                  <div class="h-full bg-teal/70" style="width: 22%;"></div>
+                </div>
+                <div class="text-xs text-cloud/60 tabular-nums w-6 text-right">2</div>
+              </div>
+              <div class="flex items-center gap-3">
+                <div class="text-xs text-cloud/80 w-20">v0</div>
+                <div class="flex-1 h-2 rounded-full bg-white/[0.06] overflow-hidden">
+                  <div class="h-full bg-teal/50" style="width: 11%;"></div>
+                </div>
+                <div class="text-xs text-cloud/60 tabular-nums w-6 text-right">1</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="pt-4 border-t border-whisper">
+            <div class="flex items-center justify-between mb-3">
+              <div class="text-xs uppercase tracking-widest text-cloud/40">Completion trend</div>
+              <div class="text-xs text-cloud/40">Last 4 weeks</div>
+            </div>
+            <div class="flex items-end gap-1.5 h-12">
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 100%;" title="Week of Apr 27: 100%"></div>
+              <div class="flex-1 rounded-t bg-teal/40" style="height: 88%;" title="Week of May 4: 88%"></div>
+              <div class="flex-1 rounded-t bg-teal/30" style="height: 77%;" title="Week of May 11: 77%"></div>
+              <div class="flex-1 rounded-t bg-yellow-500/40" style="height: 66%;" title="Week of May 18: 66%"></div>
+            </div>
+            <div class="mt-2 flex items-center justify-between text-xs">
+              <span class="text-cloud/40 tabular-nums">Apr 27</span>
+              <span class="text-yellow-300 tabular-nums">66% ↓</span>
+              <span class="text-cloud/40 tabular-nums">May 18</span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- SECTION 4 + 5 — Phase guidance + Pod resources (two-column) -->
+    <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+
+      <!-- Phase guidance — wider -->
+      <div class="lg:col-span-2 rounded-md border border-whisper bg-white/[0.02] p-6">
+        <div class="flex items-start justify-between gap-3 mb-4">
+          <div>
+            <div class="text-xs uppercase tracking-widest text-teal mb-1.5">Phase guidance</div>
+            <h3 class="text-lg font-semibold text-white">Phase 4 · Solution Proposals</h3>
+          </div>
+          <button class="text-cloud/40 hover:text-cloud transition-colors p-1" title="What this phase asks of your pod">
+            <i data-lucide="help-circle" class="h-4 w-4"></i>
+          </button>
+        </div>
+
+        <p class="text-sm text-cloud/80 leading-relaxed mb-5">
+          Members of your pod are drafting solution proposals to the problem your pod is built around. A healthy pod at this stage has at least one proposal from most active members. Watch for upskillers who haven't started — that often precedes disengagement.
+        </p>
+
+        <!-- Phase-specific signal -->
+        <div class="rounded-md border border-teal/20 bg-teal/[0.04] p-4 mb-5">
+          <div class="text-xs uppercase tracking-widest text-aqua/80 mb-2">Submissions so far</div>
+          <div class="flex items-baseline gap-2 mb-3">
+            <span class="text-3xl font-bold tabular-nums text-white">4</span>
+            <span class="text-sm text-cloud/60">of 9 members have submitted</span>
+          </div>
+          <!-- Inline mini-progress -->
+          <div class="h-1.5 rounded-full bg-white/[0.06] overflow-hidden">
+            <div class="h-full bg-teal" style="width: 44%"></div>
+          </div>
+        </div>
+
+        <!-- Deadlines -->
+        <div class="grid grid-cols-2 gap-4 pt-4 border-t border-whisper">
+          <div>
+            <div class="text-xs text-cloud/40 uppercase tracking-widest mb-1.5">Current phase closes</div>
+            <div class="text-sm text-cloud tabular-nums">May 22, 2026 · 11:59 PM ET</div>
+            <div class="text-xs text-yellow-300 mt-1">In 2 days</div>
+          </div>
+          <div>
+            <div class="text-xs text-cloud/40 uppercase tracking-widest mb-1.5">Next phase opens</div>
+            <div class="text-sm text-cloud tabular-nums">May 23, 2026 · 12:00 AM ET</div>
+            <div class="text-xs text-cloud/60 mt-1">Phase 5 · Project Voting</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Pod resources -->
+      <div class="rounded-md border border-whisper bg-white/[0.02] p-6">
+        <div class="text-xs uppercase tracking-widest text-cloud/40 mb-4">Pod resources</div>
+        <div class="space-y-2">
+          <a href="#" class="flex items-center gap-3 rounded-md px-3 py-2.5 -mx-2 hover:bg-white/[0.04] transition-colors group">
+            <div class="h-8 w-8 rounded bg-white/[0.06] grid place-items-center flex-shrink-0">
+              <i data-lucide="hash" class="h-4 w-4 text-cloud/60 group-hover:text-aqua transition-colors"></i>
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm text-cloud group-hover:text-white transition-colors">Slack channel</div>
+              <div class="text-xs text-cloud/50 truncate">#pod-health-systems-access</div>
+            </div>
+            <i data-lucide="external-link" class="h-3.5 w-3.5 text-cloud/30 flex-shrink-0"></i>
+          </a>
+          <a href="#" class="flex items-center gap-3 rounded-md px-3 py-2.5 -mx-2 hover:bg-white/[0.04] transition-colors group">
+            <div class="h-8 w-8 rounded bg-white/[0.06] grid place-items-center flex-shrink-0">
+              <i data-lucide="folder" class="h-4 w-4 text-cloud/60 group-hover:text-aqua transition-colors"></i>
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm text-cloud group-hover:text-white transition-colors">Drive folder</div>
+              <div class="text-xs text-cloud/50 truncate">Pod · Health Systems Access</div>
+            </div>
+            <i data-lucide="external-link" class="h-3.5 w-3.5 text-cloud/30 flex-shrink-0"></i>
+          </a>
+          <a href="#" class="flex items-center gap-3 rounded-md px-3 py-2.5 -mx-2 hover:bg-white/[0.04] transition-colors group">
+            <div class="h-8 w-8 rounded bg-white/[0.06] grid place-items-center flex-shrink-0">
+              <i data-lucide="github" class="h-4 w-4 text-cloud/60 group-hover:text-aqua transition-colors"></i>
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm text-cloud group-hover:text-white transition-colors">GitHub repo</div>
+              <div class="text-xs text-cloud/50 truncate">tul/pod-health-systems-access</div>
+            </div>
+            <i data-lucide="external-link" class="h-3.5 w-3.5 text-cloud/30 flex-shrink-0"></i>
+          </a>
+          <a href="#" class="flex items-center gap-3 rounded-md px-3 py-2.5 -mx-2 hover:bg-white/[0.04] transition-colors group">
+            <div class="h-8 w-8 rounded bg-white/[0.06] grid place-items-center flex-shrink-0">
+              <i data-lucide="mail" class="h-4 w-4 text-cloud/60 group-hover:text-aqua transition-colors"></i>
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm text-cloud group-hover:text-white transition-colors">Google Group</div>
+              <div class="text-xs text-cloud/50 truncate">pod-health-systems@…</div>
+            </div>
+            <i data-lucide="external-link" class="h-3.5 w-3.5 text-cloud/30 flex-shrink-0"></i>
+          </a>
+        </div>
+      </div>
+
+    </section>
+
+  </main>
+</section>
+
+<!-- ===================================================================== -->
+<!-- SCREEN 3 — PULSE RESPONSE REVIEW (per-pod with side panel overlay) -->
+<!-- ===================================================================== -->
+<section id="screen-pulse" class="screen">
+
+  <!-- Background: dimmed per-pod (re-uses simplified version) -->
+  <div class="relative">
+
+    <!-- Faded background nav -->
+    <header class="border-b border-white/[0.07] bg-[rgba(11,16,22,0.97)] backdrop-blur-sm opacity-40 pointer-events-none">
+      <div class="mx-auto flex h-[60px] max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div class="flex items-center gap-8">
+          <span class="text-sm font-semibold tracking-wide text-white">OLOS</span>
+          <nav class="hidden md:flex items-center gap-6 text-sm">
+            <a href="#" class="text-cloud/60">Cycles</a>
+            <a href="#" class="text-white">Pods</a>
+            <a href="#" class="text-cloud/60">Members</a>
+          </nav>
+        </div>
+        <div class="flex items-center gap-3">
+          <span class="inline-flex items-center gap-1.5 rounded-full bg-blue-500/15 px-2.5 py-0.5 text-xs font-medium text-blue-300">Poderator</span>
+          <div class="h-8 w-8 rounded-full bg-white/[0.08] grid place-items-center text-xs font-semibold text-cloud">MJ</div>
+        </div>
+      </div>
+    </header>
+
+    <!-- Faded background content (snippet of the per-pod page) -->
+    <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-6 pb-16 opacity-30 pointer-events-none">
+      <div class="text-xs uppercase tracking-widest text-cloud/40 mb-2">Energy &amp; Climate · Q3 2026 · Week 6</div>
+      <h1 class="text-2xl font-bold tracking-tight text-white mb-8">Health Systems Access</h1>
+      <div class="grid grid-cols-1 lg:grid-cols-4 gap-4 mb-8">
+        <div class="rounded-md border border-whisper bg-white/[0.02] p-5 h-28"></div>
+        <div class="rounded-md border border-whisper bg-white/[0.02] p-5 h-28"></div>
+        <div class="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-5 h-28"></div>
+        <div class="rounded-md border border-whisper bg-white/[0.02] p-5 h-28"></div>
+      </div>
+      <div class="rounded-md border border-whisper bg-white/[0.02] h-96"></div>
+    </main>
+
+    <!-- Backdrop -->
+    <div class="fixed inset-0 panel-backdrop z-30" onclick="showScreen('per-pod')"></div>
+
+    <!-- Side panel -->
+    <aside class="fixed top-0 right-0 bottom-0 z-40 w-full sm:max-w-lg md:max-w-xl lg:max-w-2xl xl:max-w-3xl 2xl:max-w-[800px] bg-ink border-l border-whisper shadow-2xl overflow-y-auto">
+
+      <!-- Panel header -->
+      <div class="sticky top-0 bg-ink border-b border-whisper px-6 py-4 z-10">
+        <div class="flex items-start justify-between gap-4">
+          <div class="flex items-center gap-3 min-w-0">
+            <div class="h-10 w-10 rounded-full bg-white/[0.08] grid place-items-center text-sm font-semibold text-cloud flex-shrink-0">LP</div>
+            <div class="min-w-0">
+              <div class="text-base font-semibold text-white">Linda P.</div>
+              <div class="text-xs text-cloud/60 truncate">Health Systems Access</div>
+            </div>
+          </div>
+          <button class="p-1.5 rounded text-cloud/40 hover:bg-white/[0.04] hover:text-cloud transition-colors" aria-label="Close" onclick="showScreen('per-pod')">
+            <i data-lucide="x" class="h-5 w-5"></i>
+          </button>
+        </div>
+
+        <!-- Member context strip -->
+        <div class="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs">
+          <span class="inline-flex items-center gap-1.5 rounded-full bg-yellow-500/20 px-2.5 py-0.5 font-medium text-yellow-300">
+            <i data-lucide="alert-triangle" class="h-3 w-3"></i>
+            At risk
+          </span>
+          <span class="text-cloud/60">New to building</span>
+          <span class="text-cloud/30">·</span>
+          <span class="text-cloud/60">Weekends only</span>
+          <span class="text-cloud/30">·</span>
+          <span class="text-cloud/60">Last active 19 days ago</span>
+        </div>
+
+        <!-- Prev / next member -->
+        <div class="mt-4 flex items-center justify-between">
+          <button class="inline-flex items-center gap-1.5 text-xs text-cloud/60 hover:text-aqua transition-colors">
+            <i data-lucide="chevron-left" class="h-4 w-4"></i>
+            Sarah K.
+          </button>
+          <span class="text-xs text-cloud/40 tabular-nums">Member 2 of 9</span>
+          <button class="inline-flex items-center gap-1.5 text-xs text-cloud/60 hover:text-aqua transition-colors">
+            Priya S.
+            <i data-lucide="chevron-right" class="h-4 w-4"></i>
+          </button>
+        </div>
+      </div>
+
+      <!-- Pulse responses -->
+      <div class="p-6 space-y-5">
+
+        <!-- Individual aggregation (§7.9.1) -->
+        <div class="rounded-md border border-teal/20 bg-teal/[0.04] p-5">
+          <div class="flex items-center justify-between mb-4">
+            <div class="text-xs uppercase tracking-widest text-aqua/80">Across the cycle so far</div>
+            <span class="text-xs text-cloud/50 tabular-nums">3 of 6 pulses submitted</span>
+          </div>
+
+          <!-- Engagement trajectory -->
+          <div class="mb-5">
+            <div class="text-xs text-cloud/60 mb-2">Engagement trajectory · weekly</div>
+            <div class="flex items-center gap-1.5">
+              <span class="h-2.5 w-2.5 rounded-full bg-teal/60" title="Week 1: submitted"></span>
+              <span class="h-2.5 w-2.5 rounded-full bg-teal/60" title="Week 2: submitted"></span>
+              <span class="h-2.5 w-2.5 rounded-full bg-teal/60" title="Week 3: submitted"></span>
+              <span class="h-2.5 w-2.5 rounded-full border border-yellow-500/40 bg-yellow-500/10" title="Week 4: missed"></span>
+              <span class="h-2.5 w-2.5 rounded-full border border-yellow-500/40 bg-yellow-500/10" title="Week 5: missed"></span>
+              <span class="h-2.5 w-2.5 rounded-full border border-yellow-500/40 bg-yellow-500/10" title="Week 6: missed"></span>
+            </div>
+            <div class="mt-2 text-xs text-yellow-300">Three weeks without a pulse, after three consecutive submissions.</div>
+          </div>
+
+          <!-- Aggregation grid -->
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-5 pt-4 border-t border-teal/15">
+            <div>
+              <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Tools she's used</div>
+              <div class="flex flex-wrap gap-1.5">
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/20 px-2.5 py-0.5 text-xs text-aqua">ChatGPT <span class="tabular-nums opacity-80">3</span></span>
+                <span class="inline-flex items-center gap-1.5 rounded-full bg-teal/15 px-2.5 py-0.5 text-xs text-aqua/90">Claude <span class="tabular-nums opacity-80">2</span></span>
+              </div>
+            </div>
+            <div>
+              <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Recurring stuck-on themes</div>
+              <ul class="text-xs text-cloud/85 space-y-1">
+                <li class="flex items-center justify-between gap-2 hover:text-aqua transition-colors cursor-pointer">
+                  <span>Confusion about proposal scope</span>
+                  <span class="text-cloud/40 tabular-nums">2</span>
+                </li>
+                <li class="flex items-center justify-between gap-2 hover:text-aqua transition-colors cursor-pointer">
+                  <span>Feeling behind technically</span>
+                  <span class="text-cloud/40 tabular-nums">2</span>
+                </li>
+              </ul>
+            </div>
+            <div class="sm:col-span-2 pt-4 border-t border-teal/15">
+              <div class="text-xs uppercase tracking-widest text-aqua/70 mb-2">Help she's asked for</div>
+              <ul class="text-xs text-cloud/85 space-y-1">
+                <li class="flex items-center justify-between gap-2 hover:text-aqua transition-colors cursor-pointer">
+                  <span>Pair with a more technical pod-mate</span>
+                  <span class="text-cloud/40 tabular-nums">2 weeks</span>
+                </li>
+                <li class="flex items-center justify-between gap-2 hover:text-aqua transition-colors cursor-pointer">
+                  <span>Non-technical proposal examples</span>
+                  <span class="text-cloud/40 tabular-nums">1 week</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="text-xs uppercase tracking-widest text-cloud/40 pt-2">Week by week</div>
+
+        <!-- Missed week 1 -->
+        <div class="rounded-md border border-dashed border-whisper bg-white/[0.01] p-4 text-center">
+          <div class="inline-flex items-center gap-2 text-xs font-medium text-cloud/50">
+            <i data-lucide="circle-slash" class="h-3.5 w-3.5"></i>
+            No submission · Week of May 18
+          </div>
+        </div>
+
+        <!-- Missed week 2 -->
+        <div class="rounded-md border border-dashed border-whisper bg-white/[0.01] p-4 text-center">
+          <div class="inline-flex items-center gap-2 text-xs font-medium text-cloud/50">
+            <i data-lucide="circle-slash" class="h-3.5 w-3.5"></i>
+            No submission · Week of May 11
+          </div>
+        </div>
+
+        <!-- Missed week 3 -->
+        <div class="rounded-md border border-dashed border-whisper bg-white/[0.01] p-4 text-center">
+          <div class="inline-flex items-center gap-2 text-xs font-medium text-cloud/50">
+            <i data-lucide="circle-slash" class="h-3.5 w-3.5"></i>
+            No submission · Week of May 4
+          </div>
+        </div>
+
+        <!-- Response 1 -->
+        <article class="rounded-md border border-whisper bg-white/[0.02] p-5 space-y-4">
+          <div class="flex items-center justify-between">
+            <div class="text-sm font-semibold text-white">Week of April 27</div>
+            <div class="text-xs text-cloud/50 tabular-nums">Submitted Apr 28</div>
+          </div>
+
+          <div>
+            <div class="text-xs uppercase tracking-widest text-cloud/40 mb-1.5">What went well</div>
+            <p class="text-sm text-cloud/85 leading-relaxed">I joined the pod kickoff call and met everyone. Felt out of my depth on the technical side but Marcus offered to walk me through Cursor.</p>
+          </div>
+
+          <div>
+            <div class="text-xs uppercase tracking-widest text-cloud/40 mb-1.5">What I'm stuck on</div>
+            <p class="text-sm text-cloud/85 leading-relaxed">I don't really understand what a "solution proposal" is supposed to look like. The example was technical and I'm not sure how to scope something I could actually contribute to.</p>
+          </div>
+
+          <div>
+            <div class="text-xs uppercase tracking-widest text-cloud/40 mb-1.5">Help I need</div>
+            <p class="text-sm text-cloud/85 leading-relaxed">Is there an example proposal from a non-technical person? Or could someone pair with me for 30 min this weekend?</p>
+          </div>
+
+          <div>
+            <div class="text-xs uppercase tracking-widest text-cloud/40 mb-2">AI tools used this week</div>
+            <div class="flex flex-wrap gap-1.5">
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2.5 py-0.5 text-xs text-cloud/80">ChatGPT</span>
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2.5 py-0.5 text-xs text-cloud/80">Claude</span>
+            </div>
+          </div>
+        </article>
+
+        <!-- Response 2 -->
+        <article class="rounded-md border border-whisper bg-white/[0.02] p-5 space-y-4">
+          <div class="flex items-center justify-between">
+            <div class="text-sm font-semibold text-white">Week of April 20</div>
+            <div class="text-xs text-cloud/50 tabular-nums">Submitted Apr 21</div>
+          </div>
+
+          <div>
+            <div class="text-xs uppercase tracking-widest text-cloud/40 mb-1.5">What went well</div>
+            <p class="text-sm text-cloud/85 leading-relaxed">I voted on the problem statements and was excited my top pick made the shortlist.</p>
+          </div>
+
+          <div>
+            <div class="text-xs uppercase tracking-widest text-cloud/40 mb-1.5">What I'm stuck on</div>
+            <p class="text-sm text-cloud/85 leading-relaxed">Trying to figure out how to register for the pod and which pod I'd be most useful in.</p>
+          </div>
+
+          <div>
+            <div class="text-xs uppercase tracking-widest text-cloud/40 mb-2">AI tools used this week</div>
+            <div class="flex flex-wrap gap-1.5">
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] px-2.5 py-0.5 text-xs text-cloud/80">ChatGPT</span>
+            </div>
+          </div>
+        </article>
+
+        <!-- Range expand -->
+        <div class="pt-2 text-center">
+          <button class="inline-flex items-center gap-1.5 text-xs text-cloud/60 hover:text-aqua transition-colors">
+            Show full cycle history
+            <i data-lucide="chevron-down" class="h-3.5 w-3.5"></i>
+          </button>
+        </div>
+
+      </div>
+
+      <!-- Footer actions -->
+      <div class="sticky bottom-0 bg-ink border-t border-whisper px-6 py-4">
+        <div class="flex items-center justify-between gap-3">
+          <button class="inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium text-cloud/70 ring-1 ring-whisper hover:bg-white/[0.04] hover:text-cloud transition-colors">
+            <i data-lucide="message-square" class="h-4 w-4"></i>
+            Slack DM
+          </button>
+          <button class="rounded-md bg-teal px-4 py-2 text-sm font-medium text-white hover:bg-teal/80 transition-colors shadow-[0_1px_4px_rgba(0,148,160,0.2)]">
+            Reach out
+          </button>
+        </div>
+      </div>
+    </aside>
+
+  </div>
+</section>
+
+<!-- ===================================================================== -->
+<script>
+  function showScreen(name) {
+    document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+    document.getElementById('screen-' + name).classList.add('active');
+    ['all-pods', 'per-pod', 'pulse'].forEach(n => {
+      const btn = document.getElementById('tab-' + n);
+      if (n === name) {
+        btn.classList.add('mock-tab-active');
+        btn.classList.remove('mock-tab-inactive');
+      } else {
+        btn.classList.remove('mock-tab-active');
+        btn.classList.add('mock-tab-inactive');
+      }
+    });
+    window.scrollTo({ top: 0, behavior: 'instant' });
+    setTimeout(() => { if (window.lucide) lucide.createIcons(); }, 50);
+  }
+  document.addEventListener('DOMContentLoaded', () => {
+    if (window.lucide) lucide.createIcons();
+  });
+</script>
+
+</body>
+</html>

--- a/docs/PRD-moderator-dashboard.md
+++ b/docs/PRD-moderator-dashboard.md
@@ -68,7 +68,7 @@ Within a per-pod view, sections render top to bottom as follows:
 6. Phase guidance (§7.5)
 7. Pod resources (§7.6)
 
-The All pods view shows, top to bottom: cross-pod at-risk nudges (§7.2), pod summary cards (§7.10.1), a members-needing-attention rollup (§7.10.2), cross-pod pulse insights (§7.9.3), and an LLM summary prompt export affordance (§7.10.3). The switcher and the poderator's last-selected view are described in §7.7.
+The All pods view shows, top to bottom: cross-pod at-risk nudges (§7.2), pod summary cards (§7.10.1), a members-needing-attention rollup (§7.10.2), cross-pod pulse insights (§7.9.3), and an AI-assisted summary block (§7.10.3). The switcher and the poderator's last-selected view are described in §7.7.
 
 ## 7. Functional requirements
 
@@ -210,44 +210,34 @@ Lightweight tooltips assist with UI-mechanic orientation, particularly for first
 
 Aggregated views of pulse-check data surface patterns the per-week response stream can't show on its own. Aggregations are computed server-side and render at three scopes: individual, pod, and across-pods.
 
-The structured fields on each pulse check (AI tools used, multi-select option lists) aggregate by deterministic counts. The free-text fields ("what went well," "what I'm stuck on," "help I need") are reduced to themes by an LLM pass and stored with citations back to the source pulse responses, so a poderator can always trace a theme back to who said what.
+Aggregations cover **structured fields only** — AI tools selected, multi-select options, pulse-completion rates. Free-text fields ("what went well," "what I'm stuck on," "help I need") are not summarized by OLOS; they surface as raw responses in the pulse response review (§7.4) and feed the AI-assisted summary block (§7.10.3) where the poderator can run their own analysis on them.
 
 #### 7.9.1 Individual aggregation
 
 Rendered as a block at the top of the pulse response review side panel (§7.4), above the per-week responses. Scoped to a single member across the full active cycle.
 
 - **Top AI tools used.** Up to five tools, ordered by frequency of selection across that member's pulse responses. Each shows a count of the number of pulses in which the member named it.
-- **Recurring "stuck on" themes.** Up to three themes derived from the member's free-text responses, ordered by frequency. Each theme is one short phrase plus a count of pulses where it surfaced.
-- **Recurring help requests.** Up to three themes from the "help I need" field, same shape as above.
 - **Engagement trajectory.** A small sparkline or week-by-week dot row showing pulse completion across the cycle (submitted / missed) so the poderator can see at a glance whether engagement has been rising, falling, or stable.
-- Each theme links back to the source pulse responses, scrolling the panel to the relevant week(s) on click.
 
 #### 7.9.2 Pod-level aggregation
 
 Rendered as a section on the per-pod dashboard, between the member roster (§7.3) and the phase guidance (§7.5). Scoped to one pod, default to the last four weeks with a toggle for the full cycle.
 
 - **Top AI tools across the pod.** Up to five tools, ordered by the count of pod members who named them in their pulse responses (not by raw mention count, so one heavy user doesn't dominate). Each shows the count of pod members.
-- **Top "stuck on" themes.** Up to three LLM-derived themes from the pod's free-text responses, each with a count of distinct members who surfaced it. Themes that appear in only one member's responses are suppressed.
-- **Top help requests.** Same shape as stuck-on themes.
 - **Pulse completion trend.** A small bar or line showing the pod's pulse-completion rate over the displayed range, week by week.
-- Each theme item links to the underlying pulse responses, opening the pulse review panel (§7.4) for the relevant member(s) and scrolling to the matching week.
-- A clear empty state when the pod has insufficient data (fewer than two members with pulse responses in the range): "Not enough pulse data yet to show themes."
 
 #### 7.9.3 Cross-pod aggregation
 
 Rendered as a section on the All pods view, beneath the pod-summary cards. Scoped to all of the poderator's assigned pods, default to the last four weeks with a toggle for the full cycle.
 
-- **Patterns across your pods.** LLM-derived themes that appear in two or more of the poderator's pods, surfaced as a list with per-pod breakdown (e.g. "Confusion about solution proposal scope — Health Systems Access · Energy Grid Resilience"). Helps a poderator notice when a problem is structural to the program rather than specific to one pod.
 - **AI tool adoption by pod.** A small grid comparing the top tools in each pod side by side. Useful for cross-pollination: if Pod A is getting traction with Cursor and Pod B isn't using it yet, the poderator can route that knowledge.
 - **Engagement comparison.** Each pod's pulse-completion rate over the displayed range, shown as side-by-side mini-trends so the poderator can spot a pod whose engagement is sliding relative to the others.
 - Section is suppressed entirely for single-pod poderators.
 
 #### Cross-cutting requirements
 
-- **Computation.** Theme extraction runs after each pulse submission window closes and is cached. Structured-field aggregates are computed live (cheap) unless `pulse_check_aggregates` is in use.
-- **LLM provenance.** Each LLM-derived theme records which pulse-response rows contributed to it. Poderators see this as "from N responses across M members" with a link to the underlying responses.
-- **Privacy.** Themes are visible to poderators of pods the responses came from. Cross-pod themes are visible only to poderators with assignments in all contributing pods (no leakage between unrelated pods).
-- **Tone.** Theme labels are descriptive, not judgmental. The system surfaces "Confusion about proposal scope," not "Members seem lost." This is a design rule for prompts that generate themes; copy review is required.
+- **Computation.** All aggregates are computed live from existing tables (pulse responses, AI tool selections). No theme-extraction pipeline; no LLM dependency.
+- **Privacy.** Aggregates are visible only to poderators of pods the responses came from. Cross-pod aggregates are visible only to poderators with assignments in all contributing pods (no leakage between unrelated pods).
 
 ### 7.10 All pods view composition
 
@@ -273,17 +263,40 @@ A four-metric KPI block summarizing engagement across all assigned pods. Rendere
 - **Pulses this period.** Count of pulses submitted over total possible pulses across the displayed range. Range follows the §7.9.3 last-4-weeks / full-cycle toggle.
 - **Engagement trend.** Aggregate weekly completion rate as a percentage, with a three-week trend arrow and the prior-week comparison value.
 
-#### 7.10.3 LLM summary prompt export
+#### 7.10.3 AI-assisted summary block
 
-The dashboard provides a "Copy summary prompt" affordance that produces a templated prompt the poderator can paste into a third-party LLM (ChatGPT, Claude, Gemini, etc.) to get a narrative summary of what's going on with their pods. OLOS does not call any LLM as part of this affordance — the poderator's own tool does the work.
+OLOS does not summarize free-text pulse responses internally — there is no LLM pipeline running inside OLOS for this dashboard. Instead, each insights section includes a small block that bundles the raw pulse comments with a canonical instruction prompt and gives the poderator a one-click way to copy the bundle to their own AI tool (ChatGPT, Claude, Gemini, etc.) for analysis.
 
-- The affordance renders on both the All pods view (covering all assigned pods) and each per-pod dashboard (covering one pod). Placement is alongside the §7.9 cross-pod / pod-level insights section.
-- Clicking opens a preview modal showing the exact prompt that will be copied, with the poderator's current data interpolated.
-- The prompt template, including its phrasing and the instruction to the LLM (e.g. "Summarize what's going on with these pods this week and flag anything I should pay attention to"), is stored as a versioned string the program team can edit without code changes.
-- Interpolated data: pod names, current phase per pod, count of members per pod, weekly pulse-completion rate per pod, top stuck-on themes and top help-request themes from §7.9, at-risk member count per pod.
-- **Privacy.** The prompt excludes by default: member full names (use initials), free-text pulse responses, contact information, and any field listed in §7.3 as "never exposed to the poderator." The preview is the source of truth — the poderator sees exactly what will be copied, so they can review before pasting into a third-party LLM.
-- A short disclaimer renders beside the affordance: "Copies a summary of your pod data. You'll paste it into your own AI tool — OLOS doesn't send anything." The exact copy is program-team-owned.
-- Telemetry: log copy events (poderator id, scope = `all_pods` or `pod_id`, timestamp) to gauge feature usage without recording prompt contents.
+**Where it renders.**
+
+- Per-pod insights section (§7.9.2 surface) — bundle scoped to that pod.
+- All pods cross-pod insights section (§7.9.3 surface) — bundle scoped to all the poderator's assigned pods.
+
+**What the block contains.**
+
+- A short header explaining what the block is and what clicking will do.
+- A preview list of the recent pulse comments (free-text answers) included in the bundle. Members are referenced by initials only.
+- A single button: **"Copy prompt + responses"** that copies the full bundle (prompt text + comment list) to the clipboard.
+- A passive disclaimer beneath the button: "OLOS doesn't send anything. You'll paste this into your own AI tool."
+
+**The prompt.**
+
+One canonical prompt, owned by the program team. Stored as a string the program team can update without code changes (location TBD by implementer — `cycle_config`, a simple admin form, or a constant in code; not part of this PRD's scope). The prompt instructs the LLM to:
+
+- Identify themes across the pulse comments.
+- Flag members or topics the poderator should pay attention to this week.
+- Cite the responses it draws conclusions from.
+- Be descriptive, not judgmental. (Same tone rule that applied to the previous LLM-extraction approach: "Confusion about proposal scope," not "Members seem lost.")
+
+The prompt is the **same prompt** on both the All pods and per-pod surfaces. Only the bundled comments change scope.
+
+**Privacy.**
+
+- Member full names are excluded from the bundle. Initials only.
+- Fields listed in §7.3 as "never exposed to the poderator" (phone, free-text notes, contact-consent flags) are excluded.
+- The preview is the source of truth — the poderator sees the comments before copying, so they can review what will leave the dashboard.
+
+**Scope of bundled comments.** Last four weeks by default. Follows the same time-range toggle as §7.9 (last 4 weeks / full cycle).
 
 ## 8. Permissions and access control
 
@@ -304,9 +317,8 @@ This PRD primarily consumes existing data. The following additions are anticipat
 
 - **`nudge_dismissals`** — new table. Schema: `(moderator_participant_id, pod_id, nudge_key, dismissed_at)`. Records dismissed nudge instances so they remain dismissed across sessions.
 - **`moderator_ui_state`** — new table. Tracks per-poderator switcher last-selected view (`all_pods` or a specific `pod_id`), roster filter/sort state, and tooltip suppression keys. Applies to admins and poderators alike.
-- **`pulse_themes`** — new table. Schema: `(theme_id, scope_type, scope_id, scope_window_start, scope_window_end, source_field, theme_label, member_count, mention_count, contributing_pulse_ids[], generated_at)`. Stores LLM-derived themes for §7.9 aggregations. `scope_type` is one of `individual`, `pod`, or `cross_pod`. Theme labels are subject to the tone rules in §7.9. Populated by the LLM theme-extraction pipeline that runs after each pulse submission window closes.
-- **`pulse_check_aggregates`** — deferred. May be introduced later if live query performance on `pulse_themes` proves insufficient.
-- **`cycle_config` extensions** — new fields for: pod-health band thresholds (healthy/warning/critical headcount cutoffs), the consecutive-miss threshold for the at-risk nudge, and the default time window for pulse aggregations (e.g. last four weeks vs full cycle). Global defaults applied when a cycle hasn't set its own values.
+- **`participants` extensions** — new column `ai_experience_level` (enum: `new`, `consumer`, `builder`, `shipper`) and a short `availability_snippet` string. Backs §7.3.1 member preview. Captured at registration; default `new` for legacy rows.
+- **`cycle_config` extensions** — new fields for: pod-health band thresholds (healthy/warning/critical headcount cutoffs), the consecutive-miss threshold for the at-risk nudge, the default time window for pulse aggregations (e.g. last four weeks vs full cycle), and the canonical AI-summary prompt string used by §7.10.3. Global defaults applied when a cycle hasn't set its own values.
 
 All other data — pod metadata, poderator assignments, pod memberships, pulse checks, pod-resource URLs, cycle and phase windows — is sourced from existing tables. No modification to existing core schemas is proposed.
 
@@ -324,7 +336,8 @@ This section records the decisions made during PRD review. Each decision superse
 | Profile visibility tiering | Four tiers: always in row (AI experience + availability), on expansion/hover (role, industry, employer, interest areas, work style, group strengths, labs goals), click-through to profile (AI tools, cycle-fit signal, city-level location), never visible (phone, free-text notes, contact-consent flags). Registration form copy must disclose poderator visibility. |
 | First-poderator onboarding | No in-product walkthrough. Programmatic orientation via poderator handbook + kickoff session (program-team-owned). In-product tooltips cover UI mechanics, auto-suppressing after first 1–2 encounters per element. |
 | Inactive members | Hidden from roster by default. "Show inactive" toggle reveals them at reduced opacity, sorted to the bottom, each with their inactive-since date. |
-| Pulse-check aggregations | Three scopes: individual (in the pulse response side panel), pod-level (in the per-pod dashboard), and cross-pod (in the All pods view, single-pod poderators excluded). Structured fields aggregate by counts; free-text fields are reduced to themes by an LLM pass with provenance back to source responses. Default range last 4 weeks, full-cycle toggle available. Ships with the dashboard in a single phase. |
+| Pulse-check aggregations | Three scopes: individual (in the pulse response side panel), pod-level (in the per-pod dashboard), and cross-pod (in the All pods view, single-pod poderators excluded). Structured fields only (AI tool counts, pulse-completion rates); free-text fields are not summarized internally. Default range last 4 weeks, full-cycle toggle available. |
+| AI summary approach | OLOS does not run any LLM internally. Free-text pulse responses are bundled with a canonical instruction prompt into a copy-to-clipboard block (§7.10.3) that poderators paste into their own AI tool. One prompt, owned by the program team. |
 | Route structure | Routes use `/moderator` (All pods) and `/moderator/pods/[id]` (per-pod), not the `/pods/[id]/moderator` pattern in the original PRD draft. All poderator routes live under `app/(dashboard)/moderator/`. |
 | Admin ui-state | Admins receive `moderator_ui_state` rows like poderators. Filter/sort/tooltip state persists for admins too. |
 

--- a/docs/PRD-moderator-dashboard.md
+++ b/docs/PRD-moderator-dashboard.md
@@ -44,18 +44,18 @@ A poderator today has no purpose-built place in OLOS to do their job. The inform
 
 ## 5. Glossary
 
-- **Poderator** — community member assigned to one or more pods for one cycle. Stored as one or more rows in `poderator_assignments` with `removed_at IS NULL`. See [`personas.md`](personas.md#poderator).
+- **Poderator** — community member assigned to one or more pods for one cycle. Stored as one or more rows in `moderator_assignments` with `removed_at IS NULL`. See [`personas.md`](personas.md#poderator).
 - **Pod** — group within a cycle, seeded by a top-voted problem statement.
 - **Pulse check** — weekly check-in completed by active participants. The configured number of consecutive missed pulses (default: 2) is the canonical disengagement signal.
 - **Phase** — one of the seven cycle stages (problem submission, pod voting, pod registration, solution submission, project voting, project shortlist, project registration).
-- **All Pods view** — the cross-pod overview presented to multi-pod poderators, aggregating at-risk-member nudges from all assigned pods into a single list.
+- **All pods view** — the cross-pod overview presented to multi-pod poderators, aggregating at-risk-member nudges from all assigned pods into a single list.
 - **Per-pod view** — the full dashboard scoped to one pod, comprising the pod status header, member roster, pulse response review, phase guidance, and pod resources.
 
 ## 6. Information architecture
 
 The dashboard exposes two views, navigated via a switcher control at the top of the page:
 
-- **All Pods view** — cross-pod aggregated nudges only. Default landing for multi-pod poderators on first sign-in.
+- **All pods view** — cross-pod aggregated nudges only. Default landing for multi-pod poderators on first sign-in.
 - **Per-pod view** — full per-pod content (status header, nudges scoped to that pod, member roster, phase guidance, pod resources). Default landing for single-pod poderators.
 
 Within a per-pod view, sections render top to bottom as follows:
@@ -68,7 +68,7 @@ Within a per-pod view, sections render top to bottom as follows:
 6. Phase guidance (§7.5)
 7. Pod resources (§7.6)
 
-The All Pods view shows cross-pod at-risk nudges (§7.2) and cross-pod pulse insights (§7.9). The switcher and the poderator's last-selected view are described in §7.7.
+The All pods view shows, top to bottom: cross-pod at-risk nudges (§7.2), pod summary cards (§7.10.1), a members-needing-attention rollup (§7.10.2), cross-pod pulse insights (§7.9.3), and an LLM summary prompt export affordance (§7.10.3). The switcher and the poderator's last-selected view are described in §7.7.
 
 ## 7. Functional requirements
 
@@ -94,7 +94,7 @@ Nudges are server-computed and surfaced on the dashboard. Only one nudge type sh
 - Dismissal is per poderator, per nudge instance. A dismissed nudge does not suppress future at-risk nudges for the same member if the condition re-triggers.
 - Render no more than three nudges at any time per view. Excess collapses into a "see N more" affordance.
 - The system flags only. The poderator follows up via Slack DM or other means; the dashboard does not initiate outreach.
-- In the per-pod view, nudges are scoped to the pod. In the All Pods view, nudges aggregate across all of the poderator's pod assignments and each nudge identifies the source pod.
+- In the per-pod view, nudges are scoped to the pod. In the All pods view, nudges aggregate across all of the poderator's pod assignments and each nudge identifies the source pod.
 - Delivery is dashboard-only in v1. No email or Slack push. Backend nudge computation is decoupled from delivery so future channels (e.g. weekly digest email) can be added without changing the underlying logic.
 - The miss-threshold for the nudge is configurable per cycle in cycle-config.
 
@@ -103,8 +103,8 @@ Nudges are server-computed and surfaced on the dashboard. Only one nudge type sh
 The roster lists every member of the pod with engagement signal.
 
 - One row per member.
-- Each row displays: member name, **always-visible profile preview** (AI experience level + availability snippet), pulse-engagement status, and last-activity timestamp formatted as a relative time.
-- On row expansion or hover, additional profile fields are revealed: professional role, industry, employer, interest areas, work style, group strengths, labs goals.
+- Each row displays the **member preview** (§7.3.1 below), the pulse-engagement status badge, and the last-activity timestamp formatted as a relative time.
+- On row expansion or hover, additional profile fields are revealed: employer, interest areas, work style, group strengths, labs goals.
 - A click-through to the member's full profile additionally exposes: AI tools used, cycle-fit signal, city-level location.
 - Never exposed to the poderator: phone number, free-text personal notes, contact-consent flags. The registration form must disclose to upskillers which fields their poderator can see (program-team-owned copy update, ships alongside this dashboard).
 - Pulse-engagement status values:
@@ -117,6 +117,38 @@ The roster lists every member of the pod with engagement signal.
 - Each row exposes two quick actions: open the member's pulse response history (links into §7.4) and open a Slack DM to the member (deep-link to Slack).
 - Members with `cycle_enrollments.status = 'inactive'` are excluded from the default view. A "Show inactive" toggle reveals them, rendered at reduced opacity, sorted to the bottom, each showing their inactive-since date.
 
+#### 7.3.1 Member preview shape
+
+The same structured **member preview** is used everywhere a poderator sees a member at-a-glance: the per-pod roster, the All pods nudges (§7.2), and the pulse response panel header (§7.4). One shape, rendered slightly differently per surface but with no field redefinition.
+
+| Field | Type | Source |
+|---|---|---|
+| `name` | string — first name + last initial (e.g. "Linda P.") | `participants.first_name`, `participants.last_name` |
+| `ai_experience_level` | enum: `new`, `consumer`, `builder`, `shipper` | `participants.ai_experience_level` (new column) |
+| `professional_role` | string (short — e.g. "Researcher") | `participants.professional_role` |
+| `industry` | string (short — e.g. "NGO", "Federal") | `participants.industry` |
+| `availability` | string (short, freeform — e.g. "weekends only") | `participants.availability_snippet` |
+
+UI labels for `ai_experience_level` (program-team-owned copy, may be edited without code changes):
+
+| Enum value | Default UI label |
+|---|---|
+| `new` | New to building |
+| `consumer` | Consumer of AI tools |
+| `builder` | Has built with AI |
+| `shipper` | Ships AI projects |
+
+Render rules per surface:
+
+- **Per-pod roster row.** Two-line display: line 1 — `name`; line 2 — `{ai_experience_level label} · {availability}`. A separate "Background" table column shows `{professional_role} · {industry}` on viewports md and above.
+- **All pods nudges (§7.2).** Single-line preview: `{name}` · `{professional_role} · {industry}` · `{availability}`. AI experience level is omitted at the cross-pod triage stage to keep the line scannable; the poderator can drill in for it.
+- **Pulse response panel header (§7.4).** Same as the roster row plus the pod name as a chip; field shape unchanged.
+
+Filter/sort:
+
+- Roster filter supports filtering by `ai_experience_level` value (e.g. "show me everyone new to building").
+- Roster sort options include AI experience level (alphabetical by enum-ordered display).
+
 ### 7.4 Pulse response review
 
 The pulse response review is a drill-in surface accessed from the member roster.
@@ -125,10 +157,11 @@ The pulse response review is a drill-in surface accessed from the member roster.
 - Displays an **individual-level aggregate block** at the top of the panel, summarizing this member's pulse history across the cycle (see §7.9.1).
 - Displays the selected member's per-week pulse responses below the aggregate, most recent first.
 - Each response shows: submission timestamp, free-text answers, and selected options for multi-select fields.
-- Default range for per-week responses: last four weeks of responses for the active cycle. Configurable up to the full cycle. The aggregate block always reflects the full cycle.
-- Read-only. The poderator cannot edit pulse responses; only the participant can submit or modify their own.
+- Default range for per-week responses: last four weeks of responses for the active cycle. The poderator can expand to the full cycle via an inline "Show full cycle history" control at the bottom of the per-week stream. The aggregate block always reflects the full cycle regardless of the expand state.
+- Read-only with respect to OLOS state: the poderator cannot edit pulse responses, send messages from the panel, or initiate any outreach from inside OLOS. Only the participant can submit or modify their own responses. The panel renders a visible "Read-only — OLOS doesn't send messages" stance in the panel footer to make the no-automated-outreach posture (§4) explicit.
+- The panel surfaces a single passive affordance: an **Open Slack DM** link that deep-links to Slack for the currently-viewed member. The same affordance from §7.3 carries into the panel for one-click convenience; OLOS does not send the message — Slack does, and only after the poderator types and sends.
 - Access is scoped to the poderator's assigned pods. Attempts to load responses for members outside the poderator's pod assignments return 403.
-- Navigation between members within the panel does not close the panel; the aggregate block re-renders for the new member.
+- Navigation between members within the panel does not close the panel; the aggregate block re-renders for the new member. The panel header shows a "Member N of M" indicator reflecting the member's position in the current roster sort, with previous/next arrows that follow that order.
 
 ### 7.5 Phase guidance
 
@@ -154,13 +187,13 @@ The resources panel surfaces external resources provisioned for the pod.
 
 ### 7.7 Switcher and last-view persistence
 
-The switcher is the primary navigation control between the All Pods view and per-pod views.
+The switcher is the primary navigation control between the All pods view and per-pod views.
 
 - The switcher appears at the top of every dashboard page.
-- The switcher options are: "All Pods" (overview) and each pod the poderator is assigned to, listed by name.
-- Single-pod poderators see a switcher with one option; the All Pods entry is suppressed.
+- The switcher options are: "All pods" (overview) and each pod the poderator is assigned to, listed by name.
+- Single-pod poderators see a switcher with one option; the All pods entry is suppressed.
 - A poderator's most recent selection persists across sessions. They land wherever they last were.
-- First-time multi-pod poderators land on **All Pods** by default.
+- First-time multi-pod poderators land on **All pods** by default.
 - First-time single-pod poderators land on their single pod's view.
 - The active selection is reflected in the URL path so that links between poderators (e.g. shared in Slack) deep-link correctly.
 
@@ -174,8 +207,6 @@ Lightweight tooltips assist with UI-mechanic orientation, particularly for first
 - The "help" affordance for each tooltipped element remains visible (e.g. small `?` icon) so a poderator can re-trigger the tooltip on demand even after auto-suppression.
 
 ### 7.9 Pulse-check aggregations
-
-> **Phase 2 — not shipped in the initial dashboard release.** The aggregation UI sections do not render at all in Phase 1 (no empty states, no placeholders). The `pulse_themes` table is created in Phase 1 migrations so Phase 2 can populate it without schema changes. See §10 decisions log.
 
 Aggregated views of pulse-check data surface patterns the per-week response stream can't show on its own. Aggregations are computed server-side and render at three scopes: individual, pod, and across-pods.
 
@@ -204,7 +235,7 @@ Rendered as a section on the per-pod dashboard, between the member roster (§7.3
 
 #### 7.9.3 Cross-pod aggregation
 
-Rendered as a section on the All Pods view, beneath the pod-summary cards. Scoped to all of the poderator's assigned pods, default to the last four weeks with a toggle for the full cycle.
+Rendered as a section on the All pods view, beneath the pod-summary cards. Scoped to all of the poderator's assigned pods, default to the last four weeks with a toggle for the full cycle.
 
 - **Patterns across your pods.** LLM-derived themes that appear in two or more of the poderator's pods, surfaced as a list with per-pod breakdown (e.g. "Confusion about solution proposal scope — Health Systems Access · Energy Grid Resilience"). Helps a poderator notice when a problem is structural to the program rather than specific to one pod.
 - **AI tool adoption by pod.** A small grid comparing the top tools in each pod side by side. Useful for cross-pollination: if Pod A is getting traction with Cursor and Pod B isn't using it yet, the poderator can route that knowledge.
@@ -218,28 +249,64 @@ Rendered as a section on the All Pods view, beneath the pod-summary cards. Scope
 - **Privacy.** Themes are visible to poderators of pods the responses came from. Cross-pod themes are visible only to poderators with assignments in all contributing pods (no leakage between unrelated pods).
 - **Tone.** Theme labels are descriptive, not judgmental. The system surfaces "Confusion about proposal scope," not "Members seem lost." This is a design rule for prompts that generate themes; copy review is required.
 
+### 7.10 All pods view composition
+
+The All pods view aggregates signal across every pod the poderator is assigned to. In addition to cross-pod nudges (§7.2) and cross-pod insights (§7.9.3), three All-Pods-specific surfaces render here.
+
+Single-pod poderators do not see §7.10.1 or §7.10.2 (their default landing is the per-pod view). §7.10.3 renders on both the All pods view and on each per-pod dashboard.
+
+#### 7.10.1 Pod summary cards
+
+One card per assigned pod, rendered in a horizontal grid beneath the cross-pod nudges.
+
+- Each card displays: pod name, pod status (`forming`, `active`, `inactive`), cycle phase name + week number, headline pulse-health figure (count of members missing this week's pulse), and a three-week trend arrow (↑ / ↓ / →).
+- The headline figure uses the same band thresholds as §7.1 (healthy / warning / critical).
+- Each card is a click-through to that pod's per-pod view.
+- Default sort: pods with non-zero at-risk nudge counts first, then alphabetical by pod name.
+
+#### 7.10.2 Members-needing-attention rollup
+
+A four-metric KPI block summarizing engagement across all assigned pods. Rendered between the pod summary cards (§7.10.1) and the cross-pod insights (§7.9.3).
+
+- **Pulsing this week.** Count of members who have submitted this week's pulse over total active members across all assigned pods.
+- **At risk.** Count of members at the configured consecutive-miss threshold (§7.2 nudge condition), with count of pods affected.
+- **Pulses this period.** Count of pulses submitted over total possible pulses across the displayed range. Range follows the §7.9.3 last-4-weeks / full-cycle toggle.
+- **Engagement trend.** Aggregate weekly completion rate as a percentage, with a three-week trend arrow and the prior-week comparison value.
+
+#### 7.10.3 LLM summary prompt export
+
+The dashboard provides a "Copy summary prompt" affordance that produces a templated prompt the poderator can paste into a third-party LLM (ChatGPT, Claude, Gemini, etc.) to get a narrative summary of what's going on with their pods. OLOS does not call any LLM as part of this affordance — the poderator's own tool does the work.
+
+- The affordance renders on both the All pods view (covering all assigned pods) and each per-pod dashboard (covering one pod). Placement is alongside the §7.9 cross-pod / pod-level insights section.
+- Clicking opens a preview modal showing the exact prompt that will be copied, with the poderator's current data interpolated.
+- The prompt template, including its phrasing and the instruction to the LLM (e.g. "Summarize what's going on with these pods this week and flag anything I should pay attention to"), is stored as a versioned string the program team can edit without code changes.
+- Interpolated data: pod names, current phase per pod, count of members per pod, weekly pulse-completion rate per pod, top stuck-on themes and top help-request themes from §7.9, at-risk member count per pod.
+- **Privacy.** The prompt excludes by default: member full names (use initials), free-text pulse responses, contact information, and any field listed in §7.3 as "never exposed to the poderator." The preview is the source of truth — the poderator sees exactly what will be copied, so they can review before pasting into a third-party LLM.
+- A short disclaimer renders beside the affordance: "Copies a summary of your pod data. You'll paste it into your own AI tool — OLOS doesn't send anything." The exact copy is program-team-owned.
+- Telemetry: log copy events (poderator id, scope = `all_pods` or `pod_id`, timestamp) to gauge feature usage without recording prompt contents.
+
 ## 8. Permissions and access control
 
 - Routes:
-  - `/moderator` — All Pods view.
+  - `/moderator` — All pods view.
   - `/moderator/pods/[id]` — per-pod view.
 - Authorization is enforced at the route level and re-checked at each underlying API endpoint.
 - Visible to:
-  - Users with one or more poderator assignments (`moderator_assignments` row, `removed_at IS NULL`). The All Pods view aggregates across all the poderator's assignments; the per-pod view requires assignment to the specific pod.
+  - Users with one or more poderator assignments (`moderator_assignments` row, `removed_at IS NULL`). The All pods view aggregates across all the poderator's assignments; the per-pod view requires assignment to the specific pod.
   - Admins and owners (global access to all pods on both views).
   - Observers (read-only access; nudge dismissals disabled).
 - A poderator with both poderator and participant roles can navigate between the poderator dashboard and the participant view without re-authentication. Role-stacking is preserved.
-- Loss of poderator assignment (`removed_at` is set) revokes access immediately on the next request, including in the All Pods view aggregation.
+- Loss of poderator assignment (`removed_at` is set) revokes access immediately on the next request, including in the All pods view aggregation.
 
 ## 9. Data model implications
 
 This PRD primarily consumes existing data. The following additions are anticipated:
 
-- **`nudge_dismissals`** — new table. Schema: `(moderator_participant_id, pod_id, nudge_key, dismissed_at)`. Records dismissed nudge instances so they remain dismissed across sessions. Created in Phase 1.
-- **`moderator_ui_state`** — new table. Tracks per-poderator switcher last-selected view (`all_pods` or a specific `pod_id`), roster filter/sort state, and tooltip suppression keys. Applies to admins and poderators alike. Created in Phase 1.
-- **`pulse_themes`** — new table. Schema: `(theme_id, scope_type, scope_id, scope_window_start, scope_window_end, source_field, theme_label, member_count, mention_count, contributing_pulse_ids[], generated_at)`. Stores LLM-derived themes for §7.9 aggregations. `scope_type` is one of `individual`, `pod`, or `cross_pod`. Theme labels are subject to the tone rules in §7.9. **Table created in Phase 1 migrations; populated by the Phase 2 LLM pipeline.**
-- **`pulse_check_aggregates`** — deferred. May be introduced in Phase 2 if live query performance on `pulse_themes` proves insufficient.
-- **`cycle_config` extensions** — new fields for: pod-health band thresholds (healthy/warning/critical headcount cutoffs), the consecutive-miss threshold for the at-risk nudge, and the default time window for pulse aggregations (e.g. last four weeks vs full cycle). Global defaults applied when a cycle hasn't set its own values. Created in Phase 1.
+- **`nudge_dismissals`** — new table. Schema: `(moderator_participant_id, pod_id, nudge_key, dismissed_at)`. Records dismissed nudge instances so they remain dismissed across sessions.
+- **`moderator_ui_state`** — new table. Tracks per-poderator switcher last-selected view (`all_pods` or a specific `pod_id`), roster filter/sort state, and tooltip suppression keys. Applies to admins and poderators alike.
+- **`pulse_themes`** — new table. Schema: `(theme_id, scope_type, scope_id, scope_window_start, scope_window_end, source_field, theme_label, member_count, mention_count, contributing_pulse_ids[], generated_at)`. Stores LLM-derived themes for §7.9 aggregations. `scope_type` is one of `individual`, `pod`, or `cross_pod`. Theme labels are subject to the tone rules in §7.9. Populated by the LLM theme-extraction pipeline that runs after each pulse submission window closes.
+- **`pulse_check_aggregates`** — deferred. May be introduced later if live query performance on `pulse_themes` proves insufficient.
+- **`cycle_config` extensions** — new fields for: pod-health band thresholds (healthy/warning/critical headcount cutoffs), the consecutive-miss threshold for the at-risk nudge, and the default time window for pulse aggregations (e.g. last four weeks vs full cycle). Global defaults applied when a cycle hasn't set its own values.
 
 All other data — pod metadata, poderator assignments, pod memberships, pulse checks, pod-resource URLs, cycle and phase windows — is sourced from existing tables. No modification to existing core schemas is proposed.
 
@@ -252,14 +319,13 @@ This section records the decisions made during PRD review. Each decision superse
 | Pod-health indicator bands | Absolute-headcount thresholds (not percentages). Single-week headline figure with a three-week trend arrow alongside. Configurable per cycle in cycle-config; global defaults apply when not overridden. |
 | Nudges in v1 | One type only: **at-risk member** (configured consecutive-miss threshold, default 2). System flags, poderator follows up; no automated outreach. Configurable per cycle. |
 | Nudge delivery | Dashboard-only for v1. Backend logic decoupled from delivery channel so a weekly digest email or per-event push can be added later without rewriting. |
-| Multi-pod poderator assignment | First-class case. Switcher offers "All Pods" overview view + per-pod views. Cross-pod aggregation applies only to nudges; rosters, phase guidance, and resources stay per-pod. |
-| View persistence | The poderator's most recent switcher selection persists across sessions. First-time multi-pod poderators default to All Pods; first-time single-pod poderators default to their pod's view. |
+| Multi-pod poderator assignment | First-class case. Switcher offers "All pods" overview view + per-pod views. Cross-pod aggregation applies only to nudges; rosters, phase guidance, and resources stay per-pod. |
+| View persistence | The poderator's most recent switcher selection persists across sessions. First-time multi-pod poderators default to All pods; first-time single-pod poderators default to their pod's view. |
 | Profile visibility tiering | Four tiers: always in row (AI experience + availability), on expansion/hover (role, industry, employer, interest areas, work style, group strengths, labs goals), click-through to profile (AI tools, cycle-fit signal, city-level location), never visible (phone, free-text notes, contact-consent flags). Registration form copy must disclose poderator visibility. |
 | First-poderator onboarding | No in-product walkthrough. Programmatic orientation via poderator handbook + kickoff session (program-team-owned). In-product tooltips cover UI mechanics, auto-suppressing after first 1–2 encounters per element. |
 | Inactive members | Hidden from roster by default. "Show inactive" toggle reveals them at reduced opacity, sorted to the bottom, each with their inactive-since date. |
-| Pulse-check aggregations | Three scopes: individual (in the pulse response side panel), pod-level (in the per-pod dashboard), and cross-pod (in the All Pods view, single-pod poderators excluded). Structured fields aggregate by counts; free-text fields are reduced to themes by an LLM pass with provenance back to source responses. Default range last 4 weeks, full-cycle toggle available. |
-| Phase 1 / Phase 2 split | §7.9 (pulse-check aggregations) is deferred entirely to Phase 2. No aggregation UI renders in Phase 1 — no empty states, no placeholders. The `pulse_themes` table is created in Phase 1 so Phase 2 can populate it without schema changes. |
-| Route structure | Routes use `/moderator` (All Pods) and `/moderator/pods/[id]` (per-pod), not the `/pods/[id]/moderator` pattern in the original PRD draft. All poderator routes live under `app/(dashboard)/moderator/`. |
+| Pulse-check aggregations | Three scopes: individual (in the pulse response side panel), pod-level (in the per-pod dashboard), and cross-pod (in the All pods view, single-pod poderators excluded). Structured fields aggregate by counts; free-text fields are reduced to themes by an LLM pass with provenance back to source responses. Default range last 4 weeks, full-cycle toggle available. Ships with the dashboard in a single phase. |
+| Route structure | Routes use `/moderator` (All pods) and `/moderator/pods/[id]` (per-pod), not the `/pods/[id]/moderator` pattern in the original PRD draft. All poderator routes live under `app/(dashboard)/moderator/`. |
 | Admin ui-state | Admins receive `moderator_ui_state` rows like poderators. Filter/sort/tooltip state persists for admins too. |
 
 ## 11. Operational note: auto-flip

--- a/docs/PRD-moderator-dashboard.md
+++ b/docs/PRD-moderator-dashboard.md
@@ -1,0 +1,275 @@
+# PRD — Poderator Dashboard
+
+| | |
+|---|---|
+| Status | Draft |
+| Author | Madhu (drafted with Claude) |
+| Last updated | 2026-05-20 |
+| Related persona | [`personas.md` — Poderator](personas.md#poderator) |
+| Related spec | [`TUL_MVP_Spec.md`](../TUL_MVP_Spec.md) §Roles, §Pulse Checks, §Pod Registration |
+| Related architecture | [`OLOS-architecture-brief.md`](OLOS-architecture-brief.md) §Roles, §Phase machine |
+| Related roadmap items | §1.13, §1.14, §2.7, §3.5, §3.6 |
+| Related code | [`lib/auth/CLAUDE.md`](../lib/auth/CLAUDE.md) (role resolution); `app/(dashboard)/pods/[id]/` (planned) |
+| Related issues | TBD (file at implementation kickoff) |
+
+## 1. Background
+
+OLOS assigns a poderator to each pod for the duration of a single cycle. The poderator's responsibility is to keep the pod's momentum up, surface and re-engage members at risk of disengagement, and orient the pod to what each phase of the cycle requires of them. They are not staff, and they are not the subject-matter expert on the pod's problem area.
+
+Poderator-facing functionality is currently scattered across the roadmap: §1.13 and §1.14 cover a pod-members list with pulse-completion status, §2.7 covers pulse response review, §3.5 covers pulse aggregations, and §3.6 covers project membership visibility. There is no unified surface that brings these capabilities together, and no single page a poderator can land on to assess their pod's state.
+
+## 2. Problem statement
+
+A poderator today has no purpose-built place in OLOS to do their job. The information they need to identify at-risk members, understand what their pod should be doing this week, and act on disengagement signals is either not yet built, lives in disconnected views, or sits in external systems (Slack, sheets). Without a unified surface, the poderator role is harder to take on, harder to scale across cycles, and less effective at the program's core goal of preventing silent attrition.
+
+## 3. Goals
+
+- Provide a single signed-in page where a poderator can assess the health of their pod(s) and identify members needing attention within 30 seconds of landing on it.
+- Surface disengagement signals (missed pulses, dropped activity) in time for the poderator to intervene before a member leaves.
+- Consolidate the poderator-facing capabilities already on the roadmap into one coherent surface.
+- Make pod-scoped program state legible without requiring the poderator to contact staff or open external tools.
+- Reduce orientation cost for first-time poderators who do not have prior participant experience.
+- Preserve role-stacking: a poderator who is also a participant in their own project must retain both views.
+- Support multi-pod poderator assignment as a first-class case, since multi-pod assignment is the common pattern.
+
+## 4. Non-goals
+
+- A project-level dashboard for the building phase that follows pod and project formation.
+- Cross-pod analytics or organizer-facing aggregations.
+- Modification of the pulse-check schema, response shape, or submission behavior.
+- New external-resource provisioning (Slack channels, Drive folders, GitHub repos, Google Groups remain provisioned at pod activation, per the existing architectural invariant).
+- Replacement of poderator ↔ member communication channels (conversations continue in Slack; the dashboard surfaces signal only).
+- Modification of pod membership (add/remove member actions remain staff-only and are handled elsewhere).
+- Automated outreach to members (no auto-DMs, auto-emails, or auto-reminders sent from OLOS on the poderator's behalf).
+
+## 5. Glossary
+
+- **Poderator** — community member assigned to one or more pods for one cycle. Stored as one or more rows in `poderator_assignments` with `removed_at IS NULL`. See [`personas.md`](personas.md#poderator).
+- **Pod** — group within a cycle, seeded by a top-voted problem statement.
+- **Pulse check** — weekly check-in completed by active participants. The configured number of consecutive missed pulses (default: 2) is the canonical disengagement signal.
+- **Phase** — one of the seven cycle stages (problem submission, pod voting, pod registration, solution submission, project voting, project shortlist, project registration).
+- **All Pods view** — the cross-pod overview presented to multi-pod poderators, aggregating at-risk-member nudges from all assigned pods into a single list.
+- **Per-pod view** — the full dashboard scoped to one pod, comprising the pod status header, member roster, pulse response review, phase guidance, and pod resources.
+
+## 6. Information architecture
+
+The dashboard exposes two views, navigated via a switcher control at the top of the page:
+
+- **All Pods view** — cross-pod aggregated nudges only. Default landing for multi-pod poderators on first sign-in.
+- **Per-pod view** — full per-pod content (status header, nudges scoped to that pod, member roster, phase guidance, pod resources). Default landing for single-pod poderators.
+
+Within a per-pod view, sections render top to bottom as follows:
+
+1. Pod status header (§7.1)
+2. At-risk-member nudges, scoped to the pod (§7.2)
+3. Member roster (§7.3)
+4. Pulse response review — drill-in from the roster (§7.4)
+5. Pod-level pulse insights (§7.9)
+6. Phase guidance (§7.5)
+7. Pod resources (§7.6)
+
+The All Pods view shows cross-pod at-risk nudges (§7.2) and cross-pod pulse insights (§7.9). The switcher and the poderator's last-selected view are described in §7.7.
+
+## 7. Functional requirements
+
+### 7.1 Pod status header
+
+The header summarizes the pod and the cycle at a single glance.
+
+- Display the pod name and the cycle name.
+- Display pod status (`forming`, `active`, or `inactive`).
+- Display the current cycle phase by name and number (e.g. "Phase 4: Solution Proposals").
+- Display the open and close timestamps for the current phase, plus a relative countdown to the close timestamp.
+- Display one pod-health indicator: the count of pod members who have **not** completed the current week's pulse check, banded into three states (healthy, warning, critical). Bands are absolute-headcount, not percentage-based, because poderators think in terms of "Sarah didn't pulse" rather than "we're at 78%."
+- Display a small **trend arrow** (↑ / ↓ / →) alongside the headline indicator, reflecting the direction of pulse-completion over the last three weeks.
+- Band thresholds (e.g. "healthy = 0 missing, warning = 1–2 missing, critical = 3+ missing") are configurable per cycle in cycle-config, with global defaults applied when a cycle hasn't overridden them.
+- For pods in `forming` or `inactive` status, suppress the pulse indicator and replace it with a status explainer.
+
+### 7.2 At-risk-member nudges
+
+Nudges are server-computed and surfaced on the dashboard. Only one nudge type ships in v1.
+
+- **At-risk member nudge.** Fires when a pod member has missed the configured number of consecutive pulses (default: 2). One nudge per affected member.
+- Nudge persists until either the member submits a pulse or the poderator dismisses it.
+- Dismissal is per poderator, per nudge instance. A dismissed nudge does not suppress future at-risk nudges for the same member if the condition re-triggers.
+- Render no more than three nudges at any time per view. Excess collapses into a "see N more" affordance.
+- The system flags only. The poderator follows up via Slack DM or other means; the dashboard does not initiate outreach.
+- In the per-pod view, nudges are scoped to the pod. In the All Pods view, nudges aggregate across all of the poderator's pod assignments and each nudge identifies the source pod.
+- Delivery is dashboard-only in v1. No email or Slack push. Backend nudge computation is decoupled from delivery so future channels (e.g. weekly digest email) can be added without changing the underlying logic.
+- The miss-threshold for the nudge is configurable per cycle in cycle-config.
+
+### 7.3 Member roster
+
+The roster lists every member of the pod with engagement signal.
+
+- One row per member.
+- Each row displays: member name, **always-visible profile preview** (AI experience level + availability snippet), pulse-engagement status, and last-activity timestamp formatted as a relative time.
+- On row expansion or hover, additional profile fields are revealed: professional role, industry, employer, interest areas, work style, group strengths, labs goals.
+- A click-through to the member's full profile additionally exposes: AI tools used, cycle-fit signal, city-level location.
+- Never exposed to the poderator: phone number, free-text personal notes, contact-consent flags. The registration form must disclose to upskillers which fields their poderator can see (program-team-owned copy update, ships alongside this dashboard).
+- Pulse-engagement status values:
+  - **Current** — completed this week's pulse.
+  - **Pending** — pulse window is open, no submission yet.
+  - **Late** — pulse window closed without a submission.
+  - **At risk** — has hit the configured consecutive-miss threshold.
+- Default sort order: at-risk, late, pending, current.
+- Filter by status; search by name. Filter and sort state persists per poderator across sessions.
+- Each row exposes two quick actions: open the member's pulse response history (links into §7.4) and open a Slack DM to the member (deep-link to Slack).
+- Members with `cycle_enrollments.status = 'inactive'` are excluded from the default view. A "Show inactive" toggle reveals them, rendered at reduced opacity, sorted to the bottom, each showing their inactive-since date.
+
+### 7.4 Pulse response review
+
+The pulse response review is a drill-in surface accessed from the member roster.
+
+- Opens as a side panel (or modal on narrow viewports) without navigating away from the dashboard.
+- Displays an **individual-level aggregate block** at the top of the panel, summarizing this member's pulse history across the cycle (see §7.9.1).
+- Displays the selected member's per-week pulse responses below the aggregate, most recent first.
+- Each response shows: submission timestamp, free-text answers, and selected options for multi-select fields.
+- Default range for per-week responses: last four weeks of responses for the active cycle. Configurable up to the full cycle. The aggregate block always reflects the full cycle.
+- Read-only. The poderator cannot edit pulse responses; only the participant can submit or modify their own.
+- Access is scoped to the poderator's assigned pods. Attempts to load responses for members outside the poderator's pod assignments return 403.
+- Navigation between members within the panel does not close the panel; the aggregate block re-renders for the new member.
+
+### 7.5 Phase guidance
+
+The phase guidance section orients the poderator to what the cycle phase requires of their pod.
+
+- Display a plain-English description of the current phase, including what members are expected to do, what the poderator should look out for, and what healthy pod activity looks like at this stage.
+- Display the close timestamp for the current phase and the open timestamp for the next phase.
+- Display a phase-specific signal block, with content determined by the current phase:
+  - Pod voting: count of pod members who have voted vs. registered.
+  - Solution proposal submission: count of proposals submitted, with submitter identity.
+  - Project voting: count of active members who have cast ballots.
+  - Project registration: list of projects below the minimum registrant threshold.
+- The plain-English description and the deadlines are always present. The phase-specific signal block updates as the cycle progresses through phases.
+
+### 7.6 Pod resources
+
+The resources panel surfaces external resources provisioned for the pod.
+
+- Display deep links to the pod's Slack channel, Drive folder, GitHub repo, and Google Group.
+- Each link sources from the URL persisted to the database at pod activation.
+- If a resource failed to provision and is missing from the database, render a "missing — contact staff" affordance instead of a broken link.
+- The panel is read-only. Resource provisioning is handled at pod activation; this dashboard does not provision or re-provision resources.
+
+### 7.7 Switcher and last-view persistence
+
+The switcher is the primary navigation control between the All Pods view and per-pod views.
+
+- The switcher appears at the top of every dashboard page.
+- The switcher options are: "All Pods" (overview) and each pod the poderator is assigned to, listed by name.
+- Single-pod poderators see a switcher with one option; the All Pods entry is suppressed.
+- A poderator's most recent selection persists across sessions. They land wherever they last were.
+- First-time multi-pod poderators land on **All Pods** by default.
+- First-time single-pod poderators land on their single pod's view.
+- The active selection is reflected in the URL path so that links between poderators (e.g. shared in Slack) deep-link correctly.
+
+### 7.8 In-product tooltips
+
+Lightweight tooltips assist with UI-mechanic orientation, particularly for first-time poderators. They do not replace the poderator handbook or kickoff session, which own programmatic orientation ("what does a healthy pod look like at week 4").
+
+- Tooltips attach to specific UI elements: the pod-health indicator, the trend arrow, engagement-status badges, the at-risk nudge type, the phase guidance section header.
+- Tooltips trigger on hover for desktop, on tap for touch devices.
+- Each tooltip displays automatically the first 1–2 times a poderator encounters its element, then suppresses for that poderator. Suppression is per poderator, per tooltip key.
+- The "help" affordance for each tooltipped element remains visible (e.g. small `?` icon) so a poderator can re-trigger the tooltip on demand even after auto-suppression.
+
+### 7.9 Pulse-check aggregations
+
+> **Phase 2 — not shipped in the initial dashboard release.** The aggregation UI sections do not render at all in Phase 1 (no empty states, no placeholders). The `pulse_themes` table is created in Phase 1 migrations so Phase 2 can populate it without schema changes. See §10 decisions log.
+
+Aggregated views of pulse-check data surface patterns the per-week response stream can't show on its own. Aggregations are computed server-side and render at three scopes: individual, pod, and across-pods.
+
+The structured fields on each pulse check (AI tools used, multi-select option lists) aggregate by deterministic counts. The free-text fields ("what went well," "what I'm stuck on," "help I need") are reduced to themes by an LLM pass and stored with citations back to the source pulse responses, so a poderator can always trace a theme back to who said what.
+
+#### 7.9.1 Individual aggregation
+
+Rendered as a block at the top of the pulse response review side panel (§7.4), above the per-week responses. Scoped to a single member across the full active cycle.
+
+- **Top AI tools used.** Up to five tools, ordered by frequency of selection across that member's pulse responses. Each shows a count of the number of pulses in which the member named it.
+- **Recurring "stuck on" themes.** Up to three themes derived from the member's free-text responses, ordered by frequency. Each theme is one short phrase plus a count of pulses where it surfaced.
+- **Recurring help requests.** Up to three themes from the "help I need" field, same shape as above.
+- **Engagement trajectory.** A small sparkline or week-by-week dot row showing pulse completion across the cycle (submitted / missed) so the poderator can see at a glance whether engagement has been rising, falling, or stable.
+- Each theme links back to the source pulse responses, scrolling the panel to the relevant week(s) on click.
+
+#### 7.9.2 Pod-level aggregation
+
+Rendered as a section on the per-pod dashboard, between the member roster (§7.3) and the phase guidance (§7.5). Scoped to one pod, default to the last four weeks with a toggle for the full cycle.
+
+- **Top AI tools across the pod.** Up to five tools, ordered by the count of pod members who named them in their pulse responses (not by raw mention count, so one heavy user doesn't dominate). Each shows the count of pod members.
+- **Top "stuck on" themes.** Up to three LLM-derived themes from the pod's free-text responses, each with a count of distinct members who surfaced it. Themes that appear in only one member's responses are suppressed.
+- **Top help requests.** Same shape as stuck-on themes.
+- **Pulse completion trend.** A small bar or line showing the pod's pulse-completion rate over the displayed range, week by week.
+- Each theme item links to the underlying pulse responses, opening the pulse review panel (§7.4) for the relevant member(s) and scrolling to the matching week.
+- A clear empty state when the pod has insufficient data (fewer than two members with pulse responses in the range): "Not enough pulse data yet to show themes."
+
+#### 7.9.3 Cross-pod aggregation
+
+Rendered as a section on the All Pods view, beneath the pod-summary cards. Scoped to all of the poderator's assigned pods, default to the last four weeks with a toggle for the full cycle.
+
+- **Patterns across your pods.** LLM-derived themes that appear in two or more of the poderator's pods, surfaced as a list with per-pod breakdown (e.g. "Confusion about solution proposal scope — Health Systems Access · Energy Grid Resilience"). Helps a poderator notice when a problem is structural to the program rather than specific to one pod.
+- **AI tool adoption by pod.** A small grid comparing the top tools in each pod side by side. Useful for cross-pollination: if Pod A is getting traction with Cursor and Pod B isn't using it yet, the poderator can route that knowledge.
+- **Engagement comparison.** Each pod's pulse-completion rate over the displayed range, shown as side-by-side mini-trends so the poderator can spot a pod whose engagement is sliding relative to the others.
+- Section is suppressed entirely for single-pod poderators.
+
+#### Cross-cutting requirements
+
+- **Computation.** Theme extraction runs after each pulse submission window closes and is cached. Structured-field aggregates are computed live (cheap) unless `pulse_check_aggregates` is in use.
+- **LLM provenance.** Each LLM-derived theme records which pulse-response rows contributed to it. Poderators see this as "from N responses across M members" with a link to the underlying responses.
+- **Privacy.** Themes are visible to poderators of pods the responses came from. Cross-pod themes are visible only to poderators with assignments in all contributing pods (no leakage between unrelated pods).
+- **Tone.** Theme labels are descriptive, not judgmental. The system surfaces "Confusion about proposal scope," not "Members seem lost." This is a design rule for prompts that generate themes; copy review is required.
+
+## 8. Permissions and access control
+
+- Routes:
+  - `/moderator` — All Pods view.
+  - `/moderator/pods/[id]` — per-pod view.
+- Authorization is enforced at the route level and re-checked at each underlying API endpoint.
+- Visible to:
+  - Users with one or more poderator assignments (`moderator_assignments` row, `removed_at IS NULL`). The All Pods view aggregates across all the poderator's assignments; the per-pod view requires assignment to the specific pod.
+  - Admins and owners (global access to all pods on both views).
+  - Observers (read-only access; nudge dismissals disabled).
+- A poderator with both poderator and participant roles can navigate between the poderator dashboard and the participant view without re-authentication. Role-stacking is preserved.
+- Loss of poderator assignment (`removed_at` is set) revokes access immediately on the next request, including in the All Pods view aggregation.
+
+## 9. Data model implications
+
+This PRD primarily consumes existing data. The following additions are anticipated:
+
+- **`nudge_dismissals`** — new table. Schema: `(moderator_participant_id, pod_id, nudge_key, dismissed_at)`. Records dismissed nudge instances so they remain dismissed across sessions. Created in Phase 1.
+- **`moderator_ui_state`** — new table. Tracks per-poderator switcher last-selected view (`all_pods` or a specific `pod_id`), roster filter/sort state, and tooltip suppression keys. Applies to admins and poderators alike. Created in Phase 1.
+- **`pulse_themes`** — new table. Schema: `(theme_id, scope_type, scope_id, scope_window_start, scope_window_end, source_field, theme_label, member_count, mention_count, contributing_pulse_ids[], generated_at)`. Stores LLM-derived themes for §7.9 aggregations. `scope_type` is one of `individual`, `pod`, or `cross_pod`. Theme labels are subject to the tone rules in §7.9. **Table created in Phase 1 migrations; populated by the Phase 2 LLM pipeline.**
+- **`pulse_check_aggregates`** — deferred. May be introduced in Phase 2 if live query performance on `pulse_themes` proves insufficient.
+- **`cycle_config` extensions** — new fields for: pod-health band thresholds (healthy/warning/critical headcount cutoffs), the consecutive-miss threshold for the at-risk nudge, and the default time window for pulse aggregations (e.g. last four weeks vs full cycle). Global defaults applied when a cycle hasn't set its own values. Created in Phase 1.
+
+All other data — pod metadata, poderator assignments, pod memberships, pulse checks, pod-resource URLs, cycle and phase windows — is sourced from existing tables. No modification to existing core schemas is proposed.
+
+## 10. Decisions log
+
+This section records the decisions made during PRD review. Each decision supersedes the corresponding open question from the prior draft.
+
+| Topic | Decision |
+|---|---|
+| Pod-health indicator bands | Absolute-headcount thresholds (not percentages). Single-week headline figure with a three-week trend arrow alongside. Configurable per cycle in cycle-config; global defaults apply when not overridden. |
+| Nudges in v1 | One type only: **at-risk member** (configured consecutive-miss threshold, default 2). System flags, poderator follows up; no automated outreach. Configurable per cycle. |
+| Nudge delivery | Dashboard-only for v1. Backend logic decoupled from delivery channel so a weekly digest email or per-event push can be added later without rewriting. |
+| Multi-pod poderator assignment | First-class case. Switcher offers "All Pods" overview view + per-pod views. Cross-pod aggregation applies only to nudges; rosters, phase guidance, and resources stay per-pod. |
+| View persistence | The poderator's most recent switcher selection persists across sessions. First-time multi-pod poderators default to All Pods; first-time single-pod poderators default to their pod's view. |
+| Profile visibility tiering | Four tiers: always in row (AI experience + availability), on expansion/hover (role, industry, employer, interest areas, work style, group strengths, labs goals), click-through to profile (AI tools, cycle-fit signal, city-level location), never visible (phone, free-text notes, contact-consent flags). Registration form copy must disclose poderator visibility. |
+| First-poderator onboarding | No in-product walkthrough. Programmatic orientation via poderator handbook + kickoff session (program-team-owned). In-product tooltips cover UI mechanics, auto-suppressing after first 1–2 encounters per element. |
+| Inactive members | Hidden from roster by default. "Show inactive" toggle reveals them at reduced opacity, sorted to the bottom, each with their inactive-since date. |
+| Pulse-check aggregations | Three scopes: individual (in the pulse response side panel), pod-level (in the per-pod dashboard), and cross-pod (in the All Pods view, single-pod poderators excluded). Structured fields aggregate by counts; free-text fields are reduced to themes by an LLM pass with provenance back to source responses. Default range last 4 weeks, full-cycle toggle available. |
+| Phase 1 / Phase 2 split | §7.9 (pulse-check aggregations) is deferred entirely to Phase 2. No aggregation UI renders in Phase 1 — no empty states, no placeholders. The `pulse_themes` table is created in Phase 1 so Phase 2 can populate it without schema changes. |
+| Route structure | Routes use `/moderator` (All Pods) and `/moderator/pods/[id]` (per-pod), not the `/pods/[id]/moderator` pattern in the original PRD draft. All poderator routes live under `app/(dashboard)/moderator/`. |
+| Admin ui-state | Admins receive `moderator_ui_state` rows like poderators. Filter/sort/tooltip state persists for admins too. |
+
+## 11. Operational note: auto-flip
+
+The cycle-inactivity auto-flip (member → `inactive` after two consecutive missed pulses) is **disabled for the current cycle**. This is set elsewhere in cycle-config and is not changed by this dashboard. Confirm before relying on the auto-flip in any downstream logic or messaging. A separate breadcrumb in the cycle-config notes or the architecture brief is recommended to keep this decision discoverable.
+
+## 12. References
+
+- [`personas.md` — Poderator](personas.md#poderator)
+- [`OLOS-architecture-brief.md`](OLOS-architecture-brief.md), §Roles and §Phase machine
+- [`OLOS-roadmap.md`](OLOS-roadmap.md), §1.13, §1.14, §2.7, §3.5, §3.6
+- [`TUL_MVP_Spec.md`](../TUL_MVP_Spec.md), §Roles, §Pulse Checks, §Pod Registration
+- [`lib/auth/CLAUDE.md`](../lib/auth/CLAUDE.md), session model and role resolution

--- a/docs/poderator-dashboard/CLAUDE.md
+++ b/docs/poderator-dashboard/CLAUDE.md
@@ -70,8 +70,8 @@ correctly (PRD §7.7).
 | `GET /api/moderator/pods` | All pods for the authed poderator (wraps `moderator_assignments`). Admins get all pods. |
 | `GET /api/moderator/pods/[pod_id]` | Single pod detail + phase signal + member roster with pulse status |
 | `GET /api/moderator/pods/[pod_id]/pulse-responses/[participant_id]` | Per-member pulse history for the side panel (§7.4). Returns 403 if caller is not assigned to the pod. |
-| `GET /api/moderator/pods/[pod_id]/insights` | Pod-level aggregations (§7.9.2): top tools, stuck-on themes, help themes, completion trend |
-| `GET /api/moderator/insights` | Cross-pod aggregations (§7.9.3): patterns across all assigned pods |
+| `GET /api/moderator/pods/[pod_id]/insights` | Pod-level structured aggregates (§7.9.2): top AI tools, weekly completion trend. Plus the bundle for the AI-assisted summary block (§7.10.3): recent pulse comments (initials only) + the canonical `cycle_config.ai_summary_prompt` string. |
+| `GET /api/moderator/insights` | Cross-pod structured aggregates (§7.9.3): AI tool adoption by pod, engagement comparison. Plus the AI-assisted summary bundle scoped across all assigned pods. |
 | `POST /api/moderator/nudges/dismiss` | Dismiss a nudge instance. Body: `{ pod_id, nudge_key }`. Writes to `nudge_dismissals`. |
 | `GET /api/moderator/ui-state` | Last-selected switcher view + roster filter/sort state |
 | `PUT /api/moderator/ui-state` | Persist switcher selection, roster filter, tooltip suppression keys |
@@ -112,8 +112,10 @@ loss of assignment takes effect immediately (PRD §8).
 
 ## New DB tables
 
-Next migration number: **00019** (latest is `00018_solution_proposals_rich_fields.sql`).
-Split into logical migration files; don't bundle everything in one.
+Next migration number: **00023** (latest at time of writing is
+`00022_pod_memberships_select_hide_soft_deleted.sql`; 00019–00022 were
+consumed by the RLS soft-delete fixes in PR #110/#111). Split into
+logical migration files; don't bundle everything in one.
 
 ### `nudge_dismissals`
 
@@ -147,27 +149,21 @@ create table moderator_ui_state (
 
 Upsert on every PUT. One row per poderator.
 
-### `pulse_themes`
+### `participants` extension
+
+Add the member-preview structured fields (PRD §7.3.1):
 
 ```sql
-create table pulse_themes (
-  id                    bigint generated always as identity primary key,
-  scope_type            text not null check (scope_type in ('individual','pod','cross_pod')),
-  scope_id              bigint not null,  -- participant_id, pod_id, or moderator participant_id
-  scope_window_start    date not null,
-  scope_window_end      date not null,
-  source_field          text not null check (source_field in ('stuck_on','help_needed','what_went_well')),
-  theme_label           text not null,
-  member_count          int  not null default 0,
-  mention_count         int  not null default 0,
-  contributing_pulse_ids bigint[] not null default '{}',
-  generated_at          timestamptz not null default now()
-);
-create index on pulse_themes (scope_type, scope_id, scope_window_start, scope_window_end);
+-- AI experience level enum
+create type ai_experience_level as enum ('new', 'consumer', 'builder', 'shipper');
+
+alter table participants
+  add column if not exists ai_experience_level ai_experience_level not null default 'new',
+  add column if not exists availability_snippet text;
 ```
 
-Themes are written by a server action / cron that runs after each pulse
-window closes. They are read-only from the dashboard.
+Legacy rows default to `new`. UI labels for the enum are program-team-owned
+copy (see PRD §7.3.1 table); the enum is the canonical sort/filter key.
 
 ### `cycle_config` extensions
 
@@ -182,11 +178,20 @@ alter table cycle_config
   -- At-risk nudge threshold
   add column if not exists at_risk_consecutive_misses int default 2,
   -- Default aggregation window (weeks)
-  add column if not exists pulse_agg_default_weeks int default 4;
+  add column if not exists pulse_agg_default_weeks int default 4,
+  -- Canonical AI summary prompt (§7.10.3); same prompt for both All pods and per-pod scopes
+  add column if not exists ai_summary_prompt text;
 ```
 
 Global defaults (1/3/2/4) apply when the cycle hasn't set its own values
-(PRD §7.1, §7.2).
+(PRD §7.1, §7.2). The `ai_summary_prompt` is program-team-owned and
+defaults to a single string applied globally; cycles can override.
+
+### NOT building
+
+No `pulse_themes` table. No LLM theme-extraction pipeline. No
+`pulse_check_aggregates` materialized view. All free-text analysis is
+pushed to the poderator's own AI tool via §7.10.3.
 
 ---
 
@@ -216,7 +221,8 @@ decision entry in `docs/PRD-moderator-dashboard.md §10`:
 | Multi-pod poderators | First-class. All pods view is the default landing. |
 | Inactive members | Hidden by default; "Show inactive" toggle. |
 | Profile visibility | Four tiers (always/hover/click-through/never). See PRD §7.3. |
-| Pulse aggregation | Three scopes: individual (side panel), pod-level (per-pod page), cross-pod (All pods). LLM themes for free-text fields. |
+| Pulse aggregation | Three scopes: individual (side panel), pod-level (per-pod page), cross-pod (All pods). Structured fields only (AI tool counts, completion rates). No LLM in OLOS — free-text analysis is via the §7.10.3 Copy-prompt block. |
+| AI summary approach | OLOS does not run any LLM. The "AI-assisted summary block" (§7.10.3) bundles recent pulse comments with a canonical prompt and copies the bundle to clipboard; the poderator pastes into ChatGPT/Claude/etc. themselves. One prompt, owned by program team, stored on `cycle_config`. |
 | Auto-flip | Disabled for the current cycle. Don't activate it from dashboard logic. |
 | No in-product walkthrough | Tooltips only (UI mechanics). Programmatic orientation is handbook + kickoff. |
 
@@ -234,6 +240,11 @@ decision entry in `docs/PRD-moderator-dashboard.md §10`:
   library — filled dot = submitted, outlined dot = missed.
 - The **completion trend bars** (§7.9.2, §7.9.3) are simple `<div>` bars with
   inline `height` percentages, as in the mockup. No chart library needed.
+- The **AI-assisted summary block** (§7.10.3) is a thin client component: the
+  RSC page assembles the bundle (recent pulse comments by initials +
+  `cycle_config.ai_summary_prompt`) and passes it as a prop. The Client
+  Component renders the preview and a Copy button that writes the bundle to
+  the clipboard. No API call on copy, no telemetry required, no modal.
 - Tooltips (§7.8): auto-suppress after 1–2 encounters per key. Store seen keys
   in `moderator_ui_state.tooltip_seen[]`. Always show a `?` icon so the
   poderator can re-trigger.
@@ -244,22 +255,30 @@ decision entry in `docs/PRD-moderator-dashboard.md §10`:
 
 Suggested order — each step is independently shippable:
 
-1. **Migrations** (`00019`+) — `nudge_dismissals`, `moderator_ui_state`,
-   `pulse_themes`, `cycle_config` extensions.
+1. **Migrations** (`00023`–`00026`) — `nudge_dismissals`, `moderator_ui_state`,
+   `participants.ai_experience_level` + `availability_snippet`, `cycle_config`
+   extensions including `ai_summary_prompt`. No `pulse_themes`.
 2. **All pods view** — replace the existing `moderator/page.tsx` stub with the
-   full page: pod cards with health indicator, cross-pod nudge list, switcher.
-3. **Per-pod view** — new `moderator/pods/[pod_id]/page.tsx`: status header,
-   at-risk nudge, member roster with filter/search/sort, phase guidance, pod
-   resources.
+   full page: nudge list, pod summary cards (§7.10.1), members-needing-
+   attention rollup (§7.10.2), switcher.
+3. **Per-pod view** — new `moderator/pods/[pod_id]/page.tsx`: status header
+   (with open + close timestamps), at-risk nudges, member roster with
+   filter/search/sort, phase guidance (incl. submitter identities in the
+   solution-proposal phase), pod resources (incl. missing-resource affordance).
 4. **Pulse review side panel** — per-member pulse history + individual
-   aggregation block (§7.9.1). Opens from roster row.
-5. **Pod-level pulse insights** (§7.9.2) — themes + completion trend on the
-   per-pod page.
-6. **Cross-pod pulse insights** (§7.9.3) — patterns + tool grid + engagement
-   comparison on the All pods view.
-7. **Nudge dismissal** — `POST /api/moderator/nudges/dismiss` + dismiss button
-   on each nudge card.
-8. **UI state persistence** — switcher last-view, roster filter/sort, tooltip
-   suppression.
-9. **Tooltip layer** — attach to pod-health indicator, trend arrow, status
-   badges, nudge type, phase guidance header.
+   aggregation block (§7.9.1: AI tools + engagement trajectory only). Opens
+   from roster row.
+5. **Pod-level pulse insights** (§7.9.2) — top AI tools + weekly completion
+   trend on the per-pod page.
+6. **Cross-pod pulse insights** (§7.9.3) — AI tool adoption by pod +
+   engagement comparison on the All pods view. Suppressed for single-pod
+   poderators.
+7. **AI-assisted summary block** (§7.10.3) — assemble the comment bundle
+   server-side, render preview + Copy button in a shared Client Component.
+   Used on both All pods and per-pod insights sections.
+8. **Nudge dismissal** — `POST /api/moderator/nudges/dismiss` + dismiss button
+   on each nudge card (on both All pods and per-pod nudges).
+9. **UI state persistence** — switcher last-view, roster filter/sort
+   (including by `ai_experience_level`), tooltip suppression.
+10. **Tooltip layer** — attach to pod-health indicator, trend arrow, status
+    badges, nudge type, phase guidance header.

--- a/docs/poderator-dashboard/CLAUDE.md
+++ b/docs/poderator-dashboard/CLAUDE.md
@@ -1,0 +1,265 @@
+# Poderator Dashboard — Claude Code Context
+
+Read this before touching anything under `app/(dashboard)/moderator/`,
+`app/api/moderator/`, or any migration that creates the tables listed in §New
+DB tables below.
+
+---
+
+## Naming convention — UI vs. internal
+
+| Layer | Term | Example |
+|---|---|---|
+| User-facing UI | **Poderator** | Page title, role badge, tooltips, copy |
+| Internal code & DB | **moderator** | `isModerator()`, `moderatorPodIds`, `moderator_assignments`, route paths |
+
+Never expose "moderator" to users in copy. Never use "poderator" in code,
+table names, column names, or API paths. The split is intentional and final.
+
+---
+
+## Relevant docs
+
+- PRD: [`docs/PRD-moderator-dashboard.md`](../PRD-moderator-dashboard.md) —
+  functional requirements, decisions log, data model implications. **This is
+  the source of truth for what to build.**
+- Mockups: [`docs/PRD-moderator-dashboard-mockups.html`](../PRD-moderator-dashboard-mockups.html) —
+  open in a browser. Three screens: All Pods view, Per-pod view, Pulse review
+  panel.
+- Auth: [`lib/auth/CLAUDE.md`](../../lib/auth/CLAUDE.md) — role resolution,
+  `UserRoles` shape, `withAuth` wrappers. Read before touching any guarded
+  route.
+- Architecture: [`docs/OLOS-architecture-brief.md`](../OLOS-architecture-brief.md)
+
+---
+
+## What already exists
+
+| File | What it does | Relationship to Poderator dashboard |
+|---|---|---|
+| `app/(dashboard)/moderator/page.tsx` | Basic pod listing — shows assigned pods grouped by cycle, links to `/pods/[id]` | **The All Pods view stub.** Replace with the full Poderator All Pods view (§6, §7.2, §7.7, §7.9.3 of PRD). Keep the auth guard pattern. |
+| `app/(dashboard)/moderator/cycles/[cycle_id]/vote-progress/page.tsx` | Vote progress for a cycle | Survives as-is. The per-pod phase guidance (§7.5) will surface similar data inline. |
+| `app/(dashboard)/pods/[pod_id]/pulse-check-dashboard.tsx` | Pulse-check data for a pod | Read this before building the member roster (§7.3) and pod-level aggregations (§7.9.2). May be extractable. |
+| `app/api/pods/[pod_id]/members/route.ts` | Pod member list | Reuse for the member roster. Check the response shape before building the roster component. |
+| `app/api/pods/[pod_id]/moderators/route.ts` | Moderator assignment read/write | Already exists. Don't duplicate. |
+
+---
+
+## Route structure
+
+All Poderator routes live inside `app/(dashboard)/` (the existing layout group
+with the shared nav). Do **not** create a separate `(moderator)` route group —
+the `(dashboard)` layout already provides the nav shell and auth redirect.
+
+| URL | File | Description |
+|---|---|---|
+| `/moderator` | `app/(dashboard)/moderator/page.tsx` | All Pods view (replace the stub) |
+| `/moderator/pods/[pod_id]` | `app/(dashboard)/moderator/pods/[pod_id]/page.tsx` | Per-pod dashboard |
+
+The PRD §8 originally specified `/pods/[id]/moderator`. Use
+`/moderator/pods/[id]` instead — it groups all poderator routes under a
+single prefix, which is cleaner for the layout and the guard.
+
+URL reflects the active pod so poderator-to-poderator links deep-link
+correctly (PRD §7.7).
+
+### API routes to create
+
+| Method + path | Purpose |
+|---|---|
+| `GET /api/moderator/pods` | All pods for the authed poderator (wraps `moderator_assignments`). Admins get all pods. |
+| `GET /api/moderator/pods/[pod_id]` | Single pod detail + phase signal + member roster with pulse status |
+| `GET /api/moderator/pods/[pod_id]/pulse-responses/[participant_id]` | Per-member pulse history for the side panel (§7.4). Returns 403 if caller is not assigned to the pod. |
+| `GET /api/moderator/pods/[pod_id]/insights` | Pod-level aggregations (§7.9.2): top tools, stuck-on themes, help themes, completion trend |
+| `GET /api/moderator/insights` | Cross-pod aggregations (§7.9.3): patterns across all assigned pods |
+| `POST /api/moderator/nudges/dismiss` | Dismiss a nudge instance. Body: `{ pod_id, nudge_key }`. Writes to `nudge_dismissals`. |
+| `GET /api/moderator/ui-state` | Last-selected switcher view + roster filter/sort state |
+| `PUT /api/moderator/ui-state` | Persist switcher selection, roster filter, tooltip suppression keys |
+
+All routes use the `withAuth` wrapper from `lib/auth/middleware.ts`. Check
+`isModerator(userRoles)` or `isAdmin(userRoles)` and return 403 otherwise.
+For pod-scoped routes, verify the caller's `userRoles.moderatorPodIds`
+includes the requested `pod_id` (or caller is admin).
+
+---
+
+## Auth integration
+
+Use the existing patterns from `lib/auth/`:
+
+```ts
+import { withAuth } from "@/lib/auth/middleware";
+import { isModerator, isAdmin } from "@/lib/auth/roles";
+
+export const GET = withAuth(async (req, { userRoles }) => {
+  if (!isModerator(userRoles) && !isAdmin(userRoles)) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  // pod-scoped check:
+  const podId = Number(params.pod_id);
+  if (!isAdmin(userRoles) && !userRoles.moderatorPodIds.includes(podId)) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  // ...
+});
+```
+
+`userRoles.moderatorPodIds` is the list of pod IDs from active
+`moderator_assignments` rows. It is resolved fresh on every request —
+loss of assignment takes effect immediately (PRD §8).
+
+---
+
+## New DB tables
+
+Next migration number: **00019** (latest is `00018_solution_proposals_rich_fields.sql`).
+Split into logical migration files; don't bundle everything in one.
+
+### `nudge_dismissals`
+
+```sql
+create table nudge_dismissals (
+  id            bigint generated always as identity primary key,
+  moderator_participant_id bigint not null references participants(id),
+  pod_id        bigint not null references pods(id),
+  nudge_key     text   not null,   -- e.g. "at_risk:{participant_id}"
+  dismissed_at  timestamptz not null default now(),
+  unique (moderator_participant_id, pod_id, nudge_key)
+);
+```
+
+A dismissed nudge re-fires if the condition re-triggers (PRD §7.2). The
+`nudge_key` encodes the instance: when a member re-trips the at-risk
+threshold after recovery, a new `nudge_key` is generated (e.g. suffix with
+epoch or occurrence count).
+
+### `moderator_ui_state`
+
+```sql
+create table moderator_ui_state (
+  participant_id  bigint primary key references participants(id),
+  last_view       text,   -- 'all_pods' | pod_id as text
+  roster_filters  jsonb,  -- { status: string[], search: string }
+  roster_sort     text,   -- column key
+  tooltip_seen    text[]  -- tooltip keys auto-suppressed after 1–2 views
+);
+```
+
+Upsert on every PUT. One row per poderator.
+
+### `pulse_themes`
+
+```sql
+create table pulse_themes (
+  id                    bigint generated always as identity primary key,
+  scope_type            text not null check (scope_type in ('individual','pod','cross_pod')),
+  scope_id              bigint not null,  -- participant_id, pod_id, or moderator participant_id
+  scope_window_start    date not null,
+  scope_window_end      date not null,
+  source_field          text not null check (source_field in ('stuck_on','help_needed','what_went_well')),
+  theme_label           text not null,
+  member_count          int  not null default 0,
+  mention_count         int  not null default 0,
+  contributing_pulse_ids bigint[] not null default '{}',
+  generated_at          timestamptz not null default now()
+);
+create index on pulse_themes (scope_type, scope_id, scope_window_start, scope_window_end);
+```
+
+Themes are written by a server action / cron that runs after each pulse
+window closes. They are read-only from the dashboard.
+
+### `cycle_config` extensions
+
+Add columns to the existing `cycle_config` table (or wherever cycle-level
+config lives — check the schema before writing the migration):
+
+```sql
+-- Pod-health indicator band thresholds
+alter table cycle_config
+  add column if not exists pulse_band_warning_min  int default 1,
+  add column if not exists pulse_band_critical_min int default 3,
+  -- At-risk nudge threshold
+  add column if not exists at_risk_consecutive_misses int default 2,
+  -- Default aggregation window (weeks)
+  add column if not exists pulse_agg_default_weeks int default 4;
+```
+
+Global defaults (1/3/2/4) apply when the cycle hasn't set its own values
+(PRD §7.1, §7.2).
+
+---
+
+## Existing tables consumed (no schema changes)
+
+| Table | Used for |
+|---|---|
+| `moderator_assignments` | Which pods a poderator is assigned to; `removed_at IS NULL` filter |
+| `pods` | Pod name, status, cycle_id, resource URLs (Slack, Drive, GitHub, Google Group) |
+| `cycles` | Cycle name, current phase, phase open/close timestamps |
+| `pod_memberships` | Member roster; `cycle_enrollments.status` for inactive filter |
+| `participants` | Member profile fields (tiered visibility — see PRD §7.3) |
+| `pulse_checks` | Per-member, per-week submissions for the roster status and pulse review |
+| `cycle_enrollments` | Active/inactive status per member per cycle |
+
+---
+
+## PRD decisions to carry forward
+
+These were explicitly decided and should not be re-litigated without a new
+decision entry in `docs/PRD-moderator-dashboard.md §10`:
+
+| Topic | Decision |
+|---|---|
+| Pod-health bands | Absolute headcount, not percentage. Configurable per cycle. |
+| Nudges in v1 | At-risk only (consecutive miss threshold). System flags; no automated outreach. |
+| Multi-pod poderators | First-class. All Pods view is the default landing. |
+| Inactive members | Hidden by default; "Show inactive" toggle. |
+| Profile visibility | Four tiers (always/hover/click-through/never). See PRD §7.3. |
+| Pulse aggregation | Three scopes: individual (side panel), pod-level (per-pod page), cross-pod (All Pods). LLM themes for free-text fields. |
+| Auto-flip | Disabled for the current cycle. Don't activate it from dashboard logic. |
+| No in-product walkthrough | Tooltips only (UI mechanics). Programmatic orientation is handbook + kickoff. |
+
+---
+
+## Component hints
+
+- The **pod switcher** (§7.7) and the **All Pods / per-pod view toggle** are
+  the same control. Render it as a dropdown or tab row at the top of the page.
+  Persist the last selection via `PUT /api/moderator/ui-state`.
+- The **pulse review side panel** (§7.4) opens without navigating. Use a
+  sheet/drawer component (check `app/components/ui` for existing primitives
+  before building new ones).
+- The **engagement trajectory sparkline** (§7.9.1) is a dot row, not a chart
+  library — filled dot = submitted, outlined dot = missed.
+- The **completion trend bars** (§7.9.2, §7.9.3) are simple `<div>` bars with
+  inline `height` percentages, as in the mockup. No chart library needed.
+- Tooltips (§7.8): auto-suppress after 1–2 encounters per key. Store seen keys
+  in `moderator_ui_state.tooltip_seen[]`. Always show a `?` icon so the
+  poderator can re-trigger.
+
+---
+
+## What to build first
+
+Suggested order — each step is independently shippable:
+
+1. **Migrations** (`00019`+) — `nudge_dismissals`, `moderator_ui_state`,
+   `pulse_themes`, `cycle_config` extensions.
+2. **All Pods view** — replace the existing `moderator/page.tsx` stub with the
+   full page: pod cards with health indicator, cross-pod nudge list, switcher.
+3. **Per-pod view** — new `moderator/pods/[pod_id]/page.tsx`: status header,
+   at-risk nudge, member roster with filter/search/sort, phase guidance, pod
+   resources.
+4. **Pulse review side panel** — per-member pulse history + individual
+   aggregation block (§7.9.1). Opens from roster row.
+5. **Pod-level pulse insights** (§7.9.2) — themes + completion trend on the
+   per-pod page.
+6. **Cross-pod pulse insights** (§7.9.3) — patterns + tool grid + engagement
+   comparison on the All Pods view.
+7. **Nudge dismissal** — `POST /api/moderator/nudges/dismiss` + dismiss button
+   on each nudge card.
+8. **UI state persistence** — switcher last-view, roster filter/sort, tooltip
+   suppression.
+9. **Tooltip layer** — attach to pod-health indicator, trend arrow, status
+   badges, nudge type, phase guidance header.

--- a/docs/poderator-dashboard/CLAUDE.md
+++ b/docs/poderator-dashboard/CLAUDE.md
@@ -24,7 +24,7 @@ table names, column names, or API paths. The split is intentional and final.
   functional requirements, decisions log, data model implications. **This is
   the source of truth for what to build.**
 - Mockups: [`docs/PRD-moderator-dashboard-mockups.html`](../PRD-moderator-dashboard-mockups.html) —
-  open in a browser. Three screens: All Pods view, Per-pod view, Pulse review
+  open in a browser. Three screens: All pods view, Per-pod view, Pulse review
   panel.
 - Auth: [`lib/auth/CLAUDE.md`](../../lib/auth/CLAUDE.md) — role resolution,
   `UserRoles` shape, `withAuth` wrappers. Read before touching any guarded
@@ -37,7 +37,7 @@ table names, column names, or API paths. The split is intentional and final.
 
 | File | What it does | Relationship to Poderator dashboard |
 |---|---|---|
-| `app/(dashboard)/moderator/page.tsx` | Basic pod listing — shows assigned pods grouped by cycle, links to `/pods/[id]` | **The All Pods view stub.** Replace with the full Poderator All Pods view (§6, §7.2, §7.7, §7.9.3 of PRD). Keep the auth guard pattern. |
+| `app/(dashboard)/moderator/page.tsx` | Basic pod listing — shows assigned pods grouped by cycle, links to `/pods/[id]` | **The All pods view stub.** Replace with the full Poderator All pods view (§6, §7.2, §7.7, §7.9.3 of PRD). Keep the auth guard pattern. |
 | `app/(dashboard)/moderator/cycles/[cycle_id]/vote-progress/page.tsx` | Vote progress for a cycle | Survives as-is. The per-pod phase guidance (§7.5) will surface similar data inline. |
 | `app/(dashboard)/pods/[pod_id]/pulse-check-dashboard.tsx` | Pulse-check data for a pod | Read this before building the member roster (§7.3) and pod-level aggregations (§7.9.2). May be extractable. |
 | `app/api/pods/[pod_id]/members/route.ts` | Pod member list | Reuse for the member roster. Check the response shape before building the roster component. |
@@ -53,7 +53,7 @@ the `(dashboard)` layout already provides the nav shell and auth redirect.
 
 | URL | File | Description |
 |---|---|---|
-| `/moderator` | `app/(dashboard)/moderator/page.tsx` | All Pods view (replace the stub) |
+| `/moderator` | `app/(dashboard)/moderator/page.tsx` | All pods view (replace the stub) |
 | `/moderator/pods/[pod_id]` | `app/(dashboard)/moderator/pods/[pod_id]/page.tsx` | Per-pod dashboard |
 
 The PRD §8 originally specified `/pods/[id]/moderator`. Use
@@ -213,10 +213,10 @@ decision entry in `docs/PRD-moderator-dashboard.md §10`:
 |---|---|
 | Pod-health bands | Absolute headcount, not percentage. Configurable per cycle. |
 | Nudges in v1 | At-risk only (consecutive miss threshold). System flags; no automated outreach. |
-| Multi-pod poderators | First-class. All Pods view is the default landing. |
+| Multi-pod poderators | First-class. All pods view is the default landing. |
 | Inactive members | Hidden by default; "Show inactive" toggle. |
 | Profile visibility | Four tiers (always/hover/click-through/never). See PRD §7.3. |
-| Pulse aggregation | Three scopes: individual (side panel), pod-level (per-pod page), cross-pod (All Pods). LLM themes for free-text fields. |
+| Pulse aggregation | Three scopes: individual (side panel), pod-level (per-pod page), cross-pod (All pods). LLM themes for free-text fields. |
 | Auto-flip | Disabled for the current cycle. Don't activate it from dashboard logic. |
 | No in-product walkthrough | Tooltips only (UI mechanics). Programmatic orientation is handbook + kickoff. |
 
@@ -224,7 +224,7 @@ decision entry in `docs/PRD-moderator-dashboard.md §10`:
 
 ## Component hints
 
-- The **pod switcher** (§7.7) and the **All Pods / per-pod view toggle** are
+- The **pod switcher** (§7.7) and the **All pods / per-pod view toggle** are
   the same control. Render it as a dropdown or tab row at the top of the page.
   Persist the last selection via `PUT /api/moderator/ui-state`.
 - The **pulse review side panel** (§7.4) opens without navigating. Use a
@@ -246,7 +246,7 @@ Suggested order — each step is independently shippable:
 
 1. **Migrations** (`00019`+) — `nudge_dismissals`, `moderator_ui_state`,
    `pulse_themes`, `cycle_config` extensions.
-2. **All Pods view** — replace the existing `moderator/page.tsx` stub with the
+2. **All pods view** — replace the existing `moderator/page.tsx` stub with the
    full page: pod cards with health indicator, cross-pod nudge list, switcher.
 3. **Per-pod view** — new `moderator/pods/[pod_id]/page.tsx`: status header,
    at-risk nudge, member roster with filter/search/sort, phase guidance, pod
@@ -256,7 +256,7 @@ Suggested order — each step is independently shippable:
 5. **Pod-level pulse insights** (§7.9.2) — themes + completion trend on the
    per-pod page.
 6. **Cross-pod pulse insights** (§7.9.3) — patterns + tool grid + engagement
-   comparison on the All Pods view.
+   comparison on the All pods view.
 7. **Nudge dismissal** — `POST /api/moderator/nudges/dismiss` + dismiss button
    on each nudge card.
 8. **UI state persistence** — switcher last-view, roster filter/sort, tooltip

--- a/docs/superpowers/specs/2026-05-22-poderator-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-22-poderator-dashboard-design.md
@@ -15,7 +15,7 @@ Phase 1 ships a fully functional poderator dashboard excluding §7.9 (pulse-chec
 
 **In scope:**
 - DB migrations 00019–00022
-- All Pods view (`/moderator`) — replace existing stub
+- All pods view (`/moderator`) — replace existing stub
 - Per-pod view (`/moderator/pods/[pod_id]`) — new page
 - Pod status header, at-risk nudges, member roster, pulse review side panel, phase guidance, pod resources
 - Nudge dismissal (API + button)
@@ -41,7 +41,7 @@ The pod switcher navigates between routes (route change = server re-render with 
 
 ```
 app/(dashboard)/moderator/
-  page.tsx                          ← All Pods view (RSC) — replace stub
+  page.tsx                          ← All pods view (RSC) — replace stub
   pods/[pod_id]/page.tsx            ← Per-pod view (RSC) — new
   cycles/[cycle_id]/vote-progress/  ← untouched
 ```
@@ -74,11 +74,11 @@ All routes use `withAuth` from `lib/auth/middleware.ts`. Pod-scoped routes verif
 
 ## Components
 
-### All Pods view (`/moderator`)
+### All pods view (`/moderator`)
 
 | Component | Type | Responsibility |
 |---|---|---|
-| `PodSwitcher` | Client | Tab/dropdown for All Pods + per-pod navigation. Receives `lastView` as prop from RSC page (already fetched server-side). Writes to `ui-state` API on change. Reflects selection in URL. |
+| `PodSwitcher` | Client | Tab/dropdown for All pods + per-pod navigation. Receives `lastView` as prop from RSC page (already fetched server-side). Writes to `ui-state` API on change. Reflects selection in URL. |
 | `NudgeList` | Server | Cross-pod at-risk nudge cards, each with a `NudgeDismissButton` (Client). Capped at 3 visible; "N more" affordance. |
 | `PodSummaryGrid` | Server | Card per assigned pod: name, status, health indicator + trend arrow. Links to per-pod view. |
 
@@ -86,9 +86,9 @@ All routes use `withAuth` from `lib/auth/middleware.ts`. Pod-scoped routes verif
 
 | Component | Type | Responsibility |
 |---|---|---|
-| `PodSwitcher` | Client | Same component as All Pods view. |
+| `PodSwitcher` | Client | Same component as All pods view. |
 | `PodStatusHeader` | Server | Pod name, cycle name, pod status badge, current phase + timestamps + countdown, health indicator + trend arrow. Suppresses health indicator for `forming`/`inactive` pods. |
-| `NudgeList` | Server | At-risk nudges scoped to this pod. Same component as All Pods view. |
+| `NudgeList` | Server | At-risk nudges scoped to this pod. Same component as All pods view. |
 | `MemberRoster` | Client | Filter (by pulse status), search (by name), sort (default: at-risk → late → pending → current). Persists state to `ui-state` API on change. Exposes inline Slack DM link and pulse review trigger per row. |
 | `PulseReviewPanel` | Client | Sheet/drawer. Opens on roster row action without navigation. Fetches `GET …/pulse-responses/[participant_id]` on open. Displays per-week responses (last 4 weeks default). Navigation between members re-fetches without closing. |
 | `PhaseGuidance` | Server | Plain-English phase description, deadlines, phase-specific signal block (varies by phase). |
@@ -108,7 +108,7 @@ Tooltip targets: pod-health indicator, trend arrow, engagement-status badges, at
 
 ## Data fetching
 
-### All Pods page — server-side
+### All pods page — server-side
 
 - `moderator_assignments` (or all pods if admin) → pod IDs
 - `pods + cycles` → pod name, status, cycle name, phase, timestamps

--- a/docs/superpowers/specs/2026-05-22-poderator-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-22-poderator-dashboard-design.md
@@ -1,0 +1,181 @@
+# Poderator Dashboard — Implementation Design
+
+| | |
+|---|---|
+| Date | 2026-05-22 |
+| PRD | [`docs/PRD-moderator-dashboard.md`](../../PRD-moderator-dashboard.md) |
+| CLAUDE.md | [`docs/poderator-dashboard/CLAUDE.md`](../../poderator-dashboard/CLAUDE.md) |
+| Phase | 1 of 2 — core dashboard (Phase 2 = LLM aggregations) |
+
+---
+
+## Scope
+
+Phase 1 ships a fully functional poderator dashboard excluding §7.9 (pulse-check aggregations). No aggregation UI renders in Phase 1 — no empty states, no placeholders. The `pulse_themes` table is created in migrations so Phase 2 can populate it without schema changes.
+
+**In scope:**
+- DB migrations 00019–00022
+- All Pods view (`/moderator`) — replace existing stub
+- Per-pod view (`/moderator/pods/[pod_id]`) — new page
+- Pod status header, at-risk nudges, member roster, pulse review side panel, phase guidance, pod resources
+- Nudge dismissal (API + button)
+- UI state persistence (switcher last-view, roster filter/sort, tooltip suppression)
+- Tooltip layer (auto-suppress after 1–2 encounters per key)
+
+**Out of scope (Phase 2):**
+- §7.9 pulse-check aggregations (individual, pod-level, cross-pod)
+- LLM theme extraction pipeline
+- `pulse_check_aggregates` materialized view
+
+---
+
+## Architecture
+
+**Approach: Server-first (RSC + API routes)**
+
+RSC pages fetch all initial data server-side via the Supabase server client. Interactive islands are Client Components that call API routes on demand. Client Components never access Supabase directly.
+
+The pod switcher navigates between routes (route change = server re-render with correct auth-scoped data). Roster filters live in client React state and are persisted to `moderator_ui_state` via API on change.
+
+### Pages
+
+```
+app/(dashboard)/moderator/
+  page.tsx                          ← All Pods view (RSC) — replace stub
+  pods/[pod_id]/page.tsx            ← Per-pod view (RSC) — new
+  cycles/[cycle_id]/vote-progress/  ← untouched
+```
+
+### API routes
+
+```
+app/api/moderator/
+  pods/route.ts                                         GET — all assigned pods
+  pods/[pod_id]/route.ts                                GET — single pod detail
+  pods/[pod_id]/pulse-responses/[participant_id]/route.ts  GET — side panel data
+  pods/[pod_id]/insights/route.ts                       GET — scaffolded, returns {} (Phase 2)
+  insights/route.ts                                     GET — scaffolded, returns {} (Phase 2)
+  nudges/dismiss/route.ts                               POST — dismiss a nudge
+  ui-state/route.ts                                     GET + PUT — switcher/filter/tooltip state
+```
+
+All routes use `withAuth` from `lib/auth/middleware.ts`. Pod-scoped routes verify `userRoles.moderatorPodIds.includes(pod_id)` unless the caller is an admin.
+
+### DB migrations
+
+| File | Table | Phase |
+|---|---|---|
+| `00019_nudge_dismissals.sql` | `nudge_dismissals` | 1 |
+| `00020_moderator_ui_state.sql` | `moderator_ui_state` | 1 |
+| `00021_pulse_themes.sql` | `pulse_themes` | 1 (populated Phase 2) |
+| `00022_cycle_config_extensions.sql` | alter `cycle_config` | 1 |
+
+---
+
+## Components
+
+### All Pods view (`/moderator`)
+
+| Component | Type | Responsibility |
+|---|---|---|
+| `PodSwitcher` | Client | Tab/dropdown for All Pods + per-pod navigation. Receives `lastView` as prop from RSC page (already fetched server-side). Writes to `ui-state` API on change. Reflects selection in URL. |
+| `NudgeList` | Server | Cross-pod at-risk nudge cards, each with a `NudgeDismissButton` (Client). Capped at 3 visible; "N more" affordance. |
+| `PodSummaryGrid` | Server | Card per assigned pod: name, status, health indicator + trend arrow. Links to per-pod view. |
+
+### Per-pod view (`/moderator/pods/[pod_id]`)
+
+| Component | Type | Responsibility |
+|---|---|---|
+| `PodSwitcher` | Client | Same component as All Pods view. |
+| `PodStatusHeader` | Server | Pod name, cycle name, pod status badge, current phase + timestamps + countdown, health indicator + trend arrow. Suppresses health indicator for `forming`/`inactive` pods. |
+| `NudgeList` | Server | At-risk nudges scoped to this pod. Same component as All Pods view. |
+| `MemberRoster` | Client | Filter (by pulse status), search (by name), sort (default: at-risk → late → pending → current). Persists state to `ui-state` API on change. Exposes inline Slack DM link and pulse review trigger per row. |
+| `PulseReviewPanel` | Client | Sheet/drawer. Opens on roster row action without navigation. Fetches `GET …/pulse-responses/[participant_id]` on open. Displays per-week responses (last 4 weeks default). Navigation between members re-fetches without closing. |
+| `PhaseGuidance` | Server | Plain-English phase description, deadlines, phase-specific signal block (varies by phase). |
+| `PodResources` | Server | Slack, Drive, GitHub, Google Group deep links. "Missing — contact staff" affordance for unprovisioned resources. |
+
+### Shared primitives
+
+Check `app/components/ui` before building: Sheet/Drawer, Tooltip, Badge, StatusBadge (already exists).
+
+### Tooltip auto-suppress
+
+RSC page passes `tooltip_seen: string[]` from `moderator_ui_state` to Client Components as a prop. Client shows tooltip if key not in `tooltip_seen` (up to 2 times per key). On auto-suppress: `PUT /api/moderator/ui-state` with updated `tooltip_seen`. A `?` icon remains visible to re-trigger on demand.
+
+Tooltip targets: pod-health indicator, trend arrow, engagement-status badges, at-risk nudge type, phase guidance section header.
+
+---
+
+## Data fetching
+
+### All Pods page — server-side
+
+- `moderator_assignments` (or all pods if admin) → pod IDs
+- `pods + cycles` → pod name, status, cycle name, phase, timestamps
+- `pulse_checks + cycle_config` → missed-pulse count per pod → health band + 3-week trend
+- `nudge_dismissals` → filter dismissed nudges for this poderator
+- `moderator_ui_state` → `tooltip_seen[]` passed to Client Components as prop
+
+### Per-pod page — server-side
+
+- `pods + cycles` → status header data
+- `pod_memberships + participants + pulse_checks` → member roster with pulse status
+- `cycle_enrollments` → inactive member filter
+- `nudge_dismissals` → filter dismissed nudges
+- `moderator_ui_state` → initial roster filter/sort + `tooltip_seen[]`
+- `cycle_config` → band thresholds, at-risk miss threshold
+
+### Client-side API calls (on demand)
+
+- `GET …/pulse-responses/[participant_id]` — when pulse review panel opens
+- `POST …/nudges/dismiss` — when poderator dismisses a nudge
+- `PUT …/ui-state` — when filter/sort changes or tooltip is seen
+
+---
+
+## Auth
+
+```ts
+// RSC pages
+const userRoles = await resolveUserRoles(serviceClient, user.id);
+if (!isModerator(userRoles) && !isAdmin(userRoles)) redirect("/cycles");
+
+// API routes (withAuth wrapper)
+if (!isModerator(userRoles) && !isAdmin(userRoles)) return 403;
+// Pod-scoped routes additionally:
+if (!isAdmin(userRoles) && !userRoles.moderatorPodIds.includes(podId)) return 403;
+```
+
+Loss of assignment (`removed_at` set) takes effect immediately — next API call returns 403, next page navigation redirects.
+
+---
+
+## Edge cases
+
+| Scenario | Behaviour |
+|---|---|
+| Lost assignment mid-session | Next API call → 403. Next navigation → redirect to `/cycles`. |
+| Role stacking (poderator + participant) | Both nav links visible. No re-auth required. |
+| Admin access | Sees all pods. `moderator_ui_state` applies (filter/sort/tooltip persistence). |
+| Pulse review for non-assigned pod | `GET` returns 403. Panel shows error state. |
+| `forming` / `inactive` pod | Health indicator suppressed; status explainer shown instead. No nudges. |
+| Missing pod resource URL | "Missing — contact staff" affordance. No broken link. |
+| No pod members | Roster shows `EmptyState`. No nudges possible. |
+| `cycle_config` missing thresholds | Global defaults: warning ≥ 1, critical ≥ 3, at_risk_misses = 2. |
+| Nudge re-triggers after dismissal | New `nudge_key` (includes epoch/occurrence). Requires new dismissal row. |
+| More than 3 nudges | Cap at 3 visible; "N more" count affordance. |
+| Member pulses after nudge fires | Nudge disappears on next page load. No real-time update needed. |
+| First-time poderator (no ui-state row) | Multi-pod → `/moderator`. Single-pod → `/moderator/pods/[id]`. Row created on first PUT. |
+| `last_view` points to unassigned pod | Fall back to default landing. No 403 on redirect. |
+| `ui-state` PUT fails | Silent failure. Filters work locally; won't persist. No error toast. |
+
+---
+
+## Naming convention
+
+| Layer | Term |
+|---|---|
+| User-facing UI (copy, titles, badges) | **Poderator** |
+| Code, DB, API paths | **moderator** |
+
+Never use "poderator" in code. Never expose "moderator" in UI copy.

--- a/docs/superpowers/specs/2026-05-22-poderator-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-22-poderator-dashboard-design.md
@@ -5,27 +5,29 @@
 | Date | 2026-05-22 |
 | PRD | [`docs/PRD-moderator-dashboard.md`](../../PRD-moderator-dashboard.md) |
 | CLAUDE.md | [`docs/poderator-dashboard/CLAUDE.md`](../../poderator-dashboard/CLAUDE.md) |
-| Phase | 1 of 2 — core dashboard (Phase 2 = LLM aggregations) |
+| Phase | Single phase — no internal LLM, no Phase 2 deferred work |
 
 ---
 
 ## Scope
 
-Phase 1 ships a fully functional poderator dashboard excluding §7.9 (pulse-check aggregations). No aggregation UI renders in Phase 1 — no empty states, no placeholders. The `pulse_themes` table is created in migrations so Phase 2 can populate it without schema changes.
+The full poderator dashboard ships in one go. No LLM runs inside OLOS for this feature: all free-text analysis happens in the poderator's own AI tool, fed by an in-dashboard "Copy prompt + responses" block (§7.10.3). Pulse-check aggregations cover structured fields only (AI tool counts, pulse-completion rates).
 
 **In scope:**
-- DB migrations 00019–00022
-- All pods view (`/moderator`) — replace existing stub
-- Per-pod view (`/moderator/pods/[pod_id]`) — new page
-- Pod status header, at-risk nudges, member roster, pulse review side panel, phase guidance, pod resources
-- Nudge dismissal (API + button)
+- DB migrations 00023–00026 (see DB migrations table below)
+- All pods view (`/moderator`) — replace existing stub. Includes nudge list, pod summary cards (§7.10.1), members-needing-attention rollup (§7.10.2), cross-pod insights (§7.9.3), AI-assisted summary block (§7.10.3)
+- Per-pod view (`/moderator/pods/[pod_id]`) — new page. Includes pod status header, at-risk nudges, member roster, pulse review side panel, pod-level insights (§7.9.2), AI-assisted summary block (§7.10.3), phase guidance, pod resources
+- Nudge dismissal (API + button on every nudge)
 - UI state persistence (switcher last-view, roster filter/sort, tooltip suppression)
 - Tooltip layer (auto-suppress after 1–2 encounters per key)
+- Member preview shape: `ai_experience_level` enum + `availability_snippet` on `participants` (§7.3.1)
+- AI summary prompt string stored on `cycle_config` with global default
 
-**Out of scope (Phase 2):**
-- §7.9 pulse-check aggregations (individual, pod-level, cross-pod)
+**Explicitly NOT in scope (no LLM in OLOS):**
 - LLM theme extraction pipeline
+- `pulse_themes` table
 - `pulse_check_aggregates` materialized view
+- Server-side LLM calls of any kind for this dashboard
 
 ---
 
@@ -53,8 +55,8 @@ app/api/moderator/
   pods/route.ts                                         GET — all assigned pods
   pods/[pod_id]/route.ts                                GET — single pod detail
   pods/[pod_id]/pulse-responses/[participant_id]/route.ts  GET — side panel data
-  pods/[pod_id]/insights/route.ts                       GET — scaffolded, returns {} (Phase 2)
-  insights/route.ts                                     GET — scaffolded, returns {} (Phase 2)
+  pods/[pod_id]/insights/route.ts                       GET — pod-level structured aggregates (§7.9.2) + recent pulse comments for AI summary block
+  insights/route.ts                                     GET — cross-pod structured aggregates (§7.9.3) + recent pulse comments for AI summary block
   nudges/dismiss/route.ts                               POST — dismiss a nudge
   ui-state/route.ts                                     GET + PUT — switcher/filter/tooltip state
 ```
@@ -63,12 +65,12 @@ All routes use `withAuth` from `lib/auth/middleware.ts`. Pod-scoped routes verif
 
 ### DB migrations
 
-| File | Table | Phase |
-|---|---|---|
-| `00019_nudge_dismissals.sql` | `nudge_dismissals` | 1 |
-| `00020_moderator_ui_state.sql` | `moderator_ui_state` | 1 |
-| `00021_pulse_themes.sql` | `pulse_themes` | 1 (populated Phase 2) |
-| `00022_cycle_config_extensions.sql` | alter `cycle_config` | 1 |
+| File | Table / change |
+|---|---|
+| `00023_nudge_dismissals.sql` | new table `nudge_dismissals` |
+| `00024_moderator_ui_state.sql` | new table `moderator_ui_state` |
+| `00025_participants_ai_experience.sql` | alter `participants`: add `ai_experience_level` enum (`new`, `consumer`, `builder`, `shipper`) defaulting to `new`; add `availability_snippet text` |
+| `00026_cycle_config_extensions.sql` | alter `cycle_config`: add pod-health band thresholds, at-risk miss threshold, default aggregation window, and `ai_summary_prompt text` (canonical prompt for §7.10.3) |
 
 ---
 
@@ -79,19 +81,24 @@ All routes use `withAuth` from `lib/auth/middleware.ts`. Pod-scoped routes verif
 | Component | Type | Responsibility |
 |---|---|---|
 | `PodSwitcher` | Client | Tab/dropdown for All pods + per-pod navigation. Receives `lastView` as prop from RSC page (already fetched server-side). Writes to `ui-state` API on change. Reflects selection in URL. |
-| `NudgeList` | Server | Cross-pod at-risk nudge cards, each with a `NudgeDismissButton` (Client). Capped at 3 visible; "N more" affordance. |
-| `PodSummaryGrid` | Server | Card per assigned pod: name, status, health indicator + trend arrow. Links to per-pod view. |
+| `NudgeList` | Server | Cross-pod at-risk nudge cards, each with a `NudgeDismissButton` (Client). Capped at 3 visible; "N more" affordance. Per-poderator dismissal persisted via `nudge_dismissals`. |
+| `PodSummaryGrid` | Server | Card per assigned pod (§7.10.1): name, status, cycle phase + week, headline pulse-health figure, three-week trend arrow. Links to per-pod view. Sorted: pods with non-zero at-risk count first, then alphabetical. Hidden for single-pod poderators. |
+| `MembersNeedingAttentionRollup` | Server | Four-KPI block (§7.10.2): pulsing-this-week, at-risk, pulses-this-period, engagement-trend. Hidden for single-pod poderators. |
+| `CrossPodInsights` | Server | §7.9.3 structured aggregates only: AI tool adoption by pod (grid) + engagement comparison (mini-trends). Suppressed entirely for single-pod poderators. |
+| `AISummaryBlock` | Client | §7.10.3. Receives bundled pulse comments + canonical prompt string as props (assembled server-side). Renders preview of comments and "Copy prompt + responses" button. Clipboard copy is client-only; no API call. Same component shared with per-pod view. |
 
 ### Per-pod view (`/moderator/pods/[pod_id]`)
 
 | Component | Type | Responsibility |
 |---|---|---|
 | `PodSwitcher` | Client | Same component as All pods view. |
-| `PodStatusHeader` | Server | Pod name, cycle name, pod status badge, current phase + timestamps + countdown, health indicator + trend arrow. Suppresses health indicator for `forming`/`inactive` pods. |
+| `PodStatusHeader` | Server | Pod name, cycle name, pod status badge, current phase + open and close timestamps + countdown, health indicator + trend arrow. Suppresses health indicator for `forming`/`inactive` pods. |
 | `NudgeList` | Server | At-risk nudges scoped to this pod. Same component as All pods view. |
-| `MemberRoster` | Client | Filter (by pulse status), search (by name), sort (default: at-risk → late → pending → current). Persists state to `ui-state` API on change. Exposes inline Slack DM link and pulse review trigger per row. |
-| `PulseReviewPanel` | Client | Sheet/drawer. Opens on roster row action without navigation. Fetches `GET …/pulse-responses/[participant_id]` on open. Displays per-week responses (last 4 weeks default). Navigation between members re-fetches without closing. |
-| `PhaseGuidance` | Server | Plain-English phase description, deadlines, phase-specific signal block (varies by phase). |
+| `MemberRoster` | Client | Filter (by pulse status and by `ai_experience_level`), search (by name), sort (default: at-risk → late → pending → current; AI experience as alternate sort). Persists state to `ui-state` API on change. Exposes pulse-review and Slack DM affordances per row. |
+| `PulseReviewPanel` | Client | Sheet/drawer. Opens on roster row action without navigation. Fetches `GET …/pulse-responses/[participant_id]` on open. Displays per-week responses (last 4 weeks default with "Show full cycle history" expand). Member N of M navigation re-fetches without closing. Footer shows read-only stance + Open Slack DM. |
+| `PodInsights` | Server | §7.9.2 structured aggregates: top AI tools across the pod + pulse-completion trend (week-by-week). No themes. |
+| `AISummaryBlock` | Client | §7.10.3. Same component as All pods view. Bundle is scoped to this pod's pulse comments. |
+| `PhaseGuidance` | Server | Plain-English phase description, deadlines (close + next-open), phase-specific signal block (varies by phase — solution-proposal phase lists submitter identities). |
 | `PodResources` | Server | Slack, Drive, GitHub, Google Group deep links. "Missing — contact staff" affordance for unprovisioned resources. |
 
 ### Shared primitives
@@ -113,17 +120,23 @@ Tooltip targets: pod-health indicator, trend arrow, engagement-status badges, at
 - `moderator_assignments` (or all pods if admin) → pod IDs
 - `pods + cycles` → pod name, status, cycle name, phase, timestamps
 - `pulse_checks + cycle_config` → missed-pulse count per pod → health band + 3-week trend
+- `pulse_checks` AI-tool selections → cross-pod AI tool adoption (§7.9.3)
+- `pulse_checks` completion counts → engagement comparison + members-needing-attention KPIs
+- `pulse_checks` free-text fields (last 4 weeks, members shown by initials only) → bundled into `AISummaryBlock` props alongside `cycle_config.ai_summary_prompt`
 - `nudge_dismissals` → filter dismissed nudges for this poderator
 - `moderator_ui_state` → `tooltip_seen[]` passed to Client Components as prop
 
 ### Per-pod page — server-side
 
-- `pods + cycles` → status header data
-- `pod_memberships + participants + pulse_checks` → member roster with pulse status
+- `pods + cycles` → status header data (incl. open + close timestamps for current phase)
+- `pod_memberships + participants + pulse_checks` → member roster with pulse status. `participants.ai_experience_level` + `availability_snippet` join into the row preview
 - `cycle_enrollments` → inactive member filter
+- `pulse_checks` AI-tool selections → top tools for this pod (§7.9.2)
+- `pulse_checks` completion counts → weekly completion trend
+- `pulse_checks` free-text fields (last 4 weeks for this pod's members, shown by initials) → bundled into `AISummaryBlock` props
 - `nudge_dismissals` → filter dismissed nudges
 - `moderator_ui_state` → initial roster filter/sort + `tooltip_seen[]`
-- `cycle_config` → band thresholds, at-risk miss threshold
+- `cycle_config` → band thresholds, at-risk miss threshold, AI summary prompt string
 
 ### Client-side API calls (on demand)
 

--- a/lib/auth/moderator.ts
+++ b/lib/auth/moderator.ts
@@ -1,0 +1,40 @@
+/**
+ * Pod-scoped auth helper for the poderator dashboard.
+ *
+ * Consolidates the "is this user allowed to read/write this pod's
+ * moderator-dashboard data?" check so every /api/moderator/pods/[pod_id]/*
+ * route uses the same predicate.
+ *
+ * Predicate: caller is admin/owner OR has an active moderator assignment
+ * for the pod (i.e. pod_id is in their UserRoles.moderatorPodIds).
+ *
+ * Returns null when allowed, a 403 NextResponse when denied — designed
+ * to short-circuit handler logic:
+ *
+ *   const guard = requireModeratorForPod(auth.user, podId);
+ *   if (guard) return guard;
+ *
+ * The base authentication + role resolution is already done by
+ * `withAuth` (see lib/auth/middleware.ts); this helper layers the
+ * per-pod authorization check on top.
+ */
+
+import { NextResponse } from "next/server";
+import { isAdmin, isModeratorForPod, type UserRoles } from "./roles";
+
+/**
+ * Returns null if `user` is allowed to access `podId`'s moderator data,
+ * or a 403 NextResponse otherwise.
+ *
+ * Admins and owners are always allowed (they get global pod access per
+ * PRD §8). Other users must have an active moderator assignment for the
+ * specific pod.
+ */
+export function requireModeratorForPod(
+  user: UserRoles,
+  podId: number
+): NextResponse | null {
+  if (isAdmin(user)) return null;
+  if (isModeratorForPod(user, podId)) return null;
+  return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+}

--- a/lib/moderator/cross-pod-insights.ts
+++ b/lib/moderator/cross-pod-insights.ts
@@ -1,0 +1,251 @@
+/**
+ * Cross-pod pulse insights (PRD §7.9.3).
+ *
+ * Renders on the All pods view between the §7.10.2 rollup and the
+ * AI-assisted summary block. Scoped to the union of pods the
+ * poderator can see. Suppressed for single-pod poderators (PRD §7.10).
+ *
+ * Two metrics:
+ *   - AI tool adoption by pod: top tools across all pods + per-pod
+ *     breakdown of member-distinct counts.
+ *   - Engagement comparison: per-pod weekly completion rate (latest
+ *     week + 3-week trend) for side-by-side comparison.
+ *
+ * Plus the comment bundle for the §7.10.3 cross-pod AI summary.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { PulseComment, WeeklyCompletion } from "./pod-insights";
+
+export type CrossPodToolRow = {
+  tool: string;
+  members: number;
+  byPod: { pod_id: number; pod_name: string; members: number }[];
+};
+
+export type CrossPodEngagementRow = {
+  pod_id: number;
+  pod_name: string;
+  thisWeekRate: number; // 0..1
+  thisWeekCompleted: number;
+  thisWeekTotal: number;
+  weekly: WeeklyCompletion[]; // for sparkline use
+};
+
+export type CrossPodInsights = {
+  range: "4w" | "full";
+  topTools: CrossPodToolRow[];
+  engagement: CrossPodEngagementRow[];
+  recentComments: PulseComment[];
+};
+
+const TOP_N_TOOLS = 5;
+const TOP_N_RECENT_COMMENTS = 32;
+const FREE_TEXT_FIELDS = [
+  "accomplishment",
+  "highlight",
+  "challenge",
+  "blockers",
+  "tailwinds",
+  "mitigation_strategy",
+  "anything_else",
+] as const;
+
+export async function getCrossPodInsights(
+  supabase: SupabaseClient,
+  podIds: number[],
+  range: "4w" | "full"
+): Promise<CrossPodInsights | null> {
+  if (podIds.length === 0) {
+    return { range, topTools: [], engagement: [], recentComments: [] };
+  }
+
+  // Pods + their cycle_ids, names.
+  const { data: pods } = await supabase
+    .from("pods")
+    .select("id, name, cycle_id")
+    .in("id", podIds);
+  if (!pods || pods.length === 0) {
+    return { range, topTools: [], engagement: [], recentComments: [] };
+  }
+
+  const podNameById = new Map<number, string>();
+  const podCycle = new Map<number, number>();
+  for (const p of pods) {
+    podNameById.set(p.id as number, (p.name as string) ?? `Pod ${p.id}`);
+    podCycle.set(p.id as number, p.cycle_id as number);
+  }
+  const cycleIds = Array.from(new Set(podCycle.values()));
+
+  // Active memberships → (participant, pod) pairs, plus participants
+  // for initials.
+  const { data: memRows } = await supabase
+    .from("pod_memberships")
+    .select(`
+      pod_id, participant_id,
+      participants ( first_name, last_name, preferred_name )
+    `)
+    .in("pod_id", podIds)
+    .is("inactive_at", null);
+
+  const memberPod = new Map<number, number>(); // participant → pod
+  const memberInitials = new Map<number, string>();
+  for (const m of memRows ?? []) {
+    memberPod.set(m.participant_id as number, m.pod_id as number);
+    const p = (m.participants as unknown) as {
+      first_name?: string;
+      last_name?: string;
+      preferred_name?: string | null;
+    } | null;
+    const first = (p?.preferred_name?.trim() || p?.first_name?.trim() || "?")[0];
+    const last = p?.last_name?.[0] ?? "";
+    memberInitials.set(
+      m.participant_id as number,
+      `${first}${last}`.toUpperCase()
+    );
+  }
+  const participantIds = Array.from(memberPod.keys());
+  if (participantIds.length === 0) {
+    return { range, topTools: [], engagement: [], recentComments: [] };
+  }
+
+  // Pulse data scoped by cycle + participant.
+  const query = supabase
+    .from("pulse_checks")
+    .select(
+      "participant_id, cycle_id, scheduled_date, completed_at, survey_responses"
+    )
+    .in("participant_id", participantIds)
+    .in("cycle_id", cycleIds)
+    .order("scheduled_date");
+  if (range === "4w") {
+    const fourWeeksAgo = new Date();
+    fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
+    query.gte("scheduled_date", fourWeeksAgo.toISOString().slice(0, 10));
+  }
+  const { data: pulseData } = await query;
+
+  type PulseRow = {
+    participant_id: number;
+    cycle_id: number;
+    scheduled_date: string;
+    completed_at: string | null;
+    survey_responses: Record<string, unknown> | null;
+  };
+  const pulseRows = (pulseData ?? []) as PulseRow[];
+
+  // Drop cross-cycle leaks (pulse from a participant in a different
+  // cycle than their pod's cycle).
+  const cleanPulses = pulseRows.filter((p) => {
+    const pid = memberPod.get(p.participant_id);
+    if (pid === undefined) return false;
+    const expectedCycle = podCycle.get(pid);
+    return expectedCycle === p.cycle_id;
+  });
+
+  // AI tools — distinct members per tool, plus per-pod breakdown.
+  const toolMembers = new Map<string, Set<number>>();
+  const toolPodMembers = new Map<string, Map<number, Set<number>>>();
+  for (const p of cleanPulses) {
+    if (!p.completed_at || !p.survey_responses) continue;
+    const pod = memberPod.get(p.participant_id);
+    if (pod === undefined) continue;
+    const tools = (p.survey_responses as { tools_used?: unknown }).tools_used;
+    if (!Array.isArray(tools)) continue;
+    for (const t of tools) {
+      if (typeof t !== "string") continue;
+      const trimmed = t.trim();
+      if (!trimmed) continue;
+      const set = toolMembers.get(trimmed) ?? new Set<number>();
+      set.add(p.participant_id);
+      toolMembers.set(trimmed, set);
+
+      const byPodMap = toolPodMembers.get(trimmed) ?? new Map<number, Set<number>>();
+      const ps = byPodMap.get(pod) ?? new Set<number>();
+      ps.add(p.participant_id);
+      byPodMap.set(pod, ps);
+      toolPodMembers.set(trimmed, byPodMap);
+    }
+  }
+  const topTools: CrossPodToolRow[] = Array.from(toolMembers.entries())
+    .map(([tool, set]) => ({
+      tool,
+      members: set.size,
+      byPod: Array.from(toolPodMembers.get(tool)?.entries() ?? [])
+        .map(([pid, members]) => ({
+          pod_id: pid,
+          pod_name: podNameById.get(pid) ?? `Pod ${pid}`,
+          members: members.size,
+        }))
+        .sort((a, b) => b.members - a.members || a.pod_name.localeCompare(b.pod_name)),
+    }))
+    .sort((a, b) => b.members - a.members || a.tool.localeCompare(b.tool))
+    .slice(0, TOP_N_TOOLS);
+
+  // Engagement comparison — per-pod weekly buckets, latest week summarised.
+  const byPodWeek = new Map<number, Map<string, { completed: number; total: number }>>();
+  for (const p of cleanPulses) {
+    const pod = memberPod.get(p.participant_id);
+    if (pod === undefined) continue;
+    const podMap = byPodWeek.get(pod) ?? new Map();
+    const bucket = podMap.get(p.scheduled_date) ?? { completed: 0, total: 0 };
+    bucket.total += 1;
+    if (p.completed_at) bucket.completed += 1;
+    podMap.set(p.scheduled_date, bucket);
+    byPodWeek.set(pod, podMap);
+  }
+
+  const engagement: CrossPodEngagementRow[] = podIds.map((pod_id) => {
+    const podMap = byPodWeek.get(pod_id) ?? new Map();
+    const weeks = Array.from(podMap.entries()).sort(([a], [b]) =>
+      a.localeCompare(b)
+    );
+    const weekly: WeeklyCompletion[] = weeks.map(([scheduled_date, b]) => ({
+      scheduled_date,
+      completed: b.completed,
+      total: b.total,
+      rate: b.total === 0 ? 0 : b.completed / b.total,
+    }));
+    const latest = weekly[weekly.length - 1];
+    return {
+      pod_id,
+      pod_name: podNameById.get(pod_id) ?? `Pod ${pod_id}`,
+      thisWeekRate: latest?.rate ?? 0,
+      thisWeekCompleted: latest?.completed ?? 0,
+      thisWeekTotal: latest?.total ?? 0,
+      weekly,
+    };
+  });
+  engagement.sort((a, b) => b.thisWeekRate - a.thisWeekRate);
+
+  // Recent comments bundle — newest first, capped.
+  const recentComments: PulseComment[] = [];
+  const sortedDesc = [...cleanPulses]
+    .filter((p) => p.completed_at)
+    .sort((a, b) =>
+      b.scheduled_date.localeCompare(a.scheduled_date) ||
+      (b.completed_at ?? "").localeCompare(a.completed_at ?? "")
+    );
+  for (const p of sortedDesc) {
+    if (recentComments.length >= TOP_N_RECENT_COMMENTS) break;
+    const text = collectFreeText(p.survey_responses);
+    if (!text) continue;
+    recentComments.push({
+      initials: memberInitials.get(p.participant_id) ?? "??",
+      participant_id: p.participant_id,
+      scheduled_date: p.scheduled_date,
+      text,
+    });
+  }
+
+  return { range, topTools, engagement, recentComments };
+}
+
+function collectFreeText(sr: Record<string, unknown> | null): string {
+  if (!sr) return "";
+  const parts: string[] = [];
+  for (const key of FREE_TEXT_FIELDS) {
+    const v = sr[key];
+    if (typeof v === "string" && v.trim()) parts.push(v.trim());
+  }
+  return parts.join(" · ");
+}

--- a/lib/moderator/nudges.ts
+++ b/lib/moderator/nudges.ts
@@ -1,0 +1,91 @@
+/**
+ * Nudge key derivation + dismissal helpers (PRD §7.2).
+ *
+ * A `nudge_key` encodes a specific instance of a nudge so dismissals
+ * persist across sessions but re-fire when the condition re-trips
+ * (member recovers, then misses again — new key, new nudge).
+ *
+ * For at-risk nudges in v1 the key is:
+ *   at_risk:{participant_id}:{first_miss_date}
+ *
+ * The `first_miss_date` is the scheduled_date of the earliest miss in
+ * the current consecutive-miss run. When a member recovers (submits a
+ * pulse), the run ends; on the next miss a new run starts with a new
+ * `first_miss_date`, producing a new key the dismissal table hasn't
+ * seen.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type AtRiskRun = {
+  participant_id: number;
+  /** ISO date of the earliest miss in the current consecutive run. */
+  first_miss_date: string;
+  /** Number of consecutive misses ending in the most recent scheduled pulse. */
+  consecutiveMisses: number;
+};
+
+/** Compute the canonical nudge key for an at-risk run. */
+export function atRiskNudgeKey(run: AtRiskRun): string {
+  return `at_risk:${run.participant_id}:${run.first_miss_date}`;
+}
+
+/**
+ * From a pulse stream sorted any-order, derive the current at-risk
+ * run for a participant. Returns null if the most recent pulse was
+ * submitted (no active run).
+ */
+export function deriveAtRiskRun(
+  participantId: number,
+  pulses: { scheduled_date: string; completed_at: string | null }[]
+): AtRiskRun | null {
+  if (pulses.length === 0) return null;
+  const sortedDesc = [...pulses].sort((a, b) =>
+    b.scheduled_date.localeCompare(a.scheduled_date)
+  );
+  if (sortedDesc[0].completed_at) return null;
+
+  let consecutive = 0;
+  let firstMissDate = sortedDesc[0].scheduled_date;
+  for (const p of sortedDesc) {
+    if (p.completed_at) break;
+    consecutive += 1;
+    firstMissDate = p.scheduled_date; // last assignment in the run is the earliest
+  }
+  return {
+    participant_id: participantId,
+    first_miss_date: firstMissDate,
+    consecutiveMisses: consecutive,
+  };
+}
+
+/**
+ * Load dismissed nudge_keys for a poderator across the given pods.
+ * Empty Set is returned when the caller has no participantId (admin
+ * without a participant row).
+ */
+export async function loadDismissedKeys(
+  supabase: SupabaseClient,
+  moderatorParticipantId: number | null,
+  podIds: number[]
+): Promise<Set<string>> {
+  if (!moderatorParticipantId || podIds.length === 0) return new Set();
+  const { data } = await supabase
+    .from("nudge_dismissals")
+    .select("pod_id, nudge_key")
+    .eq("moderator_participant_id", moderatorParticipantId)
+    .in("pod_id", podIds);
+  const set = new Set<string>();
+  for (const row of data ?? []) {
+    set.add(`${row.pod_id}:${row.nudge_key}`);
+  }
+  return set;
+}
+
+/** Lookup helper: was this nudge dismissed for this pod by this poderator? */
+export function isDismissed(
+  dismissed: Set<string>,
+  podId: number,
+  nudgeKey: string
+): boolean {
+  return dismissed.has(`${podId}:${nudgeKey}`);
+}

--- a/lib/moderator/phase-guidance.ts
+++ b/lib/moderator/phase-guidance.ts
@@ -1,0 +1,64 @@
+/**
+ * Phase guidance copy (PRD §7.5).
+ *
+ * One paragraph per phase orienting the poderator to what their pod
+ * should be doing. Tone rule (from PRD §7.10.3): descriptive, not
+ * judgmental.
+ *
+ * The phase-specific signal block (§7.5 bullet 3 — pod-voting counts,
+ * solution-proposal submitter identities, project-voting ballots, etc.)
+ * is rendered in the page by composing this copy with separate data
+ * queries. This module is copy-only so it can be co-located with the
+ * other moderator libs and updated by the program team without touching
+ * data layers.
+ *
+ * If a phase has no copy yet, `phaseGuidance` returns null and the page
+ * falls back to a generic "Check in with your pod" message.
+ */
+
+import type { PhaseNum } from "./phase";
+
+interface PhaseGuidance {
+  /** What the phase asks of the pod, plain-English. */
+  description: string;
+  /** Optional callout for what the poderator should watch for. */
+  watchFor?: string;
+}
+
+const COPY: Record<PhaseNum, PhaseGuidance> = {
+  1: {
+    description:
+      "Cycle participants are submitting problem statements. Pods haven't formed yet — your assigned pod is provisional. There's nothing for you to action this week.",
+  },
+  2: {
+    description:
+      "Cycle participants are voting on problem statements. Pods finalize after voting closes. Healthy engagement at this stage is high ballot completion across the cohort.",
+  },
+  3: {
+    description:
+      "Members are registering with the pod for the winning problem. Healthy pods reach the configured minimum headcount before the window closes. Watch for under-registered pods you've been assigned to.",
+    watchFor:
+      "Pods below the minimum need recruitment outreach. Coordinate with staff if your pod is short.",
+  },
+  4: {
+    description:
+      "Members of your pod are drafting solution proposals to the problem your pod is built around. A healthy pod at this stage has at least one proposal from most active members.",
+    watchFor:
+      "Watch for upskillers who haven't started — that often precedes disengagement.",
+  },
+  5: {
+    description:
+      "Members are voting on the solution proposals submitted within your pod. Healthy engagement at this stage is most active members casting their ballot.",
+  },
+  6: {
+    description:
+      "Members are registering with one of the winning projects. Projects below the minimum registrant threshold may not move forward — flag those to staff and encourage members to choose.",
+    watchFor:
+      "Watch for projects that haven't reached the minimum registration count.",
+  },
+};
+
+export function phaseGuidance(phase: PhaseNum | null): PhaseGuidance | null {
+  if (phase === null) return null;
+  return COPY[phase] ?? null;
+}

--- a/lib/moderator/phase.ts
+++ b/lib/moderator/phase.ts
@@ -1,0 +1,111 @@
+/**
+ * Phase resolver for the poderator dashboard (PRD §7.1).
+ *
+ * Maps the current timestamp to one of the cycle's operational phases
+ * using cycle_config window pairs. Six phases total — matches the
+ * canonical OPERATIONAL_WINDOWS in
+ * app/(dashboard)/cycles/cycle-phase-indicator.tsx:58-65.
+ *
+ * The PRD glossary §5 mentions seven phases ("project shortlist" as a
+ * seventh) but the schema and existing code recognize six operational
+ * windows. We keep the six-phase model here as the source of truth and
+ * file a follow-up to reconcile the PRD glossary.
+ *
+ * If `now` falls outside any open window, the resolver returns the
+ * upcoming phase (if any) so the dashboard can render "opens in N days"
+ * rather than an empty state. If the cycle is over, returns null.
+ */
+
+export type PhaseNum = 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface ResolvedPhase {
+  num: PhaseNum;
+  /** Canonical phase display name (e.g. "Phase 4: Solution Proposals"). */
+  displayName: string;
+  /** Short name without the "Phase N:" prefix (e.g. "Solution Proposals"). */
+  shortName: string;
+  /** When the phase opened. Null when not scheduled (rare). */
+  openAt: string | null;
+  /** When the phase closes. Null when not scheduled (rare). */
+  closeAt: string | null;
+  /** True when `now` is between openAt and closeAt (the phase is live). */
+  isActive: boolean;
+}
+
+export interface CycleConfigPhaseColumns {
+  problem_statement_open: string | null;
+  problem_statement_close: string | null;
+  voting_open: string | null;
+  voting_close: string | null;
+  pod_registration_open: string | null;
+  pod_registration_close: string | null;
+  solution_proposal_open: string | null;
+  solution_proposal_close: string | null;
+  solution_voting_open: string | null;
+  solution_voting_close: string | null;
+  project_registration_open: string | null;
+  project_registration_close: string | null;
+}
+
+interface PhaseSpec {
+  num: PhaseNum;
+  shortName: string;
+  openKey: keyof CycleConfigPhaseColumns;
+  closeKey: keyof CycleConfigPhaseColumns;
+}
+
+const PHASES: PhaseSpec[] = [
+  { num: 1, shortName: "Problem Statements", openKey: "problem_statement_open", closeKey: "problem_statement_close" },
+  { num: 2, shortName: "Problem Voting", openKey: "voting_open", closeKey: "voting_close" },
+  { num: 3, shortName: "Pod Registration", openKey: "pod_registration_open", closeKey: "pod_registration_close" },
+  { num: 4, shortName: "Solution Proposals", openKey: "solution_proposal_open", closeKey: "solution_proposal_close" },
+  { num: 5, shortName: "Solution Voting", openKey: "solution_voting_open", closeKey: "solution_voting_close" },
+  { num: 6, shortName: "Project Registration", openKey: "project_registration_open", closeKey: "project_registration_close" },
+];
+
+function toResolved(spec: PhaseSpec, openAt: string | null, closeAt: string | null, isActive: boolean): ResolvedPhase {
+  return {
+    num: spec.num,
+    displayName: `Phase ${spec.num}: ${spec.shortName}`,
+    shortName: spec.shortName,
+    openAt,
+    closeAt,
+    isActive,
+  };
+}
+
+/**
+ * Resolve the current phase. Returns:
+ *   - the active phase if `now` is within an open window
+ *   - otherwise the next upcoming phase (next opening) so the header can
+ *     render "Opens in N days"
+ *   - null if all phases have closed (cycle is over)
+ */
+export function resolveCurrentPhase(
+  cfg: CycleConfigPhaseColumns,
+  now: Date = new Date()
+): ResolvedPhase | null {
+  // First pass: active window
+  for (const spec of PHASES) {
+    const openAt = cfg[spec.openKey];
+    const closeAt = cfg[spec.closeKey];
+    if (!openAt || !closeAt) continue;
+    if (now >= new Date(openAt) && now <= new Date(closeAt)) {
+      return toResolved(spec, openAt, closeAt, true);
+    }
+  }
+
+  // Second pass: nearest upcoming
+  let upcoming: ResolvedPhase | null = null;
+  let upcomingOpenMs = Infinity;
+  for (const spec of PHASES) {
+    const openAt = cfg[spec.openKey];
+    if (!openAt) continue;
+    const openMs = new Date(openAt).getTime();
+    if (openMs > now.getTime() && openMs < upcomingOpenMs) {
+      upcoming = toResolved(spec, openAt, cfg[spec.closeKey], false);
+      upcomingOpenMs = openMs;
+    }
+  }
+  return upcoming;
+}

--- a/lib/moderator/pod-detail.ts
+++ b/lib/moderator/pod-detail.ts
@@ -1,0 +1,277 @@
+/**
+ * Per-pod detail query for the Per-pod view (PRD §7.1 status header,
+ * §7.3 member roster, §7.5 phase guidance).
+ *
+ * Shared between the RSC `app/(dashboard)/moderator/pods/[pod_id]/page.tsx`
+ * and the REST endpoint `GET /api/moderator/pods/[pod_id]`. Both surfaces
+ * use identical pulse-status bucketing and pod-health computation.
+ *
+ * This helper does NOT authorize the caller — callers must check
+ * `requireModeratorForPod` (route) or run the equivalent check in the
+ * RSC before invoking.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { resolveCurrentPhase, type CycleConfigPhaseColumns } from "./phase";
+import {
+  bandFor,
+  trendOver3Weeks,
+  type Band,
+  type Trend,
+  type PulseHealthCfg,
+} from "./pulse-health";
+
+const DEFAULT_AT_RISK_MISSES = 2;
+
+export type PulseStatus = "current" | "pending" | "late" | "at_risk";
+
+export type RosterRow = {
+  participant_id: number;
+  initials: string;
+  display_name: string;
+  ai_experience_level: string;
+  availability_snippet: string | null;
+  email: string | null;
+  joined_at: string;
+  is_inactive: boolean;
+  inactive_since: string | null;
+  pulse_status: PulseStatus;
+  last_activity_at: string | null;
+};
+
+export type PodDetail = {
+  id: number;
+  name: string | null;
+  status: string;
+  cycle_id: number;
+  cycle_name: string | null;
+  phase_num: number | null;
+  phase_display_name: string | null;
+  phase_short_name: string | null;
+  phase_open_at: string | null;
+  phase_close_at: string | null;
+  phase_is_active: boolean;
+  active_member_count: number;
+  missing_this_week: number;
+  band: Band;
+  trend: Trend;
+  resources: {
+    slack_channel_id: string | null;
+    drive_folder_id: string | null;
+    github_repo_url: string | null;
+  };
+  members: RosterRow[];
+  at_risk_threshold: number;
+};
+
+export async function getPodDetail(
+  supabase: SupabaseClient,
+  podId: number
+): Promise<PodDetail | null> {
+  const { data: pod, error: podErr } = await supabase
+    .from("pods")
+    .select(`
+      id, name, status, cycle_id,
+      slack_channel_id, drive_folder_id, github_repo_url,
+      cycles (id, name)
+    `)
+    .eq("id", podId)
+    .single();
+
+  if (podErr || !pod) return null;
+
+  const { data: cfg } = await supabase
+    .from("cycle_config")
+    .select(
+      "problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close, pulse_band_warning_min, pulse_band_critical_min, at_risk_consecutive_misses"
+    )
+    .eq("cycle_id", pod.cycle_id as number)
+    .maybeSingle();
+
+  const phase = cfg ? resolveCurrentPhase(cfg as unknown as CycleConfigPhaseColumns) : null;
+  const atRiskThreshold =
+    (cfg as { at_risk_consecutive_misses?: number } | null)?.at_risk_consecutive_misses ??
+    DEFAULT_AT_RISK_MISSES;
+
+  const { data: memberRows } = await supabase
+    .from("pod_memberships")
+    .select(`
+      participant_id, joined_at, inactive_at,
+      participants (
+        id, first_name, last_name, preferred_name, email,
+        ai_experience_level, availability_snippet
+      )
+    `)
+    .eq("pod_id", podId)
+    .order("joined_at");
+
+  const memberIds = (memberRows ?? []).map((m) => m.participant_id as number);
+
+  let enrollmentsByParticipant = new Map<number, { status: string }>();
+  if (memberIds.length > 0) {
+    const { data: enrolls } = await supabase
+      .from("cycle_enrollments")
+      .select("participant_id, status")
+      .eq("cycle_id", pod.cycle_id as number)
+      .in("participant_id", memberIds);
+    enrollmentsByParticipant = new Map(
+      (enrolls ?? []).map((e) => [e.participant_id as number, { status: e.status as string }])
+    );
+  }
+
+  const fourWeeksAgo = new Date();
+  fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
+
+  type PulseRow = {
+    participant_id: number;
+    scheduled_date: string;
+    completed_at: string | null;
+  };
+  let pulseRows: PulseRow[] = [];
+  if (memberIds.length > 0) {
+    const { data } = await supabase
+      .from("pulse_checks")
+      .select("participant_id, scheduled_date, completed_at")
+      .in("participant_id", memberIds)
+      .eq("cycle_id", pod.cycle_id as number)
+      .gte("scheduled_date", fourWeeksAgo.toISOString().slice(0, 10))
+      .order("scheduled_date");
+    pulseRows = (data ?? []) as PulseRow[];
+  }
+
+  const pulsesByMember = new Map<number, PulseRow[]>();
+  for (const p of pulseRows) {
+    const arr = pulsesByMember.get(p.participant_id) ?? [];
+    arr.push(p);
+    pulsesByMember.set(p.participant_id, arr);
+  }
+
+  const members: RosterRow[] = (memberRows ?? []).map((m) => {
+    const p = (m.participants as unknown) as {
+      id: number;
+      first_name: string;
+      last_name: string;
+      preferred_name: string | null;
+      email: string;
+      ai_experience_level: string;
+      availability_snippet: string | null;
+    } | null;
+
+    const first = p?.preferred_name?.trim() || p?.first_name?.trim() || "?";
+    const lastInitial = p?.last_name ? p.last_name[0].toUpperCase() : "";
+    const display = lastInitial ? `${first} ${lastInitial}.` : first;
+    const initials = `${first[0] ?? "?"}${lastInitial}`.toUpperCase();
+
+    const memberPulses = pulsesByMember.get(m.participant_id as number) ?? [];
+    const status = computePulseStatus(memberPulses, atRiskThreshold);
+    const lastCompleted = memberPulses
+      .filter((q) => q.completed_at)
+      .sort((a, b) => (b.completed_at ?? "").localeCompare(a.completed_at ?? ""))[0];
+
+    const enrollment = enrollmentsByParticipant.get(m.participant_id as number);
+    const isInactive = enrollment?.status === "inactive";
+
+    return {
+      participant_id: m.participant_id as number,
+      initials,
+      display_name: display,
+      ai_experience_level: p?.ai_experience_level ?? "new",
+      availability_snippet: p?.availability_snippet ?? null,
+      email: p?.email ?? null,
+      joined_at: m.joined_at as string,
+      is_inactive: isInactive,
+      inactive_since: m.inactive_at as string | null,
+      pulse_status: status,
+      last_activity_at: lastCompleted?.completed_at ?? null,
+    };
+  });
+
+  // Pod-level pulse-health: only count active members.
+  const activeMemberIds = (memberRows ?? [])
+    .filter((m) => m.inactive_at === null)
+    .map((m) => m.participant_id as number);
+  const activeMemberIdSet = new Set(activeMemberIds);
+  const activePulses = pulseRows.filter((p) => activeMemberIdSet.has(p.participant_id));
+
+  const { missingThisWeek, weeklyRates } = bucketPulses(
+    activePulses,
+    activeMemberIds.length
+  );
+
+  return {
+    id: pod.id as number,
+    name: pod.name as string | null,
+    status: pod.status as string,
+    cycle_id: pod.cycle_id as number,
+    cycle_name:
+      (pod.cycles as unknown as { name: string } | null)?.name ?? null,
+    phase_num: phase?.num ?? null,
+    phase_display_name: phase?.displayName ?? null,
+    phase_short_name: phase?.shortName ?? null,
+    phase_open_at: phase?.openAt ?? null,
+    phase_close_at: phase?.closeAt ?? null,
+    phase_is_active: phase?.isActive ?? false,
+    active_member_count: activeMemberIds.length,
+    missing_this_week: missingThisWeek,
+    band: bandFor(missingThisWeek, cfg as unknown as PulseHealthCfg | null),
+    trend: trendOver3Weeks(weeklyRates),
+    resources: {
+      slack_channel_id: pod.slack_channel_id as string | null,
+      drive_folder_id: pod.drive_folder_id as string | null,
+      github_repo_url: pod.github_repo_url as string | null,
+    },
+    members,
+    at_risk_threshold: atRiskThreshold,
+  };
+}
+
+/** Determine the engagement bucket from a member's recent pulses. */
+function computePulseStatus(
+  pulses: { scheduled_date: string; completed_at: string | null }[],
+  atRiskThreshold: number
+): PulseStatus {
+  if (pulses.length === 0) return "pending";
+
+  const sorted = [...pulses].sort((a, b) =>
+    b.scheduled_date.localeCompare(a.scheduled_date)
+  );
+
+  let consecutiveMisses = 0;
+  for (const p of sorted) {
+    if (p.completed_at) break;
+    consecutiveMisses += 1;
+  }
+  if (consecutiveMisses >= atRiskThreshold) return "at_risk";
+
+  const mostRecent = sorted[0];
+  if (mostRecent.completed_at) return "current";
+
+  const scheduledMs = new Date(mostRecent.scheduled_date).getTime();
+  const ageDays = (Date.now() - scheduledMs) / 86_400_000;
+  return ageDays > 7 ? "late" : "pending";
+}
+
+/** Bucket pulse rows into weeks. */
+function bucketPulses(
+  rows: { participant_id: number; scheduled_date: string; completed_at: string | null }[],
+  activeCount: number
+): { missingThisWeek: number; weeklyRates: number[] } {
+  if (rows.length === 0 || activeCount === 0) {
+    return { missingThisWeek: 0, weeklyRates: [] };
+  }
+  const byWeek = new Map<string, { completed: number; total: number }>();
+  for (const r of rows) {
+    const bucket = byWeek.get(r.scheduled_date) ?? { completed: 0, total: 0 };
+    bucket.total += 1;
+    if (r.completed_at) bucket.completed += 1;
+    byWeek.set(r.scheduled_date, bucket);
+  }
+  const weekKeys = Array.from(byWeek.keys()).sort();
+  const weeklyRates = weekKeys.map((k) => {
+    const b = byWeek.get(k)!;
+    return b.total === 0 ? 0 : b.completed / b.total;
+  });
+  const latestKey = weekKeys[weekKeys.length - 1];
+  const latest = byWeek.get(latestKey)!;
+  const missingThisWeek = Math.max(0, activeCount - latest.completed);
+  return { missingThisWeek, weeklyRates };
+}

--- a/lib/moderator/pod-detail.ts
+++ b/lib/moderator/pod-detail.ts
@@ -19,6 +19,7 @@ import {
   type Trend,
   type PulseHealthCfg,
 } from "./pulse-health";
+import { atRiskNudgeKey, deriveAtRiskRun, loadDismissedKeys, isDismissed } from "./nudges";
 
 const DEFAULT_AT_RISK_MISSES = 2;
 
@@ -36,6 +37,13 @@ export type RosterRow = {
   inactive_since: string | null;
   pulse_status: PulseStatus;
   last_activity_at: string | null;
+  /**
+   * Nudge instance key for at-risk members. Null when not at-risk.
+   * Re-fires when the consecutive-miss run starts over after a recovery.
+   */
+  nudge_key: string | null;
+  /** True when the caller (poderator) has dismissed this specific nudge. */
+  nudge_dismissed: boolean;
 };
 
 export type PodDetail = {
@@ -65,7 +73,9 @@ export type PodDetail = {
 
 export async function getPodDetail(
   supabase: SupabaseClient,
-  podId: number
+  podId: number,
+  /** Caller's participant id; used to load their nudge dismissals. */
+  callerParticipantId: number | null = null
 ): Promise<PodDetail | null> {
   const { data: pod, error: podErr } = await supabase
     .from("pods")
@@ -145,6 +155,9 @@ export async function getPodDetail(
     pulsesByMember.set(p.participant_id, arr);
   }
 
+  // Load this poderator's nudge dismissals for this pod.
+  const dismissedKeys = await loadDismissedKeys(supabase, callerParticipantId, [podId]);
+
   const members: RosterRow[] = (memberRows ?? []).map((m) => {
     const p = (m.participants as unknown) as {
       id: number;
@@ -170,6 +183,19 @@ export async function getPodDetail(
     const enrollment = enrollmentsByParticipant.get(m.participant_id as number);
     const isInactive = enrollment?.status === "inactive";
 
+    // For at-risk members, derive the nudge_key from the current
+    // consecutive-miss run so re-trips after recovery produce a fresh
+    // key the dismissal table hasn't seen.
+    let nudge_key: string | null = null;
+    let nudge_dismissed = false;
+    if (status === "at_risk") {
+      const run = deriveAtRiskRun(m.participant_id as number, memberPulses);
+      if (run) {
+        nudge_key = atRiskNudgeKey(run);
+        nudge_dismissed = isDismissed(dismissedKeys, podId, nudge_key);
+      }
+    }
+
     return {
       participant_id: m.participant_id as number,
       initials,
@@ -182,6 +208,8 @@ export async function getPodDetail(
       inactive_since: m.inactive_at as string | null,
       pulse_status: status,
       last_activity_at: lastCompleted?.completed_at ?? null,
+      nudge_key,
+      nudge_dismissed,
     };
   });
 

--- a/lib/moderator/pod-detail.ts
+++ b/lib/moderator/pod-detail.ts
@@ -44,6 +44,20 @@ export type RosterRow = {
   nudge_key: string | null;
   /** True when the caller (poderator) has dismissed this specific nudge. */
   nudge_dismissed: boolean;
+  /**
+   * Current consecutive-submitted pulse streak, computed from most recent
+   * scheduled date walking back until a missed pulse. Zero when the most
+   * recent pulse was missed (or no pulses yet). Surfaced as a 🔥 badge
+   * in the roster.
+   */
+  streak: number;
+  /**
+   * True when consecutive misses == at_risk_threshold - 1 AND status is
+   * not yet at_risk. Early warning: one more miss flips this member to
+   * at_risk and a nudge card appears. Surfaced as a "trending" pill on
+   * the roster row.
+   */
+  is_trending_at_risk: boolean;
 };
 
 export type PodDetail = {
@@ -176,6 +190,12 @@ export async function getPodDetail(
 
     const memberPulses = pulsesByMember.get(m.participant_id as number) ?? [];
     const status = computePulseStatus(memberPulses, atRiskThreshold);
+    const streak = computeStreak(memberPulses);
+    const consecutiveMisses = countConsecutiveMisses(memberPulses);
+    const isTrendingAtRisk =
+      status !== "at_risk" &&
+      atRiskThreshold > 1 &&
+      consecutiveMisses === atRiskThreshold - 1;
     const lastCompleted = memberPulses
       .filter((q) => q.completed_at)
       .sort((a, b) => (b.completed_at ?? "").localeCompare(a.completed_at ?? ""))[0];
@@ -210,6 +230,8 @@ export async function getPodDetail(
       last_activity_at: lastCompleted?.completed_at ?? null,
       nudge_key,
       nudge_dismissed,
+      streak,
+      is_trending_at_risk: isTrendingAtRisk,
     };
   });
 
@@ -276,6 +298,51 @@ function computePulseStatus(
   const scheduledMs = new Date(mostRecent.scheduled_date).getTime();
   const ageDays = (Date.now() - scheduledMs) / 86_400_000;
   return ageDays > 7 ? "late" : "pending";
+}
+
+/**
+ * Count consecutive submitted pulses from the most recent scheduled date
+ * walking back. Stops at the first missed pulse. Returns 0 when the most
+ * recent pulse was missed or when there are no pulses.
+ *
+ * Note: this only sees the 4-week window pulled by getPodDetail, so a
+ * streak older than 4 weeks reads as 4. Good enough for the roster
+ * badge; the side panel has the full-cycle trajectory if precise streak
+ * length matters.
+ */
+function computeStreak(
+  pulses: { scheduled_date: string; completed_at: string | null }[]
+): number {
+  if (pulses.length === 0) return 0;
+  const sorted = [...pulses].sort((a, b) =>
+    b.scheduled_date.localeCompare(a.scheduled_date)
+  );
+  let n = 0;
+  for (const p of sorted) {
+    if (!p.completed_at) break;
+    n += 1;
+  }
+  return n;
+}
+
+/**
+ * Count consecutive missed pulses from the most recent scheduled date
+ * walking back. Mirrors computeStreak but for misses; powers the
+ * is_trending_at_risk early-warning flag.
+ */
+function countConsecutiveMisses(
+  pulses: { scheduled_date: string; completed_at: string | null }[]
+): number {
+  if (pulses.length === 0) return 0;
+  const sorted = [...pulses].sort((a, b) =>
+    b.scheduled_date.localeCompare(a.scheduled_date)
+  );
+  let n = 0;
+  for (const p of sorted) {
+    if (p.completed_at) break;
+    n += 1;
+  }
+  return n;
 }
 
 /** Bucket pulse rows into weeks. */

--- a/lib/moderator/pod-insights.ts
+++ b/lib/moderator/pod-insights.ts
@@ -1,0 +1,192 @@
+/**
+ * Pod-level pulse insights (PRD §7.9.2).
+ *
+ * Renders between the member roster (§7.3) and phase guidance (§7.5)
+ * on the per-pod dashboard. Scoped to one pod.
+ *
+ * Two metrics:
+ *   - Top AI tools across the pod: up to 5, ordered by member count
+ *     (one heavy user doesn't dominate). Members named the tool in at
+ *     least one pulse_check.survey_responses.tools_used array.
+ *   - Weekly completion trend: per-week submitted / scheduled rate.
+ *
+ * Range is caller-controlled: 4-week default, or null = full cycle.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type PodToolCount = {
+  tool: string;
+  members: number;
+};
+
+export type WeeklyCompletion = {
+  scheduled_date: string;
+  completed: number;
+  total: number;
+  rate: number;
+};
+
+export type PodInsights = {
+  range: "4w" | "full";
+  topTools: PodToolCount[];
+  weekly: WeeklyCompletion[];
+  /** Sample of recent free-text pulse comments — feeds the §7.10.3 bundle. */
+  recentComments: PulseComment[];
+};
+
+export type PulseComment = {
+  initials: string;
+  participant_id: number;
+  scheduled_date: string;
+  /** Concatenated free-text fields from survey_responses (no field labels). */
+  text: string;
+};
+
+const TOP_N_TOOLS = 5;
+const FREE_TEXT_FIELDS = [
+  "accomplishment",
+  "highlight",
+  "challenge",
+  "blockers",
+  "tailwinds",
+  "mitigation_strategy",
+  "anything_else",
+] as const;
+
+export async function getPodInsights(
+  supabase: SupabaseClient,
+  podId: number,
+  range: "4w" | "full"
+): Promise<PodInsights | null> {
+  const { data: pod } = await supabase
+    .from("pods")
+    .select("id, cycle_id")
+    .eq("id", podId)
+    .maybeSingle();
+  if (!pod) return null;
+  const cycleId = pod.cycle_id as number;
+
+  const { data: memberRows } = await supabase
+    .from("pod_memberships")
+    .select(`
+      participant_id,
+      participants ( first_name, last_name, preferred_name )
+    `)
+    .eq("pod_id", podId)
+    .is("inactive_at", null);
+
+  const memberIds = (memberRows ?? []).map((m) => m.participant_id as number);
+  const memberInitials = new Map<number, string>();
+  for (const m of memberRows ?? []) {
+    const p = (m.participants as unknown) as {
+      first_name?: string;
+      last_name?: string;
+      preferred_name?: string | null;
+    } | null;
+    const first = (p?.preferred_name?.trim() || p?.first_name?.trim() || "?")[0];
+    const last = p?.last_name?.[0] ?? "";
+    memberInitials.set(
+      m.participant_id as number,
+      `${first}${last}`.toUpperCase()
+    );
+  }
+
+  let pulseRows: {
+    participant_id: number;
+    scheduled_date: string;
+    completed_at: string | null;
+    survey_responses: Record<string, unknown> | null;
+  }[] = [];
+
+  if (memberIds.length > 0) {
+    const query = supabase
+      .from("pulse_checks")
+      .select(
+        "participant_id, scheduled_date, completed_at, survey_responses"
+      )
+      .in("participant_id", memberIds)
+      .eq("cycle_id", cycleId)
+      .order("scheduled_date");
+
+    if (range === "4w") {
+      const fourWeeksAgo = new Date();
+      fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
+      query.gte("scheduled_date", fourWeeksAgo.toISOString().slice(0, 10));
+    }
+
+    const { data } = await query;
+    pulseRows = (data ?? []) as typeof pulseRows;
+  }
+
+  // Top AI tools by distinct-member count.
+  const toolMembers = new Map<string, Set<number>>();
+  for (const p of pulseRows) {
+    if (!p.completed_at || !p.survey_responses) continue;
+    const tools = (p.survey_responses as { tools_used?: unknown }).tools_used;
+    if (!Array.isArray(tools)) continue;
+    for (const t of tools) {
+      if (typeof t !== "string") continue;
+      const trimmed = t.trim();
+      if (!trimmed) continue;
+      const set = toolMembers.get(trimmed) ?? new Set<number>();
+      set.add(p.participant_id);
+      toolMembers.set(trimmed, set);
+    }
+  }
+  const topTools: PodToolCount[] = Array.from(toolMembers.entries())
+    .map(([tool, set]) => ({ tool, members: set.size }))
+    .sort((a, b) => b.members - a.members || a.tool.localeCompare(b.tool))
+    .slice(0, TOP_N_TOOLS);
+
+  // Weekly completion: bucket per scheduled_date.
+  const byWeek = new Map<string, { completed: number; total: number }>();
+  for (const p of pulseRows) {
+    const bucket = byWeek.get(p.scheduled_date) ?? { completed: 0, total: 0 };
+    bucket.total += 1;
+    if (p.completed_at) bucket.completed += 1;
+    byWeek.set(p.scheduled_date, bucket);
+  }
+  const weekly: WeeklyCompletion[] = Array.from(byWeek.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([scheduled_date, b]) => ({
+      scheduled_date,
+      completed: b.completed,
+      total: b.total,
+      rate: b.total === 0 ? 0 : b.completed / b.total,
+    }));
+
+  // Recent comments for §7.10.3 bundle. Most recent 24 completed pulses
+  // with at least one free-text field, newest first.
+  const recentComments: PulseComment[] = [];
+  const sortedDesc = [...pulseRows]
+    .filter((p) => p.completed_at)
+    .sort((a, b) =>
+      b.scheduled_date.localeCompare(a.scheduled_date) ||
+      (b.completed_at ?? "").localeCompare(a.completed_at ?? "")
+    );
+  for (const p of sortedDesc) {
+    if (recentComments.length >= 24) break;
+    const text = collectFreeText(p.survey_responses);
+    if (!text) continue;
+    recentComments.push({
+      initials: memberInitials.get(p.participant_id) ?? "??",
+      participant_id: p.participant_id,
+      scheduled_date: p.scheduled_date,
+      text,
+    });
+  }
+
+  return { range, topTools, weekly, recentComments };
+}
+
+function collectFreeText(
+  sr: Record<string, unknown> | null
+): string {
+  if (!sr) return "";
+  const parts: string[] = [];
+  for (const key of FREE_TEXT_FIELDS) {
+    const v = sr[key];
+    if (typeof v === "string" && v.trim()) parts.push(v.trim());
+  }
+  return parts.join(" · ");
+}

--- a/lib/moderator/pod-insights.ts
+++ b/lib/moderator/pod-insights.ts
@@ -26,10 +26,36 @@ export type WeeklyCompletion = {
   rate: number;
 };
 
+/**
+ * Per-week average free-text length across submitted pulses. Engagement
+ * proxy — a pod going from paragraphs to one-liners is disengaging.
+ * `avgChars` is rounded to the nearest integer; `samples` is the count
+ * of submitted pulses with any free text in that week (zero-length
+ * responses are excluded so they don't drag the average to zero).
+ */
+export type WeeklyDepth = {
+  scheduled_date: string;
+  avgChars: number;
+  samples: number;
+};
+
+/**
+ * Per-week count of submitted pulses mentioning blockers vs tailwinds.
+ * A pulse counts in both buckets if it has both fields. Surfaced as a
+ * morale gauge — higher tailwinds:blockers suggests momentum.
+ */
+export type WeeklySentiment = {
+  scheduled_date: string;
+  tailwinds: number;
+  blockers: number;
+};
+
 export type PodInsights = {
   range: "4w" | "full";
   topTools: PodToolCount[];
   weekly: WeeklyCompletion[];
+  depth: WeeklyDepth[];
+  sentiment: WeeklySentiment[];
   /** Sample of recent free-text pulse comments — feeds the §7.10.3 bundle. */
   recentComments: PulseComment[];
 };
@@ -155,6 +181,47 @@ export async function getPodInsights(
       rate: b.total === 0 ? 0 : b.completed / b.total,
     }));
 
+  // Weekly response depth + sentiment (blockers vs tailwinds).
+  const depthByWeek = new Map<string, { chars: number; samples: number }>();
+  const sentimentByWeek = new Map<
+    string,
+    { tailwinds: number; blockers: number }
+  >();
+  for (const p of pulseRows) {
+    if (!p.completed_at) continue;
+    const text = collectFreeText(p.survey_responses);
+    if (text.length > 0) {
+      const d = depthByWeek.get(p.scheduled_date) ?? { chars: 0, samples: 0 };
+      d.chars += text.length;
+      d.samples += 1;
+      depthByWeek.set(p.scheduled_date, d);
+    }
+    const sr = p.survey_responses ?? {};
+    const hasTail = nonEmptyString((sr as Record<string, unknown>).tailwinds);
+    const hasBlk = nonEmptyString((sr as Record<string, unknown>).blockers);
+    if (hasTail || hasBlk) {
+      const s =
+        sentimentByWeek.get(p.scheduled_date) ?? { tailwinds: 0, blockers: 0 };
+      if (hasTail) s.tailwinds += 1;
+      if (hasBlk) s.blockers += 1;
+      sentimentByWeek.set(p.scheduled_date, s);
+    }
+  }
+  const depth: WeeklyDepth[] = Array.from(depthByWeek.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([scheduled_date, d]) => ({
+      scheduled_date,
+      avgChars: Math.round(d.chars / d.samples),
+      samples: d.samples,
+    }));
+  const sentiment: WeeklySentiment[] = Array.from(sentimentByWeek.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([scheduled_date, s]) => ({
+      scheduled_date,
+      tailwinds: s.tailwinds,
+      blockers: s.blockers,
+    }));
+
   // Recent comments for §7.10.3 bundle. Most recent 24 completed pulses
   // with at least one free-text field, newest first.
   const recentComments: PulseComment[] = [];
@@ -176,7 +243,11 @@ export async function getPodInsights(
     });
   }
 
-  return { range, topTools, weekly, recentComments };
+  return { range, topTools, weekly, depth, sentiment, recentComments };
+}
+
+function nonEmptyString(v: unknown): boolean {
+  return typeof v === "string" && v.trim().length > 0;
 }
 
 function collectFreeText(

--- a/lib/moderator/pods-list.ts
+++ b/lib/moderator/pods-list.ts
@@ -1,0 +1,227 @@
+/**
+ * Pods-list query for the All pods view (PRD §7.10.1).
+ *
+ * Shared between the RSC `app/(dashboard)/moderator/page.tsx` and the
+ * REST endpoint `GET /api/moderator/pods` so both surfaces use identical
+ * pod selection, pulse-health computation, and sort order.
+ *
+ * Scope is determined by `user`:
+ *   - admin / owner  → every pod
+ *   - moderator      → pods with an active `moderator_assignments` row
+ *
+ * The pulse query is cycle-scoped to prevent cross-cycle leak when a
+ * participant is enrolled in multiple cycles.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { isAdmin, type UserRoles } from "@/lib/auth/roles";
+import { resolveCurrentPhase, type CycleConfigPhaseColumns } from "./phase";
+import {
+  bandFor,
+  trendOver3Weeks,
+  type Band,
+  type Trend,
+  type PulseHealthCfg,
+} from "./pulse-health";
+
+export type PodCard = {
+  id: number;
+  name: string | null;
+  status: string;
+  cycle_id: number;
+  cycle_name: string | null;
+  phase_num: number | null;
+  phase_display_name: string | null;
+  phase_open_at: string | null;
+  phase_close_at: string | null;
+  active_member_count: number;
+  missing_this_week: number;
+  band: Band;
+  trend: Trend;
+};
+
+/**
+ * Resolve which pods the user can see for the All pods view.
+ * Returns admin scope (all pods) when the user has `cycles:write`,
+ * otherwise their `moderator_assignments` set.
+ */
+async function resolveAccessiblePodIds(
+  supabase: SupabaseClient,
+  user: UserRoles
+): Promise<number[]> {
+  if (isAdmin(user)) {
+    const { data } = await supabase
+      .from("pods")
+      .select("id")
+      .order("created_at", { ascending: false });
+    return (data ?? []).map((r) => r.id as number);
+  }
+  if (!user.participantId) return [];
+  // moderatorPodIds is already resolved on `user`, but re-query so this
+  // helper is self-contained and the API caller doesn't need to thread
+  // pre-resolved state through.
+  const { data } = await supabase
+    .from("moderator_assignments")
+    .select("pod_id")
+    .eq("participant_id", user.participantId)
+    .is("removed_at", null);
+  return (data ?? []).map((r) => r.pod_id as number);
+}
+
+/**
+ * Build the All pods view cards for `user`. Empty array when the user
+ * has no accessible pods (e.g. moderator with no assignments).
+ */
+export async function getPodsForUser(
+  supabase: SupabaseClient,
+  user: UserRoles
+): Promise<PodCard[]> {
+  const podIds = await resolveAccessiblePodIds(supabase, user);
+  if (podIds.length === 0) return [];
+
+  // Pods + cycle metadata.
+  const { data: podRows } = await supabase
+    .from("pods")
+    .select("id, name, status, cycle_id, cycles (id, name)")
+    .in("id", podIds);
+
+  if (!podRows || podRows.length === 0) return [];
+
+  const cycleIds = Array.from(new Set(podRows.map((p) => p.cycle_id as number)));
+
+  // Cycle configs (phase windows + pulse-health thresholds).
+  const { data: configRows } = await supabase
+    .from("cycle_config")
+    .select(
+      "cycle_id, problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close, pulse_band_warning_min, pulse_band_critical_min"
+    )
+    .in("cycle_id", cycleIds);
+
+  const configByCycle = new Map<number, CycleConfigPhaseColumns & PulseHealthCfg>();
+  for (const row of configRows ?? []) {
+    configByCycle.set(row.cycle_id as number, row as CycleConfigPhaseColumns & PulseHealthCfg);
+  }
+
+  // Active memberships per pod.
+  const { data: membershipRows } = await supabase
+    .from("pod_memberships")
+    .select("pod_id, participant_id")
+    .in("pod_id", podIds)
+    .is("inactive_at", null);
+
+  const membersByPod = new Map<number, number[]>();
+  for (const m of membershipRows ?? []) {
+    const arr = membersByPod.get(m.pod_id as number) ?? [];
+    arr.push(m.participant_id as number);
+    membersByPod.set(m.pod_id as number, arr);
+  }
+
+  // Last 3 weeks of pulse data for trend + missing-this-week.
+  const threeWeeksAgo = new Date();
+  threeWeeksAgo.setDate(threeWeeksAgo.getDate() - 21);
+
+  const allParticipantIds = Array.from(
+    new Set(Array.from(membersByPod.values()).flat())
+  );
+
+  let pulseRows: {
+    participant_id: number;
+    cycle_id: number;
+    scheduled_date: string;
+    completed_at: string | null;
+  }[] = [];
+  if (allParticipantIds.length > 0 && cycleIds.length > 0) {
+    const { data } = await supabase
+      .from("pulse_checks")
+      .select("participant_id, cycle_id, scheduled_date, completed_at")
+      .in("participant_id", allParticipantIds)
+      .in("cycle_id", cycleIds)
+      .gte("scheduled_date", threeWeeksAgo.toISOString().slice(0, 10));
+    pulseRows = (data ?? []) as typeof pulseRows;
+  }
+
+  // Compose cards.
+  const cards: PodCard[] = podRows.map((pod) => {
+    const cfg = configByCycle.get(pod.cycle_id as number) ?? null;
+    const phase = cfg ? resolveCurrentPhase(cfg) : null;
+    const memberIds = membersByPod.get(pod.id as number) ?? [];
+    const memberIdSet = new Set(memberIds);
+
+    const podPulses = pulseRows.filter(
+      (p) => p.cycle_id === pod.cycle_id && memberIdSet.has(p.participant_id)
+    );
+    const { missingThisWeek, weeklyRates } = computeWeeklyRates(
+      podPulses,
+      memberIds.length
+    );
+
+    const cycleName =
+      (pod.cycles as unknown as { name: string } | null)?.name ?? null;
+
+    return {
+      id: pod.id as number,
+      name: pod.name as string | null,
+      status: pod.status as string,
+      cycle_id: pod.cycle_id as number,
+      cycle_name: cycleName,
+      phase_num: phase?.num ?? null,
+      phase_display_name: phase?.displayName ?? null,
+      phase_open_at: phase?.openAt ?? null,
+      phase_close_at: phase?.closeAt ?? null,
+      active_member_count: memberIds.length,
+      missing_this_week: missingThisWeek,
+      band: bandFor(missingThisWeek, cfg),
+      trend: trendOver3Weeks(weeklyRates),
+    };
+  });
+
+  // Sort: pods with non-zero missing first, then descending by missing,
+  // then alphabetical by name (PRD §7.10.1).
+  cards.sort((a, b) => {
+    if ((a.missing_this_week > 0) !== (b.missing_this_week > 0)) {
+      return a.missing_this_week > 0 ? -1 : 1;
+    }
+    if (a.missing_this_week !== b.missing_this_week) {
+      return b.missing_this_week - a.missing_this_week;
+    }
+    return (a.name ?? "").localeCompare(b.name ?? "");
+  });
+
+  return cards;
+}
+
+/**
+ * Buckets pulse rows into weeks (using scheduled_date) and returns
+ * { missingThisWeek, weeklyRates } where weeklyRates is the completion
+ * rate (0..1) per week, oldest first.
+ *
+ * "This week" = the most recent week with at least one scheduled pulse
+ * row for this pod's members.
+ */
+function computeWeeklyRates(
+  rows: { scheduled_date: string; completed_at: string | null }[],
+  activeCount: number
+): { missingThisWeek: number; weeklyRates: number[] } {
+  if (rows.length === 0 || activeCount === 0) {
+    return { missingThisWeek: 0, weeklyRates: [] };
+  }
+
+  const byWeek = new Map<string, { completed: number; total: number }>();
+  for (const r of rows) {
+    const bucket = byWeek.get(r.scheduled_date) ?? { completed: 0, total: 0 };
+    bucket.total += 1;
+    if (r.completed_at) bucket.completed += 1;
+    byWeek.set(r.scheduled_date, bucket);
+  }
+
+  const weekKeys = Array.from(byWeek.keys()).sort();
+  const weeklyRates = weekKeys.map((k) => {
+    const b = byWeek.get(k)!;
+    return b.total === 0 ? 0 : b.completed / b.total;
+  });
+
+  const latestKey = weekKeys[weekKeys.length - 1];
+  const latest = byWeek.get(latestKey)!;
+  const missingThisWeek = Math.max(0, activeCount - latest.completed);
+
+  return { missingThisWeek, weeklyRates };
+}

--- a/lib/moderator/pulse-health.ts
+++ b/lib/moderator/pulse-health.ts
@@ -1,0 +1,59 @@
+/**
+ * Pod-health indicator helpers (PRD §7.1).
+ *
+ * Two responsibilities:
+ *   1. `bandFor(missing, cfg)` — classifies a missing-pulse count into
+ *      one of three bands (healthy / warning / critical) using the
+ *      cycle's configured thresholds.
+ *   2. `trendOver3Weeks(...)` — computes a ↑ / ↓ / → arrow from the
+ *      last three weeks of pulse-completion rates.
+ *
+ * Thresholds are absolute headcount (PRD §10 decision) and live on
+ * cycle_config (added in migration 00026). Global defaults apply when a
+ * cycle's row predates the migration or doesn't override.
+ */
+
+export type Band = "healthy" | "warning" | "critical";
+export type Trend = "up" | "down" | "flat";
+
+export interface PulseHealthCfg {
+  /** Min count to switch from healthy → warning. Default 1. */
+  pulse_band_warning_min: number | null;
+  /** Min count to switch from warning → critical. Default 3. */
+  pulse_band_critical_min: number | null;
+}
+
+const DEFAULT_WARNING_MIN = 1;
+const DEFAULT_CRITICAL_MIN = 3;
+
+export function bandFor(missing: number, cfg: PulseHealthCfg | null): Band {
+  const warningMin = cfg?.pulse_band_warning_min ?? DEFAULT_WARNING_MIN;
+  const criticalMin = cfg?.pulse_band_critical_min ?? DEFAULT_CRITICAL_MIN;
+  if (missing >= criticalMin) return "critical";
+  if (missing >= warningMin) return "warning";
+  return "healthy";
+}
+
+/**
+ * Trend over the most recent three weeks, comparing this week's
+ * completion rate against the average of the prior two weeks.
+ *
+ * `rates` is week-by-week pulse-completion percentage (0..1), oldest
+ * first. Need at least two weeks of data for a real trend; fewer than
+ * two returns "flat".
+ *
+ * The tolerance (default 5pp) absorbs tiny week-over-week jitter so the
+ * arrow doesn't flip on noise.
+ */
+export function trendOver3Weeks(
+  rates: number[],
+  tolerance: number = 0.05
+): Trend {
+  if (rates.length < 2) return "flat";
+  const current = rates[rates.length - 1];
+  const prior = rates.slice(-3, -1);
+  const priorAvg = prior.reduce((s, r) => s + r, 0) / prior.length;
+  const delta = current - priorAvg;
+  if (Math.abs(delta) <= tolerance) return "flat";
+  return delta > 0 ? "up" : "down";
+}

--- a/lib/moderator/pulse-responses.ts
+++ b/lib/moderator/pulse-responses.ts
@@ -1,0 +1,126 @@
+/**
+ * Per-member pulse history + individual aggregation (PRD §7.4, §7.9.1).
+ *
+ * Backs the pulse review side panel. Two-part payload:
+ *   - `aggregate` (§7.9.1) — full-cycle: top AI tools + engagement
+ *     trajectory dot row. Always full cycle regardless of the response
+ *     stream range (per PRD §7.4).
+ *   - `responses` — per-pulse rows (scheduled_date, completed_at, the
+ *     survey_responses JSON). Most recent first.
+ *
+ * Pod-mate verification: the participant must be (or have been) a
+ * member of the pod the caller scoped the query to. Without this check
+ * an assigned poderator could read any participant's pulses by
+ * URL-manipulating the participant_id.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type PulseResponse = {
+  scheduled_date: string;
+  completed_at: string | null;
+  survey_responses: Record<string, unknown> | null;
+};
+
+export type TrajectoryDot = {
+  scheduled_date: string;
+  submitted: boolean;
+};
+
+export type ToolCount = {
+  tool: string;
+  count: number;
+};
+
+export type IndividualAggregate = {
+  topTools: ToolCount[];
+  trajectory: TrajectoryDot[];
+};
+
+export type PulseHistoryPayload = {
+  participantId: number;
+  cycleId: number;
+  aggregate: IndividualAggregate;
+  responses: PulseResponse[];
+};
+
+const TOP_N_TOOLS = 5;
+
+export async function getMemberPulseHistory(
+  supabase: SupabaseClient,
+  podId: number,
+  participantId: number
+): Promise<PulseHistoryPayload | { error: "not-pod-member" | "pod-not-found" }> {
+  // 1. Resolve the pod's cycle.
+  const { data: pod } = await supabase
+    .from("pods")
+    .select("id, cycle_id")
+    .eq("id", podId)
+    .maybeSingle();
+  if (!pod) return { error: "pod-not-found" };
+  const cycleId = pod.cycle_id as number;
+
+  // 2. Verify membership in this pod (any historical row — includes
+  //    inactive members so the side panel can render for them too).
+  const { data: membership } = await supabase
+    .from("pod_memberships")
+    .select("id")
+    .eq("pod_id", podId)
+    .eq("participant_id", participantId)
+    .maybeSingle();
+  if (!membership) return { error: "not-pod-member" };
+
+  // 3. Pull pulses for the participant in this pod's cycle.
+  const { data: pulseRows } = await supabase
+    .from("pulse_checks")
+    .select("scheduled_date, completed_at, survey_responses")
+    .eq("participant_id", participantId)
+    .eq("cycle_id", cycleId)
+    .order("scheduled_date", { ascending: false });
+
+  const responses = (pulseRows ?? []) as PulseResponse[];
+
+  // 4. Build aggregate.
+  const aggregate = buildAggregate(responses);
+
+  return {
+    participantId,
+    cycleId,
+    aggregate,
+    responses,
+  };
+}
+
+function buildAggregate(responses: PulseResponse[]): IndividualAggregate {
+  // Trajectory: oldest → newest for the dot row.
+  const trajectory: TrajectoryDot[] = [...responses]
+    .reverse()
+    .map((r) => ({
+      scheduled_date: r.scheduled_date,
+      submitted: r.completed_at !== null,
+    }));
+
+  // Tool counts: tools_used is a string[] on survey_responses (see
+  // lib/validations/pulse-checks.ts). Count one mention per pulse per
+  // tool — repeats within the same pulse don't double-count.
+  const counts = new Map<string, number>();
+  for (const r of responses) {
+    if (!r.completed_at || !r.survey_responses) continue;
+    const tools = (r.survey_responses as { tools_used?: unknown }).tools_used;
+    if (!Array.isArray(tools)) continue;
+    const seenInPulse = new Set<string>();
+    for (const t of tools) {
+      if (typeof t !== "string") continue;
+      const trimmed = t.trim();
+      if (!trimmed || seenInPulse.has(trimmed)) continue;
+      seenInPulse.add(trimmed);
+      counts.set(trimmed, (counts.get(trimmed) ?? 0) + 1);
+    }
+  }
+
+  const topTools: ToolCount[] = Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, TOP_N_TOOLS)
+    .map(([tool, count]) => ({ tool, count }));
+
+  return { topTools, trajectory };
+}

--- a/lib/moderator/recent-pulses.ts
+++ b/lib/moderator/recent-pulses.ts
@@ -1,0 +1,139 @@
+/**
+ * Recent pulses across a pod — feed view (PRD §7.4 read-only).
+ *
+ * Backs the "Recent pulses" tab on the per-pod page. Returns the most
+ * recent submitted pulses across all members of the pod, newest first,
+ * with the full survey_responses payload so the feed can render each
+ * response inline (no per-row fetch).
+ *
+ * Auth is enforced at the route layer (same `requireModeratorForPod`
+ * guard as the other /api/moderator/pods/* routes); this helper does NOT
+ * check authorization.
+ *
+ * Pagination is cursor-based on `completed_at`: pass the oldest
+ * completed_at from the previous page back as `before` to load older.
+ * Page size is bounded so a single request never explodes the response.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const RECENT_PULSES_PAGE_SIZE = 20;
+export const RECENT_PULSES_MAX_PAGE_SIZE = 50;
+
+export type RecentPulse = {
+  participant_id: number;
+  display_name: string;
+  initials: string;
+  scheduled_date: string;
+  completed_at: string;
+  survey_responses: Record<string, unknown> | null;
+};
+
+export type RecentPulsesPayload = {
+  podId: number;
+  cycleId: number;
+  pulses: RecentPulse[];
+  /**
+   * ISO timestamp of the oldest pulse in this page; pass back as `before`
+   * to load the next (older) page. Null when there are no more pages.
+   */
+  nextCursor: string | null;
+};
+
+export async function getRecentPulses(
+  supabase: SupabaseClient,
+  podId: number,
+  options: { before?: string | null; limit?: number } = {}
+): Promise<RecentPulsesPayload | { error: "pod-not-found" }> {
+  const limit = Math.min(
+    Math.max(1, options.limit ?? RECENT_PULSES_PAGE_SIZE),
+    RECENT_PULSES_MAX_PAGE_SIZE
+  );
+
+  // 1. Resolve cycle from the pod.
+  const { data: pod } = await supabase
+    .from("pods")
+    .select("id, cycle_id")
+    .eq("id", podId)
+    .maybeSingle();
+  if (!pod) return { error: "pod-not-found" };
+  const cycleId = pod.cycle_id as number;
+
+  // 2. Pod members (current or historical — we still want to show pulses
+  //    from members who later left, so the feed is a complete record).
+  const { data: memberRows } = await supabase
+    .from("pod_memberships")
+    .select(`
+      participant_id,
+      participants ( id, first_name, last_name, preferred_name )
+    `)
+    .eq("pod_id", podId);
+
+  const memberIds = (memberRows ?? []).map((m) => m.participant_id as number);
+  if (memberIds.length === 0) {
+    return { podId, cycleId, pulses: [], nextCursor: null };
+  }
+
+  const nameByParticipant = new Map<
+    number,
+    { display_name: string; initials: string }
+  >();
+  for (const m of memberRows ?? []) {
+    const p = (m.participants as unknown) as {
+      first_name: string;
+      last_name: string;
+      preferred_name: string | null;
+    } | null;
+    const first = p?.preferred_name?.trim() || p?.first_name?.trim() || "?";
+    const lastInitial = p?.last_name ? p.last_name[0].toUpperCase() : "";
+    const display = lastInitial ? `${first} ${lastInitial}.` : first;
+    const initials = `${first[0] ?? "?"}${lastInitial}`.toUpperCase();
+    nameByParticipant.set(m.participant_id as number, {
+      display_name: display,
+      initials,
+    });
+  }
+
+  // 3. Pull submitted pulses across the pod, newest first. Fetch limit+1
+  //    so we can determine if there's a next page without a count query.
+  let query = supabase
+    .from("pulse_checks")
+    .select("participant_id, scheduled_date, completed_at, survey_responses")
+    .in("participant_id", memberIds)
+    .eq("cycle_id", cycleId)
+    .not("completed_at", "is", null)
+    .order("completed_at", { ascending: false })
+    .limit(limit + 1);
+
+  if (options.before) {
+    query = query.lt("completed_at", options.before);
+  }
+
+  const { data: pulseRows } = await query;
+  const rows = (pulseRows ?? []) as Array<{
+    participant_id: number;
+    scheduled_date: string;
+    completed_at: string;
+    survey_responses: Record<string, unknown> | null;
+  }>;
+
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor = hasMore ? page[page.length - 1].completed_at : null;
+
+  const pulses: RecentPulse[] = page.map((r) => {
+    const ident = nameByParticipant.get(r.participant_id) ?? {
+      display_name: "?",
+      initials: "?",
+    };
+    return {
+      participant_id: r.participant_id,
+      display_name: ident.display_name,
+      initials: ident.initials,
+      scheduled_date: r.scheduled_date,
+      completed_at: r.completed_at,
+      survey_responses: r.survey_responses,
+    };
+  });
+
+  return { podId, cycleId, pulses, nextCursor };
+}

--- a/lib/moderator/rollup.ts
+++ b/lib/moderator/rollup.ts
@@ -1,0 +1,264 @@
+/**
+ * Members-needing-attention rollup (PRD §7.10.2).
+ *
+ * Four KPIs aggregated across every pod the poderator can see:
+ *   1. pulsingThisWeek      — submitted vs total active members this week
+ *   2. atRisk               — count of members at the consecutive-miss
+ *                              threshold (§7.2), plus pods affected
+ *   3. pulsesThisPeriod     — submitted vs possible over the default
+ *                              4-week window (PRD §7.9 / §7.10.2)
+ *   4. engagementTrend      — aggregate weekly completion rate %, plus
+ *                              3-week trend arrow and prior-week value
+ *
+ * The at-risk threshold can vary per cycle (`cycle_config.at_risk_consecutive_misses`),
+ * so evaluation is performed per (member, cycle) pair.
+ *
+ * Data scope mirrors `pods-list.ts`: pulses are filtered by cycle and
+ * pod membership so a participant in multiple cycles can't leak signal
+ * across them.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { trendOver3Weeks, type Trend } from "./pulse-health";
+
+const DEFAULT_AT_RISK_MISSES = 2;
+const DEFAULT_PERIOD_WEEKS = 4;
+
+export interface RollupInput {
+  /** Pod IDs the poderator can see (already access-checked). */
+  podIds: number[];
+}
+
+export interface RollupResult {
+  totalActiveMembers: number;
+  totalPodsCovered: number;
+  pulsingThisWeek: {
+    submitted: number;
+    total: number;
+    /** completed / total as integer percent (0..100). 0 when total is 0. */
+    percent: number;
+  };
+  atRisk: {
+    /** Count of distinct members at or over the configured threshold. */
+    members: number;
+    /** Count of pods that contain at least one at-risk member. */
+    podsAffected: number;
+  };
+  pulsesThisPeriod: {
+    submitted: number;
+    possible: number;
+    periodWeeks: number;
+  };
+  engagementTrend: {
+    /** Aggregate completion % for the most recent week (0..100). */
+    currentPercent: number;
+    /** Prior-week completion % (0..100). null when only one week of data. */
+    priorPercent: number | null;
+    trend: Trend;
+  };
+}
+
+const EMPTY: RollupResult = {
+  totalActiveMembers: 0,
+  totalPodsCovered: 0,
+  pulsingThisWeek: { submitted: 0, total: 0, percent: 0 },
+  atRisk: { members: 0, podsAffected: 0 },
+  pulsesThisPeriod: { submitted: 0, possible: 0, periodWeeks: DEFAULT_PERIOD_WEEKS },
+  engagementTrend: { currentPercent: 0, priorPercent: null, trend: "flat" },
+};
+
+export async function getRollup(
+  supabase: SupabaseClient,
+  { podIds }: RollupInput,
+  periodWeeks: number = DEFAULT_PERIOD_WEEKS
+): Promise<RollupResult> {
+  if (podIds.length === 0) return EMPTY;
+
+  // Pod → cycle map (and the set of cycles we need configs for).
+  const { data: podRows } = await supabase
+    .from("pods")
+    .select("id, cycle_id")
+    .in("id", podIds);
+
+  const podCycle = new Map<number, number>();
+  for (const p of podRows ?? []) {
+    podCycle.set(p.id as number, p.cycle_id as number);
+  }
+  const cycleIds = Array.from(new Set(podCycle.values()));
+  if (cycleIds.length === 0) return EMPTY;
+
+  // Per-cycle at-risk threshold.
+  const { data: cfgRows } = await supabase
+    .from("cycle_config")
+    .select("cycle_id, at_risk_consecutive_misses")
+    .in("cycle_id", cycleIds);
+
+  const atRiskByCycle = new Map<number, number>();
+  for (const c of cfgRows ?? []) {
+    atRiskByCycle.set(
+      c.cycle_id as number,
+      (c.at_risk_consecutive_misses as number | null) ?? DEFAULT_AT_RISK_MISSES
+    );
+  }
+
+  // Active pod memberships → (pod_id, participant_id) pairs.
+  const { data: memRows } = await supabase
+    .from("pod_memberships")
+    .select("pod_id, participant_id")
+    .in("pod_id", podIds)
+    .is("inactive_at", null);
+
+  const memberPods = new Map<number, Set<number>>(); // participant → pods
+  const podMembers = new Map<number, Set<number>>(); // pod → participants
+  for (const m of memRows ?? []) {
+    const pid = m.participant_id as number;
+    const pod = m.pod_id as number;
+    const ps = memberPods.get(pid) ?? new Set<number>();
+    ps.add(pod);
+    memberPods.set(pid, ps);
+    const ms = podMembers.get(pod) ?? new Set<number>();
+    ms.add(pid);
+    podMembers.set(pod, ms);
+  }
+
+  const totalActiveMembers = memberPods.size;
+  const totalPodsCovered = podMembers.size;
+  if (totalActiveMembers === 0) {
+    return { ...EMPTY, totalPodsCovered, pulsesThisPeriod: { ...EMPTY.pulsesThisPeriod, periodWeeks } };
+  }
+
+  // Pulse window: enough to cover both at-risk consecutive-miss counting
+  // and the configured period. Pull the larger of the two horizons.
+  const maxThreshold = Math.max(
+    ...Array.from(atRiskByCycle.values()),
+    DEFAULT_AT_RISK_MISSES
+  );
+  const horizonWeeks = Math.max(periodWeeks, maxThreshold + 1);
+  const since = new Date();
+  since.setDate(since.getDate() - horizonWeeks * 7);
+
+  const participantIds = Array.from(memberPods.keys());
+  const { data: pulseRows } = await supabase
+    .from("pulse_checks")
+    .select("participant_id, cycle_id, scheduled_date, completed_at")
+    .in("participant_id", participantIds)
+    .in("cycle_id", cycleIds)
+    .gte("scheduled_date", since.toISOString().slice(0, 10))
+    .order("scheduled_date", { ascending: false });
+
+  type PulseRow = {
+    participant_id: number;
+    cycle_id: number;
+    scheduled_date: string;
+    completed_at: string | null;
+  };
+  const pulses = (pulseRows ?? []) as PulseRow[];
+
+  // Group pulses by (participant, cycle).
+  const pulsesByMemberCycle = new Map<string, PulseRow[]>();
+  for (const p of pulses) {
+    const k = `${p.participant_id}:${p.cycle_id}`;
+    const arr = pulsesByMemberCycle.get(k) ?? [];
+    arr.push(p);
+    pulsesByMemberCycle.set(k, arr);
+  }
+
+  // Bucket pulses by scheduled_date globally for engagement trend +
+  // pulses-this-period. Each pulse is one possible submission.
+  const byWeek = new Map<string, { completed: number; total: number }>();
+  // Bound the period bucket to the period horizon (4 weeks default).
+  const periodCutoff = new Date();
+  periodCutoff.setDate(periodCutoff.getDate() - periodWeeks * 7);
+  const periodCutoffStr = periodCutoff.toISOString().slice(0, 10);
+
+  let periodSubmitted = 0;
+  let periodPossible = 0;
+  for (const p of pulses) {
+    const bucket = byWeek.get(p.scheduled_date) ?? { completed: 0, total: 0 };
+    bucket.total += 1;
+    if (p.completed_at) bucket.completed += 1;
+    byWeek.set(p.scheduled_date, bucket);
+
+    if (p.scheduled_date >= periodCutoffStr) {
+      periodPossible += 1;
+      if (p.completed_at) periodSubmitted += 1;
+    }
+  }
+
+  const weekKeys = Array.from(byWeek.keys()).sort();
+
+  // Pulsing this week: latest scheduled_date bucket.
+  let submittedThisWeek = 0;
+  if (weekKeys.length > 0) {
+    const latest = byWeek.get(weekKeys[weekKeys.length - 1])!;
+    submittedThisWeek = latest.completed;
+  }
+  const pulsingTotal = totalActiveMembers;
+  const pulsingPercent =
+    pulsingTotal === 0 ? 0 : Math.round((submittedThisWeek / pulsingTotal) * 100);
+
+  // Engagement trend: aggregate weekly completion rate over the data.
+  const weeklyRates = weekKeys.map((k) => {
+    const b = byWeek.get(k)!;
+    return b.total === 0 ? 0 : b.completed / b.total;
+  });
+  const currentPercent =
+    weeklyRates.length === 0
+      ? 0
+      : Math.round(weeklyRates[weeklyRates.length - 1] * 100);
+  const priorPercent =
+    weeklyRates.length < 2
+      ? null
+      : Math.round(weeklyRates[weeklyRates.length - 2] * 100);
+  const trend = trendOver3Weeks(weeklyRates);
+
+  // At-risk: per (member, cycle), count consecutive misses from the most
+  // recent backwards and compare to that cycle's threshold.
+  let atRiskMembers = 0;
+  const atRiskPodSet = new Set<number>();
+  for (const [key, rows] of pulsesByMemberCycle.entries()) {
+    const [pidStr, cidStr] = key.split(":");
+    const participantId = Number(pidStr);
+    const cycleId = Number(cidStr);
+    const threshold = atRiskByCycle.get(cycleId) ?? DEFAULT_AT_RISK_MISSES;
+
+    // rows are already DESC by scheduled_date (selected with that order).
+    let consecutiveMisses = 0;
+    for (const r of rows) {
+      if (r.completed_at) break;
+      consecutiveMisses += 1;
+    }
+    if (consecutiveMisses >= threshold) {
+      atRiskMembers += 1;
+      const pods = memberPods.get(participantId);
+      if (pods) {
+        for (const podId of pods) {
+          if (podCycle.get(podId) === cycleId) atRiskPodSet.add(podId);
+        }
+      }
+    }
+  }
+
+  return {
+    totalActiveMembers,
+    totalPodsCovered,
+    pulsingThisWeek: {
+      submitted: submittedThisWeek,
+      total: pulsingTotal,
+      percent: pulsingPercent,
+    },
+    atRisk: {
+      members: atRiskMembers,
+      podsAffected: atRiskPodSet.size,
+    },
+    pulsesThisPeriod: {
+      submitted: periodSubmitted,
+      possible: periodPossible,
+      periodWeeks,
+    },
+    engagementTrend: {
+      currentPercent,
+      priorPercent,
+      trend,
+    },
+  };
+}

--- a/lib/moderator/ui-state.ts
+++ b/lib/moderator/ui-state.ts
@@ -16,7 +16,11 @@ export type ModeratorUiState = {
   roster_filters: RosterFilters;
   roster_sort: RosterSort | null;
   tooltip_seen: string[];
+  last_pod_tab: PodTab | null;
 };
+
+/** Per-pod page tab (PRD §7.7 — UI state persists per poderator). */
+export type PodTab = "members" | "recent_pulses";
 
 export type RosterFilters = {
   search?: string;
@@ -26,8 +30,6 @@ export type RosterFilters = {
 };
 
 export type RosterSort =
-  | "joined_at_asc"
-  | "joined_at_desc"
   | "name_asc"
   | "name_desc"
   | "pulse_status"
@@ -40,6 +42,7 @@ const EMPTY: ModeratorUiState = {
   roster_filters: {},
   roster_sort: null,
   tooltip_seen: [],
+  last_pod_tab: null,
 };
 
 export async function getUiState(
@@ -49,7 +52,7 @@ export async function getUiState(
   if (!participantId) return EMPTY;
   const { data } = await supabase
     .from("moderator_ui_state")
-    .select("last_view, roster_filters, roster_sort, tooltip_seen")
+    .select("last_view, roster_filters, roster_sort, tooltip_seen, last_pod_tab")
     .eq("participant_id", participantId)
     .maybeSingle();
   if (!data) return EMPTY;
@@ -58,5 +61,6 @@ export async function getUiState(
     roster_filters: ((data.roster_filters as RosterFilters | null) ?? {}) as RosterFilters,
     roster_sort: (data.roster_sort as RosterSort | null) ?? null,
     tooltip_seen: (data.tooltip_seen as string[] | null) ?? [],
+    last_pod_tab: (data.last_pod_tab as PodTab | null) ?? null,
   };
 }

--- a/lib/moderator/ui-state.ts
+++ b/lib/moderator/ui-state.ts
@@ -1,0 +1,62 @@
+/**
+ * Server-side helper for the moderator UI state (PRD §7.7 + §7.8).
+ *
+ * Reads the caller's `moderator_ui_state` row. Used by the All pods
+ * page to decide whether to redirect first-time / returning poderators
+ * to their last-viewed pod, and by both pages to seed Client UI
+ * components with persisted filter/sort/tooltip state.
+ *
+ * Writes go through the existing /api/moderator/ui-state PUT endpoint
+ * from chunk 3 (Client Components fire it on user actions).
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type ModeratorUiState = {
+  last_view: string | null;
+  roster_filters: RosterFilters;
+  roster_sort: RosterSort | null;
+  tooltip_seen: string[];
+};
+
+export type RosterFilters = {
+  search?: string;
+  status?: string[];
+  ai_level?: string[];
+  show_inactive?: boolean;
+};
+
+export type RosterSort =
+  | "joined_at_asc"
+  | "joined_at_desc"
+  | "name_asc"
+  | "name_desc"
+  | "pulse_status"
+  | "last_activity_asc"
+  | "last_activity_desc"
+  | "ai_level";
+
+const EMPTY: ModeratorUiState = {
+  last_view: null,
+  roster_filters: {},
+  roster_sort: null,
+  tooltip_seen: [],
+};
+
+export async function getUiState(
+  supabase: SupabaseClient,
+  participantId: number | null
+): Promise<ModeratorUiState> {
+  if (!participantId) return EMPTY;
+  const { data } = await supabase
+    .from("moderator_ui_state")
+    .select("last_view, roster_filters, roster_sort, tooltip_seen")
+    .eq("participant_id", participantId)
+    .maybeSingle();
+  if (!data) return EMPTY;
+  return {
+    last_view: (data.last_view as string | null) ?? null,
+    roster_filters: ((data.roster_filters as RosterFilters | null) ?? {}) as RosterFilters,
+    roster_sort: (data.roster_sort as RosterSort | null) ?? null,
+    tooltip_seen: (data.tooltip_seen as string[] | null) ?? [],
+  };
+}

--- a/lib/validations/moderator.ts
+++ b/lib/validations/moderator.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+/**
+ * Validations for the poderator-dashboard API routes (PRD
+ * §7.7 switcher, §7.8 tooltips, §7.2 nudge dismissal).
+ *
+ * Schemas are intentionally permissive on the JSON-blob fields
+ * (`roster_filters`) — the dashboard evolves filter knobs over time and
+ * we don't want every new filter to require a migration. Concrete shape
+ * is enforced at render time, not here.
+ */
+
+/** Switcher last-view: 'all_pods' or a pod id as a string. */
+const lastViewSchema = z
+  .string()
+  .min(1)
+  .max(32)
+  .refine(
+    (v) => v === "all_pods" || /^\d+$/.test(v),
+    "last_view must be 'all_pods' or a numeric pod id"
+  );
+
+/** Tooltip-suppression keys (PRD §7.8). */
+const tooltipSeenSchema = z
+  .array(z.string().min(1).max(64))
+  .max(64, "tooltip_seen has too many entries");
+
+/**
+ * PUT /api/moderator/ui-state — upsert per-poderator state.
+ * All fields optional so callers can patch one knob at a time
+ * (filter change shouldn't have to re-send tooltip_seen, etc.).
+ */
+export const uiStatePutSchema = z.object({
+  last_view: lastViewSchema.optional(),
+  roster_filters: z.record(z.string(), z.unknown()).optional(),
+  roster_sort: z.string().min(1).max(64).optional(),
+  tooltip_seen: tooltipSeenSchema.optional(),
+});
+
+export type UiStatePutInput = z.infer<typeof uiStatePutSchema>;
+
+/**
+ * POST /api/moderator/nudges/dismiss — record a per-poderator nudge
+ * dismissal (PRD §7.2). Caller must be the dismissing poderator;
+ * server-side check verifies pod assignment.
+ */
+export const nudgeDismissSchema = z.object({
+  pod_id: z.number().int().positive({
+    message: "pod_id must be a positive number",
+  }),
+  nudge_key: z
+    .string()
+    .min(1, "nudge_key is required")
+    .max(128, "nudge_key must be 128 characters or fewer"),
+});
+
+export type NudgeDismissInput = z.infer<typeof nudgeDismissSchema>;

--- a/lib/validations/moderator.ts
+++ b/lib/validations/moderator.ts
@@ -35,6 +35,7 @@ export const uiStatePutSchema = z.object({
   roster_filters: z.record(z.string(), z.unknown()).optional(),
   roster_sort: z.string().min(1).max(64).optional(),
   tooltip_seen: tooltipSeenSchema.optional(),
+  last_pod_tab: z.enum(["members", "recent_pulses"]).optional(),
 });
 
 export type UiStatePutInput = z.infer<typeof uiStatePutSchema>;

--- a/supabase/CLAUDE.md
+++ b/supabase/CLAUDE.md
@@ -71,6 +71,16 @@ Fresh installs use the baseline; deployed environments are unaffected (they've a
 
 ---
 
+## Renumber history
+
+| Original | Renamed to | Date | Reason |
+|---|---|---|---|
+| `00015_pod_memberships_preference_rank.sql` | `00028_pod_memberships_preference_rank.sql` | 2026-06-02 | Filename collided with `00015_grant_role_privileges.sql`. `supabase_migrations.schema_migrations.version` is a PK, so `supabase db push --include-all` couldn't insert both. The preference-rank DDL was already applied to dev; renumbering the disk file plus a one-row repair on the remote brought tracking back in sync. See the renamed file's header for the repair SQL pointer. |
+
+Going forward: **never reuse a migration number.** Before writing a new file, `ls supabase/migrations/ | tail -1` to confirm the next free number.
+
+---
+
 ## Active issue: ISSUE-W1-002 (#40) — seed `option_lists` (remaining 4 lists)
 
 Roadmap anchor: [§1.2](../docs/OLOS-roadmap.md). Unblocks §1.9 (pulse-check endpoint validates `tools_used` / `benefits` against these IDs) and §1.11 (registration form fetches options from `GET /api/options`). The schema for `option_lists` already exists at [migrations/00001_initial_schema.sql:108-116](migrations/00001_initial_schema.sql#L108-L116), including the `UNIQUE(list_name, value)` constraint we use for idempotency. The read endpoint is shipped at [app/api/options/route.ts](../app/api/options/route.ts) — verifying its output is the acceptance test, not new work.

--- a/supabase/migrations/00023_nudge_dismissals.sql
+++ b/supabase/migrations/00023_nudge_dismissals.sql
@@ -1,0 +1,52 @@
+-- PRD: docs/PRD-moderator-dashboard.md §7.2 / §9
+-- Subdoc: docs/poderator-dashboard/CLAUDE.md (New DB tables)
+--
+-- Records per-poderator dismissals of at-risk-member nudge instances.
+-- A dismissed nudge stays dismissed across sessions for that poderator
+-- (and only that poderator), but re-fires automatically when the
+-- condition re-trips: re-fire is signaled by a new `nudge_key` value
+-- (the key encodes occurrence; see lib/moderator/nudges.ts for the
+-- canonical key shape).
+
+CREATE TABLE nudge_dismissals (
+  id                        SERIAL PRIMARY KEY,
+  moderator_participant_id  INT NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+  pod_id                    INT NOT NULL REFERENCES pods(id) ON DELETE CASCADE,
+  nudge_key                 TEXT NOT NULL,
+  dismissed_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (moderator_participant_id, pod_id, nudge_key)
+);
+
+CREATE INDEX idx_nudge_dismissals_lookup ON nudge_dismissals (moderator_participant_id, pod_id);
+
+ALTER TABLE nudge_dismissals ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: own dismissals, or admin/owner
+CREATE POLICY "nudge_dismissals_select" ON nudge_dismissals FOR SELECT TO authenticated
+  USING (
+    moderator_participant_id = current_participant_id()
+    OR is_admin_or_owner()
+  );
+
+-- INSERT: only as the dismissing poderator. Caller must also be an active
+-- moderator of the pod the nudge belongs to (cannot dismiss nudges for pods
+-- you don't moderate).
+CREATE POLICY "nudge_dismissals_insert" ON nudge_dismissals FOR INSERT TO authenticated
+  WITH CHECK (
+    moderator_participant_id = current_participant_id()
+    AND (
+      is_admin_or_owner()
+      OR EXISTS (
+        SELECT 1
+        FROM moderator_assignments ma
+        WHERE ma.pod_id = nudge_dismissals.pod_id
+          AND ma.participant_id = current_participant_id()
+          AND ma.removed_at IS NULL
+      )
+    )
+  );
+
+-- DOWN (manual rollback — forward-only repo policy):
+-- DROP POLICY IF EXISTS "nudge_dismissals_insert" ON nudge_dismissals;
+-- DROP POLICY IF EXISTS "nudge_dismissals_select" ON nudge_dismissals;
+-- DROP TABLE IF EXISTS nudge_dismissals;

--- a/supabase/migrations/00024_moderator_ui_state.sql
+++ b/supabase/migrations/00024_moderator_ui_state.sql
@@ -1,0 +1,51 @@
+-- PRD: docs/PRD-moderator-dashboard.md §7.7, §7.8, §9
+-- Subdoc: docs/poderator-dashboard/CLAUDE.md (New DB tables)
+--
+-- Per-poderator UI state that persists across sessions:
+--   - last_view: switcher selection ('all_pods' | a specific pod_id as text)
+--   - roster_filters: filter (status, search) and any future roster filter knobs
+--   - roster_sort: column key used for the per-pod member roster
+--   - tooltip_seen: tooltip keys auto-suppressed after 1-2 encounters
+--
+-- One row per poderator (participant_id is the primary key). Admins
+-- receive rows too (see PRD §10 — "Admin ui-state").
+
+CREATE TABLE moderator_ui_state (
+  participant_id  INT PRIMARY KEY REFERENCES participants(id) ON DELETE CASCADE,
+  last_view       TEXT,
+  roster_filters  JSONB NOT NULL DEFAULT '{}'::jsonb,
+  roster_sort     TEXT,
+  tooltip_seen    TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE moderator_ui_state ENABLE ROW LEVEL SECURITY;
+
+-- SELECT/INSERT/UPDATE: own row, or admin/owner
+CREATE POLICY "moderator_ui_state_select" ON moderator_ui_state FOR SELECT TO authenticated
+  USING (
+    participant_id = current_participant_id()
+    OR is_admin_or_owner()
+  );
+
+CREATE POLICY "moderator_ui_state_insert" ON moderator_ui_state FOR INSERT TO authenticated
+  WITH CHECK (
+    participant_id = current_participant_id()
+    OR is_admin_or_owner()
+  );
+
+CREATE POLICY "moderator_ui_state_update" ON moderator_ui_state FOR UPDATE TO authenticated
+  USING (
+    participant_id = current_participant_id()
+    OR is_admin_or_owner()
+  )
+  WITH CHECK (
+    participant_id = current_participant_id()
+    OR is_admin_or_owner()
+  );
+
+-- DOWN (manual rollback — forward-only repo policy):
+-- DROP POLICY IF EXISTS "moderator_ui_state_update" ON moderator_ui_state;
+-- DROP POLICY IF EXISTS "moderator_ui_state_insert" ON moderator_ui_state;
+-- DROP POLICY IF EXISTS "moderator_ui_state_select" ON moderator_ui_state;
+-- DROP TABLE IF EXISTS moderator_ui_state;

--- a/supabase/migrations/00025_participants_ai_experience.sql
+++ b/supabase/migrations/00025_participants_ai_experience.sql
@@ -1,0 +1,29 @@
+-- PRD: docs/PRD-moderator-dashboard.md §7.3.1 (Member preview shape)
+-- Subdoc: docs/poderator-dashboard/CLAUDE.md (participants extension)
+--
+-- Adds the structured member-preview fields used by the per-pod roster
+-- (§7.3), the All pods nudge cards (§7.2), and the pulse review panel
+-- header (§7.4). One canonical shape, captured at registration.
+--
+-- `ai_experience_level` is an enum so it is sortable/filterable in the
+-- roster without UI-label lookups. UI labels for each value live in
+-- application code (program-team-owned copy).
+--
+-- Legacy rows default to 'new'. The registration form is updated
+-- separately (program-team-owned copy + form change).
+
+CREATE TYPE ai_experience_level AS ENUM ('new', 'consumer', 'builder', 'shipper');
+
+ALTER TABLE participants
+  ADD COLUMN ai_experience_level ai_experience_level NOT NULL DEFAULT 'new',
+  ADD COLUMN availability_snippet TEXT;
+
+-- No new RLS needed: participants policies (00002 + 00020) already cover
+-- visibility — own row + cross-pod-mate via the participants_select_visible
+-- predicate, plus admin/owner.
+
+-- DOWN (manual rollback — forward-only repo policy):
+-- ALTER TABLE participants
+--   DROP COLUMN IF EXISTS availability_snippet,
+--   DROP COLUMN IF EXISTS ai_experience_level;
+-- DROP TYPE IF EXISTS ai_experience_level;

--- a/supabase/migrations/00026_cycle_config_extensions.sql
+++ b/supabase/migrations/00026_cycle_config_extensions.sql
@@ -1,0 +1,49 @@
+-- PRD: docs/PRD-moderator-dashboard.md §7.1, §7.2, §7.10.3, §9
+-- Subdoc: docs/poderator-dashboard/CLAUDE.md (cycle_config extensions)
+--
+-- Cycle-scoped configuration backing the poderator dashboard:
+--   - pulse_band_warning_min / pulse_band_critical_min:
+--       pod-health indicator absolute-headcount band thresholds (§7.1).
+--       Defaults match the mockup labeling ("Healthy: 0 · Warning: 1-2 · Critical: 3+").
+--   - at_risk_consecutive_misses:
+--       miss threshold for the at-risk nudge (§7.2). Default 2 per PRD §10.
+--   - pulse_agg_default_weeks:
+--       default range for §7.9 aggregations and §7.10.3 comment bundles.
+--   - ai_summary_prompt:
+--       canonical prompt copied to clipboard by §7.10.3. One prompt for
+--       both All pods and per-pod scopes; per-cycle override possible.
+--       Seeded with a placeholder; program team refines later.
+--
+-- Existing cycle_config RLS (00002:48-50) covers reads/writes — no new
+-- policies needed.
+
+ALTER TABLE cycle_config
+  ADD COLUMN pulse_band_warning_min       INT NOT NULL DEFAULT 1,
+  ADD COLUMN pulse_band_critical_min      INT NOT NULL DEFAULT 3,
+  ADD COLUMN at_risk_consecutive_misses   INT NOT NULL DEFAULT 2,
+  ADD COLUMN pulse_agg_default_weeks      INT NOT NULL DEFAULT 4,
+  ADD COLUMN ai_summary_prompt            TEXT;
+
+-- Seed the AI summary prompt with a placeholder. Program team owns the
+-- final copy; see PRD §7.10.3. The exact wording will iterate after
+-- launch based on poderator feedback and observed quality of summaries.
+UPDATE cycle_config
+SET ai_summary_prompt = $$You are helping a community pod-leader (a "poderator") understand what's happening in their pods. Below are pulse-check responses from members of the pods I'm assigned to. Each response is tagged with the member's initials, their pod, and the week.
+
+Please:
+- Identify recurring themes across the responses (what members are stuck on, what help they're asking for, what's going well).
+- Flag members or topics I should pay attention to this week.
+- Cite the specific responses you draw conclusions from.
+- Be descriptive, not judgmental ("Confusion about proposal scope," not "Members seem lost").
+
+[Program team to refine.]
+$$
+WHERE ai_summary_prompt IS NULL;
+
+-- DOWN (manual rollback — forward-only repo policy):
+-- ALTER TABLE cycle_config
+--   DROP COLUMN IF EXISTS ai_summary_prompt,
+--   DROP COLUMN IF EXISTS pulse_agg_default_weeks,
+--   DROP COLUMN IF EXISTS at_risk_consecutive_misses,
+--   DROP COLUMN IF EXISTS pulse_band_critical_min,
+--   DROP COLUMN IF EXISTS pulse_band_warning_min;

--- a/supabase/migrations/00027_moderator_ui_state_last_pod_tab.sql
+++ b/supabase/migrations/00027_moderator_ui_state_last_pod_tab.sql
@@ -1,0 +1,15 @@
+-- PRD: docs/PRD-moderator-dashboard.md §7.7 (per-poderator UI state)
+-- Subdoc: docs/poderator-dashboard/CLAUDE.md (New DB tables → moderator_ui_state)
+--
+-- Adds the Per-pod page's active tab (Members vs Recent pulses) to the
+-- per-poderator UI state row. Persisting this lets a poderator return to
+-- the tab they last used on a given pod across sessions.
+--
+-- Values: 'members' | 'recent_pulses'. Default NULL → client renders
+-- 'members' (the existing behavior, so legacy rows degrade gracefully).
+
+ALTER TABLE moderator_ui_state
+  ADD COLUMN IF NOT EXISTS last_pod_tab TEXT;
+
+-- DOWN (manual rollback — forward-only repo policy):
+-- ALTER TABLE moderator_ui_state DROP COLUMN IF EXISTS last_pod_tab;

--- a/supabase/migrations/00028_pod_memberships_preference_rank.sql
+++ b/supabase/migrations/00028_pod_memberships_preference_rank.sql
@@ -1,3 +1,12 @@
+-- Renumbered from 00015 → 00028 on 2026-06-02. The original filename
+-- collided with 00015_grant_role_privileges.sql, which broke
+-- `supabase db push --include-all` (schema_migrations.version is a PK).
+-- The DDL below is idempotent (`ADD COLUMN IF NOT EXISTS`); on any
+-- environment where the original 00015 file had already been applied,
+-- this file is a no-op on the schema. The schema_migrations.version
+-- row is what changes — see the renumber entry in supabase/CLAUDE.md
+-- for the repair SQL.
+--
 -- ROADMAP §1.4 / ISSUE-W1-004 / D1 (resolved: preserve)
 -- Add preference_rank to pod_memberships so the legacy migration script can
 -- write Seat 1 / Seat 2 / Seat 3 form responses with their original rank


### PR DESCRIPTION
## Summary
Implements the Poderator (moderator) dashboard end-to-end, chunks 1–13.

- **Chunk 1** — DB migrations `00023`–`00026`: `nudge_dismissals`, `moderator_ui_state`, `participants.ai_experience_level` + `availability_snippet`, `cycle_config` extensions (incl. `ai_summary_prompt`).
- **Chunk 2** — `requireModeratorForPod()` auth guard + UI primitives (`sheet`, `tooltip`).
- **Chunk 3** — `GET`/`PUT /api/moderator/ui-state` with Zod validation, partial upsert.
- **Chunks 4–7** — per-pod view, member roster, pulse review side panel, `/api/moderator/pods*` + pulse-responses routes, phase guidance.
- **Chunks 8–13** — pod-level + cross-pod insights, AI-assisted summary block, nudge dismissal (`POST /api/moderator/nudges/dismiss`), UI-state persistence (switcher last-view, roster filter/sort), tooltip layer.

## Verification
- `tsc --noEmit`: clean (exit 0) across the project.
- `/api/moderator/ui-state`: authenticated GET→PUT→GET round-trip verified (partial upsert confirmed).
- Dev server compiles cleanly; `/moderator` renders 200.

## Notes / known follow-ups
- **No CI configured** in this repo — this PR is for human review only.
- Migrations `00023`–`00026` are **already applied to the dev Supabase project**, and dev's migration history was reconciled (stray timestamp versions reverted, `00001`–`00022` marked applied).
- **Duplicate `00015`** migration filename (`grant_role_privileges` vs `pod_memberships_preference_rank`) still needs renumbering — deferred until a prod-side reconcile.
- Lint: 4 errors (3 pre-existing in `solution-ballot`/`dashboard`; 1 in chunk-2 `tooltip.tsx` setState-in-effect) — none in the chunks 8–13 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)