### PR TITLE
feat(#110 Phase B): admin/moderator UI + profile-edit dual mode + placeholder remediation

### DIFF
--- a/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
@@ -41,6 +41,12 @@ export type ParticipantRow = {
   inactive_date: string | null;
   pods: number[];
   roles: string[];
+  // True when an access_revocations row exists for this (participant, cycle).
+  // Combined with status='inactive', has_revocation=false identifies
+  // 'stuck inactive' participants — never legitimately revoked, just
+  // never activated in the first place (architecture review broken edge
+  // #15). The participants-table filter uses this to surface them.
+  has_revocation: boolean;
 };
 
 export default async function AdminCycleDetailPage({
@@ -138,6 +144,16 @@ export default async function AdminCycleDetailPage({
     (rolesByParticipant[r.participant_id] ??= []).push(r.role);
   }
 
+  const { data: revocations } = await serviceClient
+    .from("access_revocations")
+    .select("participant_id, reason, revocation_scope, revoked_at, revoked_systems")
+    .eq("cycle_id", cycleId)
+    .order("revoked_at", { ascending: false });
+
+  const revokedParticipantIds = new Set(
+    (revocations ?? []).map((r) => r.participant_id)
+  );
+
   const participants: ParticipantRow[] = (enrollments ?? []).map((e) => {
     const p = (e.participants as unknown) as {
       first_name: string;
@@ -155,14 +171,9 @@ export default async function AdminCycleDetailPage({
       inactive_date: e.inactive_date,
       pods: podsByParticipant[e.participant_id] ?? [],
       roles: rolesByParticipant[e.participant_id] ?? [],
+      has_revocation: revokedParticipantIds.has(e.participant_id),
     };
   });
-
-  const { data: revocations } = await serviceClient
-    .from("access_revocations")
-    .select("participant_id, reason, revocation_scope, revoked_at, revoked_systems")
-    .eq("cycle_id", cycleId)
-    .order("revoked_at", { ascending: false });
 
   const activeCount = participants.filter((p) => p.status === "active").length;
 
@@ -359,7 +370,7 @@ export default async function AdminCycleDetailPage({
           <h2 className="mb-4 text-lg font-semibold tracking-tight text-white">
             Participants ({participants.length})
           </h2>
-          <ParticipantsTable participants={participants} />
+          <ParticipantsTable participants={participants} cycleId={cycleId} />
         </section>
 
         <hr className="border-whisper" />

--- a/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { ParticipantRow } from "./page";
 
@@ -11,99 +13,215 @@ const ROLE_COLORS: Record<string, string> = {
   observer: "bg-white/10 text-cloud/60",
 };
 
-export default function ParticipantsTable({
-  participants,
-}: {
+interface Props {
   participants: ParticipantRow[];
-}) {
+  cycleId: number;
+}
+
+export default function ParticipantsTable({ participants, cycleId }: Props) {
+  const router = useRouter();
+  const [stuckOnly, setStuckOnly] = useState(false);
+  // Single-flight: one reconcile in progress at a time. Drives the per-row
+  // disabled state. Chosen over concurrent reconciles because (a) the
+  // reconciler hits the same Postgres tables for every call, so concurrent
+  // requests would compete for the same rows anyway, and (b) keeping
+  // state simple avoids the complexity of tracking per-row Promise state.
+  const [reconcilingId, setReconcilingId] = useState<number | null>(null);
+  const [rowError, setRowError] = useState<{ id: number; message: string } | null>(
+    null
+  );
+
+  const stuckCount = useMemo(
+    () =>
+      participants.filter((p) => p.status === "inactive" && !p.has_revocation)
+        .length,
+    [participants]
+  );
+
+  const visible = useMemo(() => {
+    if (!stuckOnly) return participants;
+    return participants.filter(
+      (p) => p.status === "inactive" && !p.has_revocation
+    );
+  }, [participants, stuckOnly]);
+
+  async function runReconciler(participantId: number) {
+    setRowError(null);
+    setReconcilingId(participantId);
+    try {
+      const res = await fetch(
+        `/api/admin/participants/${participantId}/reconcile`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cycle_id: cycleId }),
+        }
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setRowError({
+          id: participantId,
+          message:
+            typeof data?.error === "string"
+              ? data.error
+              : `Request failed (${res.status})`,
+        });
+        return;
+      }
+      // router.refresh() re-runs the server component's data fetch so the
+      // table re-renders with the post-reconcile status. Alternative was
+      // optimistic update (immediate UI flip, then sync) — rejected because
+      // the reconciler's outcome depends on data we can't replicate
+      // client-side (pod_memberships joined to pods.status). Authoritative
+      // refresh is correct here.
+      router.refresh();
+    } finally {
+      setReconcilingId(null);
+    }
+  }
+
   if (participants.length === 0) {
     return <p className="text-sm text-cloud/60">No participants enrolled.</p>;
   }
 
   return (
-    <div className="overflow-hidden rounded-md border border-whisper">
-      <table className="w-full text-sm">
-        <thead className="bg-white/[0.04]">
-          <tr>
-            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
-              Name
-            </th>
-            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
-              Email
-            </th>
-            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
-              Status
-            </th>
-            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
-              Pods
-            </th>
-            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
-              Roles
-            </th>
-            <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-cloud/60" />
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-whisper">
-          {participants.map((p) => {
-            const displayName = p.preferred_name
-              ? `${p.preferred_name} ${p.last_name}`
-              : `${p.first_name} ${p.last_name}`;
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <label className="inline-flex cursor-pointer items-center gap-2 text-xs text-cloud/80">
+          <input
+            type="checkbox"
+            checked={stuckOnly}
+            onChange={(e) => setStuckOnly(e.target.checked)}
+            className="h-3.5 w-3.5 rounded border-whisper bg-white/[0.04] text-teal focus:ring-1 focus:ring-teal focus:ring-offset-0"
+          />
+          <span>
+            Show only stuck-inactive
+            <span className="ml-1 text-cloud/50 tabular-nums">
+              ({stuckCount})
+            </span>
+          </span>
+        </label>
+        {stuckOnly && stuckCount === 0 && (
+          <span className="text-xs text-cloud/60">
+            No stuck-inactive participants — every inactive row has an
+            access_revocations entry.
+          </span>
+        )}
+      </div>
 
-            return (
-              <tr
-                key={p.participant_id}
-                className="transition-colors duration-150 hover:bg-white/[0.02]"
-              >
-                <td className="px-4 py-3 font-medium text-cloud">
-                  {displayName}
-                </td>
-                <td className="px-4 py-3 text-cloud/60">{p.email}</td>
-                <td className="px-4 py-3">
-                  <span
-                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                      p.status === "active"
-                        ? "bg-teal/20 text-aqua"
-                        : p.status === "revoked"
-                          ? "bg-red/20 text-red-300"
-                          : "bg-white/10 text-cloud/60"
-                    }`}
-                  >
-                    {p.status}
-                  </span>
-                </td>
-                <td className="px-4 py-3 text-cloud/60 tabular-nums">
-                  {p.pods.length}
-                </td>
-                <td className="px-4 py-3">
-                  <div className="flex flex-wrap gap-1">
-                    {p.roles.map((role) => (
+      <div className="overflow-hidden rounded-md border border-whisper">
+        <table className="w-full text-sm">
+          <thead className="bg-white/[0.04]">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
+                Name
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
+                Email
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
+                Status
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
+                Pods
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60">
+                Roles
+              </th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-cloud/60" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-whisper">
+            {visible.map((p) => {
+              const displayName = p.preferred_name
+                ? `${p.preferred_name} ${p.last_name}`
+                : `${p.first_name} ${p.last_name}`;
+              const isStuck = p.status === "inactive" && !p.has_revocation;
+              const isReconciling = reconcilingId === p.participant_id;
+              const showRowError = rowError?.id === p.participant_id;
+
+              return (
+                <tr
+                  key={p.participant_id}
+                  className="transition-colors duration-150 hover:bg-white/[0.02]"
+                >
+                  <td className="px-4 py-3 font-medium text-cloud">
+                    {displayName}
+                    {isStuck && (
                       <span
-                        key={role}
-                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                          ROLE_COLORS[role] ?? "bg-white/10 text-cloud/60"
-                        }`}
+                        title="Inactive with no revocation row — likely never activated"
+                        className="ml-2 inline-flex items-center rounded-full bg-yellow-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-yellow-300"
                       >
-                        {role}
+                        stuck
                       </span>
-                    ))}
-                    {p.roles.length === 0 && (
-                      <span className="text-xs text-cloud/60">—</span>
                     )}
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <Link
-                    href={`/admin/participants/${p.participant_id}/permissions`}
-                    className="rounded bg-teal/20 px-3 py-1 text-xs font-semibold tracking-tight text-aqua transition-all duration-150 hover:bg-teal/30 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2 focus-visible:ring-offset-midnight"
-                  >
-                    Permissions
-                  </Link>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+                  </td>
+                  <td className="px-4 py-3 text-cloud/60">{p.email}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                        p.status === "active"
+                          ? "bg-teal/20 text-aqua"
+                          : p.status === "revoked"
+                            ? "bg-red/20 text-red-300"
+                            : "bg-white/10 text-cloud/60"
+                      }`}
+                    >
+                      {p.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-cloud/60 tabular-nums">
+                    {p.pods.length}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {p.roles.map((role) => (
+                        <span
+                          key={role}
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                            ROLE_COLORS[role] ?? "bg-white/10 text-cloud/60"
+                          }`}
+                        >
+                          {role}
+                        </span>
+                      ))}
+                      {p.roles.length === 0 && (
+                        <span className="text-xs text-cloud/60">—</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="flex flex-col items-end gap-1">
+                      <div className="flex items-center gap-2">
+                        {p.status === "inactive" && (
+                          <button
+                            type="button"
+                            onClick={() => runReconciler(p.participant_id)}
+                            disabled={isReconciling}
+                            title="Re-evaluate this participant's cycle_enrollments.status against current pod-membership reality"
+                            className="rounded bg-yellow-500/20 px-3 py-1 text-xs font-semibold tracking-tight text-yellow-300 transition-all duration-150 hover:bg-yellow-500/30 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-300 focus-visible:ring-offset-2 focus-visible:ring-offset-midnight disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            {isReconciling ? "Reconciling…" : "Run reconciler"}
+                          </button>
+                        )}
+                        <Link
+                          href={`/admin/participants/${p.participant_id}/permissions`}
+                          className="rounded bg-teal/20 px-3 py-1 text-xs font-semibold tracking-tight text-aqua transition-all duration-150 hover:bg-teal/30 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2 focus-visible:ring-offset-midnight"
+                        >
+                          Permissions
+                        </Link>
+                      </div>
+                      {showRowError && (
+                        <p className="text-xs text-red-300">{rowError.message}</p>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/app/(dashboard)/admin/participants/[participant_id]/permissions/admin-name-edit-form.tsx
+++ b/app/(dashboard)/admin/participants/[participant_id]/permissions/admin-name-edit-form.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { FormField, Input } from "@/app/components/ui/form";
+
+// Mirror of the participant-side schema in lib/validations/participants-update.ts
+// and the form schema in profile/edit/profile-edit-form.tsx. Refusing
+// 'Unknown' here means an admin cannot accidentally re-save the placeholder
+// value when nudging a stranded participant.
+const PLACEHOLDER = /^unknown$/i;
+const nameField = z
+  .string()
+  .min(1, "Required")
+  .max(100, "Too long")
+  .refine((s) => !PLACEHOLDER.test(s.trim()), {
+    message: "Cannot be 'Unknown'",
+  });
+
+const formSchema = z.object({
+  first_name: nameField,
+  last_name: nameField,
+  preferred_name: z.string().max(100).optional().or(z.literal("")),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface Props {
+  participantId: number;
+  initial: {
+    first_name: string;
+    last_name: string;
+    preferred_name: string;
+  };
+}
+
+export default function AdminNameEditForm({ participantId, initial }: Props) {
+  const router = useRouter();
+  const [serverError, setServerError] = useState("");
+  const [saved, setSaved] = useState(false);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: initial,
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isDirty },
+  } = form;
+
+  async function onSubmit(values: FormData) {
+    setServerError("");
+    setSaved(false);
+
+    const body: Record<string, string | null> = {
+      first_name: values.first_name.trim(),
+      last_name: values.last_name.trim(),
+      preferred_name: values.preferred_name?.trim()
+        ? values.preferred_name.trim()
+        : null,
+    };
+
+    // Hits the same PATCH /api/participants/[id] endpoint that powers the
+    // participant's own profile edit. The endpoint's authorization branch
+    // is isSelf || isAdmin — admins pass via the second branch. RLS
+    // migration 00021's WITH CHECK on participants_update_own enforces
+    // the same predicate at the DB layer.
+    const res = await fetch(`/api/participants/${participantId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setServerError(
+        typeof data?.error === "string"
+          ? data.error
+          : `Request failed (${res.status})`
+      );
+      return;
+    }
+
+    setSaved(true);
+    // refresh() re-runs the server component so the page header's
+    // displayName updates with the new value on next render.
+    router.refresh();
+  }
+
+  return (
+    <section className="mt-8 rounded-lg border border-whisper bg-white/[0.02] p-6">
+      <h2 className="text-base font-semibold text-white">Edit name</h2>
+      <p className="mt-1 text-sm text-cloud/70">
+        Updates first name, last name, and preferred name. Used to fix
+        placeholder values (e.g. &quot;Unknown&quot; rows from data migration)
+        without raw SQL.
+      </p>
+
+      <FormProvider {...form}>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="mt-5 grid gap-4 sm:grid-cols-3"
+        >
+          <FormField
+            name="first_name"
+            label="First name"
+            required
+            htmlFor="admin_first_name"
+          >
+            <Input
+              id="admin_first_name"
+              type="text"
+              invalid={!!errors.first_name}
+              {...register("first_name")}
+            />
+          </FormField>
+
+          <FormField
+            name="last_name"
+            label="Last name"
+            required
+            htmlFor="admin_last_name"
+          >
+            <Input
+              id="admin_last_name"
+              type="text"
+              invalid={!!errors.last_name}
+              {...register("last_name")}
+            />
+          </FormField>
+
+          <FormField
+            name="preferred_name"
+            label="Preferred name"
+            htmlFor="admin_preferred_name"
+          >
+            <Input
+              id="admin_preferred_name"
+              type="text"
+              invalid={!!errors.preferred_name}
+              {...register("preferred_name")}
+            />
+          </FormField>
+
+          <div className="sm:col-span-3 flex items-center justify-between gap-3">
+            <div className="flex-1">
+              {serverError && (
+                <p className="rounded-md border border-red/30 bg-red/10 px-3 py-2 text-sm text-red-300">
+                  {serverError}
+                </p>
+              )}
+              {saved && !serverError && (
+                <p className="text-sm text-aqua">Saved.</p>
+              )}
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting || !isDirty}
+              className="inline-flex items-center justify-center rounded-md bg-teal px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-teal/80 focus:outline-none focus:ring-2 focus:ring-teal focus:ring-offset-2 focus:ring-offset-shadow-teal disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </form>
+      </FormProvider>
+    </section>
+  );
+}

--- a/app/(dashboard)/admin/participants/[participant_id]/permissions/page.tsx
+++ b/app/(dashboard)/admin/participants/[participant_id]/permissions/page.tsx
@@ -5,6 +5,7 @@ import { redirect, notFound } from "next/navigation";
 import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
 import type { Permission } from "@/lib/auth/permissions";
 import PermissionsEditor from "./permissions-editor";
+import AdminNameEditForm from "./admin-name-edit-form";
 
 export default async function ParticipantPermissionsPage({
   params,
@@ -88,6 +89,15 @@ export default async function ParticipantPermissionsPage({
           </div>
         )}
       </div>
+
+      <AdminNameEditForm
+        participantId={participantId}
+        initial={{
+          first_name: participant.first_name ?? "",
+          last_name: participant.last_name ?? "",
+          preferred_name: participant.preferred_name ?? "",
+        }}
+      />
 
       <PermissionsEditor
         participantId={participantId}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { resolveUserRoles, isAdmin, isModerator, can } from "@/lib/auth/roles";
+import { hasPlaceholderName } from "@/lib/participants/placeholder";
 import LogoutButton from "./components/logout-button";
 import { copy as pulseCopy } from "./pulse-check/copy";
 
@@ -34,6 +35,41 @@ export default async function DashboardLayout({
     .eq("auth_user_id", user.id)
     .maybeSingle();
 
+  // Resolve the current pathname once and use it for every redirect gate
+  // below. The header order tries Next 16's canonical key first, then the
+  // older invoke-path key, then a generic fallback for any edge runtime
+  // that surfaces the URL under a different name.
+  const hdrs = await headers();
+  const pathname =
+    hdrs.get("x-pathname") ||
+    hdrs.get("x-invoke-path") ||
+    hdrs.get("next-url") ||
+    "";
+
+  // Placeholder-name gate (architecture review broken edge #3).
+  //
+  // Participants with first_name='Unknown' or last_name='Unknown' must
+  // complete their profile before any dashboard interaction. The migration
+  // script wrote these stubs for rows missing name data; without this
+  // gate they would reach /dashboard rendering as "Welcome, Unknown".
+  //
+  // Runs BEFORE the pulse-check enforcement because Phase B.4's submission-
+  // endpoint guards will reject placeholder-name participants from pulse
+  // submission anyway — they must fix their name first. Order: identity
+  // first, then phase obligations.
+  //
+  // Skip when already on /profile/edit (would infinite-loop). The
+  // ?next= query param preserves where they were headed so the form's
+  // Mode B post-save handler can return them to the original path.
+  if (
+    participant &&
+    hasPlaceholderName(participant.first_name, participant.last_name) &&
+    !pathname.startsWith("/profile/edit")
+  ) {
+    const next = pathname || "/dashboard";
+    redirect(`/profile/edit?required=true&next=${encodeURIComponent(next)}`);
+  }
+
   // Compute pulse-check enforcement status
   let enforcementStatus: EnforcementStatus = "ok";
   if (participant) {
@@ -48,12 +84,6 @@ export default async function DashboardLayout({
   }
 
   // Hard block: if overdue and not on the pulse-check page, redirect.
-  const hdrs = await headers();
-  const pathname =
-    hdrs.get("x-pathname") ||
-    hdrs.get("x-invoke-path") ||
-    hdrs.get("next-url") ||
-    "";
   if (
     enforcementStatus === "overdue" &&
     !pathname.startsWith("/pulse-check") &&

--- a/app/(dashboard)/profile/edit/page.tsx
+++ b/app/(dashboard)/profile/edit/page.tsx
@@ -1,15 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { hasPlaceholderName } from "@/lib/participants/placeholder";
 import ProfileEditForm from "./profile-edit-form";
-
-const PLACEHOLDER = /^unknown$/i;
-
-function hasPlaceholderName(first: string | null, last: string | null): boolean {
-  return (
-    PLACEHOLDER.test((first ?? "").trim()) ||
-    PLACEHOLDER.test((last ?? "").trim())
-  );
-}
 
 // Allow only same-origin relative paths in the `next` query param so the
 // redirect cannot be hijacked to push users at an arbitrary external URL.

--- a/app/(dashboard)/profile/edit/page.tsx
+++ b/app/(dashboard)/profile/edit/page.tsx
@@ -1,0 +1,104 @@
+import { redirect } from "next/navigation";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import ProfileEditForm from "./profile-edit-form";
+
+const PLACEHOLDER = /^unknown$/i;
+
+function hasPlaceholderName(first: string | null, last: string | null): boolean {
+  return (
+    PLACEHOLDER.test((first ?? "").trim()) ||
+    PLACEHOLDER.test((last ?? "").trim())
+  );
+}
+
+// Allow only same-origin relative paths in the `next` query param so the
+// redirect cannot be hijacked to push users at an arbitrary external URL.
+function safeNextPath(raw: string | undefined): string {
+  if (!raw) return "/dashboard";
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/dashboard";
+  return raw;
+}
+
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function ProfileEditPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const requiredParam = Array.isArray(params.required)
+    ? params.required[0]
+    : params.required;
+  const nextParam = Array.isArray(params.next) ? params.next[0] : params.next;
+
+  // Mode B fires when the layout redirect sends a placeholder-name
+  // participant here with ?required=true. Mode A is the voluntary path
+  // (clicking "Edit profile" from /profile or nav).
+  const required = requiredParam === "true";
+  const nextPath = safeNextPath(nextParam);
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  // Service client so we can read fields the cookie-bound client's RLS
+  // would scope away. We're only displaying the participant's own row
+  // (auth_user_id match below) so there's no cross-account exposure.
+  const serviceClient = createServiceClient();
+  const { data: participant } = await serviceClient
+    .from("participants")
+    .select("id, email, first_name, last_name, preferred_name")
+    .eq("auth_user_id", user.id)
+    .maybeSingle();
+
+  if (!participant) redirect("/register");
+
+  const placeholder = hasPlaceholderName(
+    participant.first_name,
+    participant.last_name
+  );
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="rounded-lg border border-whisper bg-white/[0.02] p-6 sm:p-8">
+        <header className="border-b border-whisper pb-4">
+          <h1 className="text-xl font-semibold text-white">
+            {required
+              ? "Complete your profile to continue"
+              : "Edit profile"}
+          </h1>
+          {required && placeholder && (
+            <p className="mt-2 text-sm text-cloud/80">
+              We don&apos;t have your name on file yet. Please enter your
+              first and last name below — you&apos;ll be returned to where
+              you were headed once we save it.
+            </p>
+          )}
+          {required && !placeholder && (
+            <p className="mt-2 text-sm text-cloud/80">
+              Please review and confirm your profile to continue.
+            </p>
+          )}
+          {!required && (
+            <p className="mt-2 text-sm text-cloud/70">
+              Update your name and how you&apos;d like to be addressed.
+            </p>
+          )}
+        </header>
+
+        <ProfileEditForm
+          participantId={participant.id}
+          initial={{
+            first_name: participant.first_name ?? "",
+            last_name: participant.last_name ?? "",
+            preferred_name: participant.preferred_name ?? "",
+          }}
+          required={required}
+          nextPath={nextPath}
+          placeholder={placeholder}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/profile/edit/profile-edit-form.tsx
+++ b/app/(dashboard)/profile/edit/profile-edit-form.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { FormField, Input } from "@/app/components/ui/form";
+
+// Form-side schema: stricter than the API's partial-update schema because
+// the form always submits all three whitelisted fields. The API accepts
+// any subset; the form requires first/last name be present and valid.
+// Mirrors the .refine() on the server schema so server + client reject
+// the same inputs (defense in depth).
+const PLACEHOLDER = /^unknown$/i;
+const nameField = z
+  .string()
+  .min(1, "Required")
+  .max(100, "Too long")
+  .refine((s) => !PLACEHOLDER.test(s.trim()), {
+    message: "Cannot be 'Unknown'",
+  });
+
+const formSchema = z.object({
+  first_name: nameField,
+  last_name: nameField,
+  preferred_name: z.string().max(100).optional().or(z.literal("")),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface Props {
+  participantId: number;
+  initial: {
+    first_name: string;
+    last_name: string;
+    preferred_name: string;
+  };
+  required: boolean;
+  nextPath: string;
+  placeholder: boolean;
+}
+
+export default function ProfileEditForm({
+  participantId,
+  initial,
+  required,
+  nextPath,
+  placeholder,
+}: Props) {
+  const router = useRouter();
+  const [serverError, setServerError] = useState("");
+  const [saved, setSaved] = useState(false);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: initial,
+    // Show validation as the user types when their starting values are
+    // placeholders (Mode B) — the 'Unknown' values are pre-filled but
+    // need to be replaced. onChange validation surfaces the error band
+    // immediately so the user understands what's expected.
+    mode: placeholder ? "onChange" : "onSubmit",
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isDirty },
+  } = form;
+
+  async function onSubmit(values: FormData) {
+    setServerError("");
+
+    // Send only the whitelisted fields. preferred_name is nullable in the
+    // DB: an empty string from the form is normalized to null so the
+    // column stores a clean absence rather than an empty literal.
+    const body: Record<string, string | null> = {
+      first_name: values.first_name.trim(),
+      last_name: values.last_name.trim(),
+      preferred_name: values.preferred_name?.trim()
+        ? values.preferred_name.trim()
+        : null,
+    };
+
+    const res = await fetch(`/api/participants/${participantId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setServerError(
+        typeof data?.error === "string"
+          ? data.error
+          : `Request failed (${res.status})`
+      );
+      return;
+    }
+
+    if (required) {
+      // Mode B: bounce the user to where they were originally headed.
+      // router.refresh() ensures the dashboard layout re-evaluates the
+      // placeholder check so it doesn't redirect back to /profile/edit
+      // on the very next request.
+      router.push(nextPath);
+      router.refresh();
+    } else {
+      // Mode A: voluntary edit — stay on the page and show success.
+      setSaved(true);
+      router.refresh();
+    }
+  }
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-5">
+        <FormField
+          name="first_name"
+          label="First name"
+          required
+          htmlFor="first_name"
+        >
+          <Input
+            id="first_name"
+            type="text"
+            autoComplete="given-name"
+            invalid={!!errors.first_name}
+            {...register("first_name")}
+          />
+        </FormField>
+
+        <FormField
+          name="last_name"
+          label="Last name"
+          required
+          htmlFor="last_name"
+        >
+          <Input
+            id="last_name"
+            type="text"
+            autoComplete="family-name"
+            invalid={!!errors.last_name}
+            {...register("last_name")}
+          />
+        </FormField>
+
+        <FormField
+          name="preferred_name"
+          label="Preferred name"
+          helper="What you'd like to be called, if different from your first name."
+          htmlFor="preferred_name"
+        >
+          <Input
+            id="preferred_name"
+            type="text"
+            autoComplete="nickname"
+            invalid={!!errors.preferred_name}
+            {...register("preferred_name")}
+          />
+        </FormField>
+
+        {serverError && (
+          <p className="rounded-md border border-red/30 bg-red/10 px-3 py-2 text-sm text-red-300">
+            {serverError}
+          </p>
+        )}
+
+        {saved && !required && (
+          <p className="rounded-md border border-aqua/30 bg-aqua/10 px-3 py-2 text-sm text-aqua">
+            Saved.{" "}
+            <Link href="/profile" className="underline">
+              Back to profile
+            </Link>
+          </p>
+        )}
+
+        <div className="flex items-center justify-between gap-3 pt-2">
+          {!required && (
+            <Link
+              href="/profile"
+              className="text-sm text-cloud/70 underline-offset-2 hover:text-white hover:underline"
+            >
+              Cancel
+            </Link>
+          )}
+          <button
+            type="submit"
+            disabled={isSubmitting || (!isDirty && !required)}
+            className="ml-auto inline-flex items-center justify-center rounded-md bg-teal px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-teal/80 focus:outline-none focus:ring-2 focus:ring-teal focus:ring-offset-2 focus:ring-offset-shadow-teal disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting
+              ? "Saving…"
+              : required
+              ? "Save and continue"
+              : "Save changes"}
+          </button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/app/api/admin/participants/[participant_id]/reconcile/route.ts
+++ b/app/api/admin/participants/[participant_id]/reconcile/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import { parseIntParam } from "@/lib/api/params";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { adminReconcileSchema } from "@/lib/validations/admin-reconcile";
+import { reconcileEnrollmentActivation } from "@/lib/enrollment/reconciler";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+
+/**
+ * POST /api/admin/participants/[participant_id]/reconcile
+ *
+ * Operator-driven trigger for the Phase A reconciler. Used by the
+ * "Run reconciler" button on the admin participants-table filter for
+ * "stuck inactive" enrollments — participants whose cycle_enrollments
+ * row is 'inactive' AND who have no access_revocations entry, meaning
+ * they were never legitimately revoked, just never activated in the
+ * first place (architecture review broken edge #15).
+ *
+ * Body: { cycle_id: number }
+ * Auth: withAdminAuth
+ * Returns: { participantId, cycleId, before, after, mutated, audited }
+ *          (the full ReconcileResult so the UI can show what changed)
+ *
+ * Behavior
+ * --------
+ * Calls reconcileEnrollmentActivation with no logRevocation flag. The
+ * reconciler is idempotent:
+ *   - If the participant has at least one active pod_membership in an
+ *     active pod, status flips to 'active' and the result reports
+ *     mutated=true, after='active'
+ *   - If they have no active memberships, the reconciler leaves status
+ *     as-is (also no-op) OR demotes to 'inactive' depending on current
+ *     state. Either way it's safe to call.
+ *
+ * Architecture alignment
+ * ----------------------
+ *   - Brief invariant #2 (roles stack): withAdminAuth gate
+ *   - Brief invariant #4 (resources at activation): when reconciler
+ *     flips inactive → active for a participant whose pod is itself
+ *     active, downstream resource provisioning would fire if/when that
+ *     code lands. Same gap as B.7's pod-status override; not coded
+ *     anywhere yet.
+ *   - Brief invariant #5 (audit): reconciler writes access_revocations
+ *     only on demotion + opts.logRevocation. Admin-triggered activation
+ *     doesn't need a revocation row; the StatusBadge in the UI is
+ *     itself the visible record.
+ *
+ * === KNOWN GAP — admin audit trail ===
+ *
+ * No record of which admin clicked Run reconciler for which participant.
+ * Same deferral as B.6/B.7; tracked at #115 for the coordinated audit
+ * migration. The recommended audit will add a small action log (e.g.
+ * admin_actions table) capturing actor + target + timestamp + reason
+ * for every Phase B admin write surface — including this one. Until
+ * then, the cycle_enrollments status change is the only signal, and
+ * the access_revocations table covers cron-driven demotions (not
+ * admin-driven activations).
+ *
+ * Where this is headed: once #115 lands, the route accepts an optional
+ * { reason?: string } in the body, writes an admin_actions row, and the
+ * participants-table renders "Last reconciled by X on Y" alongside the
+ * status badge.
+ */
+export const POST = withAdminAuth(
+  async (request: NextRequest, _auth: AuthenticatedRequest, params: Record<string, string>) => {
+    const participantId = parseIntParam(params.participant_id, "participant_id");
+    if (participantId instanceof NextResponse) return participantId;
+
+    const body = await parseBody(request, adminReconcileSchema);
+    if (isErrorResponse(body)) return body;
+
+    const result = await reconcileEnrollmentActivation(
+      participantId,
+      body.cycle_id
+    );
+
+    return NextResponse.json(result);
+  }
+);

--- a/app/api/admin/pods/[pod_id]/memberships/[participant_id]/route.ts
+++ b/app/api/admin/pods/[pod_id]/memberships/[participant_id]/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import { dbError } from "@/lib/api/errors";
+import { parseIntParam } from "@/lib/api/params";
+import { reconcileEnrollmentActivation } from "@/lib/enrollment/reconciler";
+import { createServiceClient } from "@/lib/supabase/server";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+
+/**
+ * DELETE /api/admin/pods/[pod_id]/memberships/[participant_id]
+ *
+ * Admin override of the participant-facing leave-pod route. Used to remove
+ * a participant from a pod on their behalf (architecture review broken
+ * edge #13).
+ *
+ * Soft-deletes per architecture brief §5 (sets inactive_at; preserves the
+ * row + joined_at). Calls the Phase A reconciler so the participant's
+ * cycle_enrollments status demotes to 'inactive' iff this was their last
+ * active pod in the cycle. Reconciler is idempotent — calling it when
+ * the participant still has another active pod is a no-op.
+ *
+ * Does NOT check the pod_registration window — admins are explicitly
+ * allowed to act outside windows for remediation.
+ *
+ * === KNOWN GAP — admin audit trail ===
+ *
+ * This DELETE sets inactive_at but records nothing about WHICH admin
+ * triggered the removal or WHY. If a participant asks "why am I out of
+ * Pod 5?" tomorrow, the database holds the timestamp but not the actor
+ * or reason. Same gap as the sibling POST route (and the forthcoming
+ * Phase B.7 pod-status override + B.8 reconciler-trigger).
+ *
+ * The recommended follow-up adds three columns to pod_memberships:
+ *   - removed_by_admin_id INT NULL REFERENCES participants(id)
+ *   - removal_reason      VARCHAR(255)
+ *   - admin_action_at     TIMESTAMP
+ *
+ * And updates this route to:
+ *   - Accept an optional { reason?: string } in the request body
+ *   - Write removed_by_admin_id = auth.user.participantId
+ *   - Write removal_reason from the body (or a default 'admin action')
+ *   - Write admin_action_at = now()
+ *
+ * Deferred deliberately: the audit columns should land in ONE migration
+ * covering all three Phase B admin write surfaces (B.6 + B.7 + B.8), not
+ * three separate follow-ups. Architecture brief §5 ('audit trail') is
+ * partially honored — rows persist via soft-delete — but actor-level
+ * audit is the gap. Tracked at #115.
+ *
+ * Where this is headed: once the audit columns land, the access_revocations
+ * table continues to log cycle_enrollment demotions (the reconciler still
+ * writes there when logRevocation=true), while the new pod_memberships
+ * audit columns capture pod-level admin actions. Two layers, two
+ * concerns: enrollment status changes (access_revocations) vs membership
+ * actions (pod_memberships audit columns).
+ */
+export const DELETE = withAdminAuth(
+  async (_request: NextRequest, _auth: AuthenticatedRequest, params: Record<string, string>) => {
+    const podId = parseIntParam(params.pod_id, "pod_id");
+    if (podId instanceof NextResponse) return podId;
+    const participantId = parseIntParam(params.participant_id, "participant_id");
+    if (participantId instanceof NextResponse) return participantId;
+
+    const client = createServiceClient();
+
+    const { data: pod } = await client
+      .from("pods")
+      .select("cycle_id")
+      .eq("id", podId)
+      .maybeSingle();
+    if (!pod) {
+      return NextResponse.json({ error: "Pod not found" }, { status: 404 });
+    }
+
+    const { error } = await client
+      .from("pod_memberships")
+      .update({ inactive_at: new Date().toISOString() })
+      .eq("pod_id", podId)
+      .eq("participant_id", participantId)
+      .is("inactive_at", null);
+    if (error) return dbError(error);
+
+    await reconcileEnrollmentActivation(participantId, pod.cycle_id);
+
+    return NextResponse.json({ success: true });
+  }
+);

--- a/app/api/admin/pods/[pod_id]/memberships/route.ts
+++ b/app/api/admin/pods/[pod_id]/memberships/route.ts
@@ -1,0 +1,179 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import { dbError } from "@/lib/api/errors";
+import { parseIntParam } from "@/lib/api/params";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { adminAddPodMembershipSchema } from "@/lib/validations/admin-pod-membership";
+import {
+  reconcileEnrollmentActivation,
+  reconcilePodMembers,
+} from "@/lib/enrollment/reconciler";
+import { createServiceClient } from "@/lib/supabase/server";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+
+/**
+ * POST /api/admin/pods/[pod_id]/memberships
+ *
+ * Admin override of the participant-facing self-register route. Used to
+ * place a participant in a pod on their behalf (e.g. operator reconciliation
+ * for stranded enrollments — architecture review broken edge #13).
+ *
+ * Mirrors the participant register route's shape:
+ *   - pod must exist + be forming/active
+ *   - reactivates a soft-deleted membership if one exists (preserves
+ *     joined_at and audit trail — architecture brief §5 invariant)
+ *   - honors the 2-pod-per-cycle cap (architecture brief §3 invariant)
+ *   - calls the Phase A reconciler so the participant's cycle_enrollments
+ *     status reflects the new pod-membership reality
+ *
+ * Does NOT check the pod_registration window — admins are explicitly
+ * allowed to act outside windows for remediation (architecture review §5.3
+ * 'Admin overrides explicitly bypass via withAdminAuth'). The participant
+ * route's checkWindow stays for self-registration; this admin route omits
+ * it on purpose.
+ *
+ * === KNOWN GAP — admin audit trail ===
+ *
+ * This route mutates pod_memberships from an admin perspective WITHOUT
+ * recording which admin made the change. If an admin removes Aaron from
+ * Pod 5 today and a teammate asks "who did this?" tomorrow, there is no
+ * answer in the database — only the inactive_at timestamp.
+ *
+ * The recommended follow-up is filed at #115 and adds:
+ *   - added_by_admin_id  INT NULL REFERENCES participants(id)
+ *   - removed_by_admin_id INT NULL REFERENCES participants(id)
+ *   - removal_reason     VARCHAR(255)
+ *   - admin_action_at    TIMESTAMP
+ *
+ * Once that migration ships, this route writes added_by_admin_id =
+ * auth.user.participantId on the INSERT path, removed_by_admin_id +
+ * removal_reason on the DELETE sibling, and admin_action_at on either.
+ *
+ * Why deferred: the consolidation in #110 is scoped to fixing the
+ * state-machine fragmentation; admin observability is its own concern
+ * worth landing as a focused PR after Phase B's primary surface
+ * stabilizes. Architecture brief §5 ('Soft delete everywhere ... gives
+ * us an audit trail') is honored at the row-existence level — rows are
+ * preserved with inactive_at — just not at the actor level yet.
+ *
+ * Where this is headed: the admin audit pattern will become the template
+ * for B.7 (pod-status override) and B.8 (reconciler-trigger from
+ * stuck-inactive filter). All three routes should land their audit
+ * columns in one coordinated migration rather than three separate
+ * follow-ups. Tracked at #115.
+ */
+export const POST = withAdminAuth(
+  async (request: NextRequest, _auth: AuthenticatedRequest, params: Record<string, string>) => {
+    const podId = parseIntParam(params.pod_id, "pod_id");
+    if (podId instanceof NextResponse) return podId;
+
+    const body = await parseBody(request, adminAddPodMembershipSchema);
+    if (isErrorResponse(body)) return body;
+    const { participant_id } = body;
+
+    const client = createServiceClient();
+
+    const { data: pod } = await client
+      .from("pods")
+      .select("id, cycle_id, status")
+      .eq("id", podId)
+      .maybeSingle();
+    if (!pod) {
+      return NextResponse.json({ error: "Pod not found" }, { status: 404 });
+    }
+    if (!["forming", "active"].includes(pod.status)) {
+      return NextResponse.json(
+        { error: "Pod is not accepting memberships" },
+        { status: 400 }
+      );
+    }
+
+    const { data: participant } = await client
+      .from("participants")
+      .select("id")
+      .eq("id", participant_id)
+      .maybeSingle();
+    if (!participant) {
+      return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+    }
+
+    const { data: existing } = await client
+      .from("pod_memberships")
+      .select("id, inactive_at, joined_at")
+      .eq("pod_id", podId)
+      .eq("participant_id", participant_id)
+      .maybeSingle();
+
+    if (existing && existing.inactive_at === null) {
+      return NextResponse.json(
+        { error: "Participant is already a member of this pod" },
+        { status: 400 }
+      );
+    }
+
+    // 2-pod-per-cycle cap. NOTE: hardcoded as `>= 2` to match the
+    // participant register route's existing behavior; roadmap §2.1
+    // ('Move the hardcoded 2-pod cap to cycle_config.pod_limit')
+    // tracks the cleanup that should update both call sites together.
+    // Until §2.1 lands, the cap here MUST stay in sync with
+    // app/api/pods/[pod_id]/register/route.ts.
+    const { data: cyclePods } = await client
+      .from("pod_memberships")
+      .select("id, pods!inner(cycle_id)")
+      .eq("participant_id", participant_id)
+      .eq("pods.cycle_id", pod.cycle_id)
+      .is("inactive_at", null);
+    if ((cyclePods ?? []).length >= 2) {
+      return NextResponse.json(
+        { error: "Participant is already in 2 pods for this cycle" },
+        { status: 400 }
+      );
+    }
+
+    let membership: { id: number; joined_at: string };
+    if (existing) {
+      const { data: reactivated, error } = await client
+        .from("pod_memberships")
+        .update({ inactive_at: null })
+        .eq("id", existing.id)
+        .select("id, joined_at")
+        .single();
+      if (error) return dbError(error);
+      membership = reactivated;
+    } else {
+      const { data: inserted, error } = await client
+        .from("pod_memberships")
+        .insert({ participant_id, pod_id: podId })
+        .select("id, joined_at")
+        .single();
+      if (error) return dbError(error);
+      membership = inserted;
+    }
+
+    // Pod auto-activation parity with the participant route.
+    const { data: config } = await client
+      .from("cycle_config")
+      .select("pod_min")
+      .eq("cycle_id", pod.cycle_id)
+      .single();
+    const { count } = await client
+      .from("pod_memberships")
+      .select("id", { count: "exact", head: true })
+      .eq("pod_id", podId)
+      .is("inactive_at", null);
+    if (config && count && count >= config.pod_min && pod.status === "forming") {
+      await client
+        .from("pods")
+        .update({ status: "active", updated_at: new Date().toISOString() })
+        .eq("id", podId);
+      await reconcilePodMembers(podId);
+    } else {
+      await reconcileEnrollmentActivation(participant_id, pod.cycle_id);
+    }
+
+    return NextResponse.json(
+      { pod_membership_id: membership.id, registered_at: membership.joined_at },
+      { status: 201 }
+    );
+  }
+);

--- a/app/api/admin/pods/[pod_id]/route.ts
+++ b/app/api/admin/pods/[pod_id]/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import { dbError } from "@/lib/api/errors";
+import { parseIntParam } from "@/lib/api/params";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { adminPodStatusSchema } from "@/lib/validations/admin-pod-status";
+import { reconcilePodMembers } from "@/lib/enrollment/reconciler";
+import { createServiceClient } from "@/lib/supabase/server";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+
+/**
+ * PATCH /api/admin/pods/[pod_id]
+ *
+ * Admin pod-status override. Closes architecture review broken edge #14
+ * ('Admin can force pod status forming → active: No PATCH route exists').
+ *
+ * Concrete scenario this exists for: Pod 8 from the May 2026 Energy hot
+ * fix had 8 active members (pod_min=5) but stayed in 'forming' because
+ * the auto-transition in the participant register route never fired
+ * for any of those members. Pre-Phase-B that required a manual SQL
+ * UPDATE; this route makes it a clickable admin action.
+ *
+ * Allowed transitions
+ * -------------------
+ *   forming → active   — the primary use case
+ *   forming → forming  — no-op (returns success without writing)
+ *   active  → active   — no-op (returns success without writing)
+ *   active  → forming  — REJECTED (400)
+ *
+ * Why active → forming is rejected
+ * ---------------------------------
+ * Architecture brief invariant #4 ('Resources provision at activation,
+ * not formation') means that once a pod is 'active', external systems
+ * (Slack channel, Drive folder, GitHub repo, Google Group) have been
+ * provisioned (or will be, once that work lands). Reversing 'active' to
+ * 'forming' would imply de-provisioning those resources — a destructive
+ * operation that's both more complex than this route should attempt and
+ * not a documented operator need today. If a use case for archival or
+ * reversal emerges, that's a separate route with explicit semantics, not
+ * an overload of this endpoint.
+ *
+ * Why pod_min is NOT checked
+ * --------------------------
+ * The participant-facing register route only flips a pod to active when
+ * pod_member count >= pod_min. This admin override deliberately skips
+ * that check — the whole point is to handle the two cases where the
+ * auto-check fails:
+ *   (a) Pod 8 case: pod_min was reached but the inline activation in
+ *       the register route silently RLS-failed (Phase A's discovery)
+ *   (b) Operator wants to activate a pod below pod_min for a special
+ *       case (e.g. a small experimental cohort)
+ *
+ * Resource provisioning gap
+ * --------------------------
+ * Brief invariant #4 says active pods get external resources provisioned.
+ * The current codebase has NO resource-provisioning code anywhere — the
+ * participant register route's activation block also doesn't provision.
+ * That gap is intentional out-of-scope for #110; when provisioning
+ * lands, it'll land in BOTH this route AND the participant register
+ * route's activation block via a shared helper. This route's contract
+ * (when provisioning ships): admin override fires provisioning the same
+ * way an automatic transition does.
+ *
+ * Reconciler integration
+ * ----------------------
+ * After a forming → active transition, calls reconcilePodMembers(podId)
+ * which fans out reconcileEnrollmentActivation across every active
+ * member of the pod. Each member's cycle_enrollments.status flips to
+ * 'active' (if it wasn't already). Idempotent: members who are already
+ * active are no-op'd.
+ *
+ * === KNOWN GAP — admin audit trail ===
+ *
+ * This route mutates pods.status without recording which admin made the
+ * change or why. Same gap as B.6's admin pod-membership routes; tracked
+ * for coordinated fix at #115. The recommended audit migration there
+ * adds pod-level audit columns (status_changed_by_admin_id,
+ * status_change_reason, status_changed_at) alongside the pod_memberships
+ * audit columns so all admin write surfaces land observability at once.
+ *
+ * Where this is headed: once #115 lands, this route writes
+ *   status_changed_by_admin_id = auth.user.participantId
+ *   status_change_reason       = body.reason  (schema gets a reason field)
+ *   status_changed_at          = now()
+ * and the schema in lib/validations/admin-pod-status.ts grows an
+ * optional reason field. No structural change to the route's control
+ * flow.
+ */
+export const PATCH = withAdminAuth(
+  async (request: NextRequest, _auth: AuthenticatedRequest, params: Record<string, string>) => {
+    const podId = parseIntParam(params.pod_id, "pod_id");
+    if (podId instanceof NextResponse) return podId;
+
+    const body = await parseBody(request, adminPodStatusSchema);
+    if (isErrorResponse(body)) return body;
+    const { status: newStatus } = body;
+
+    const client = createServiceClient();
+
+    const { data: pod } = await client
+      .from("pods")
+      .select("id, cycle_id, status")
+      .eq("id", podId)
+      .maybeSingle();
+    if (!pod) {
+      return NextResponse.json({ error: "Pod not found" }, { status: 404 });
+    }
+
+    // No-op fast path: status already matches.
+    if (pod.status === newStatus) {
+      return NextResponse.json({ pod_id: pod.id, status: pod.status });
+    }
+
+    // Reject active → forming. See route header for rationale.
+    if (pod.status === "active" && newStatus === "forming") {
+      return NextResponse.json(
+        {
+          error:
+            "Cannot revert active pod to forming. Reversing activation would " +
+            "imply de-provisioning external resources, which is not a " +
+            "supported operation. Open a separate ticket if this need is real.",
+        },
+        { status: 400 }
+      );
+    }
+
+    // Reject anything else that wasn't no-op or forming → active.
+    if (!(pod.status === "forming" && newStatus === "active")) {
+      return NextResponse.json(
+        { error: `Unsupported transition: ${pod.status} → ${newStatus}` },
+        { status: 400 }
+      );
+    }
+
+    // forming → active path
+    const { error } = await client
+      .from("pods")
+      .update({ status: "active", updated_at: new Date().toISOString() })
+      .eq("id", podId);
+    if (error) return dbError(error);
+
+    // Reconcile every active member's enrollment status. Idempotent;
+    // members already at status='active' are no-op'd. Members who
+    // joined after a soft-delete/rejoin cycle get their enrollment
+    // brought current.
+    await reconcilePodMembers(podId);
+
+    return NextResponse.json({ pod_id: pod.id, status: "active" });
+  }
+);

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -4,15 +4,7 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { isOwnerEmail, ensureOwnerRole } from "@/lib/auth/owner-emails";
 import { escapeEmailForIlike } from "@/lib/auth/email";
 import { reconcileEnrollmentActivation } from "@/lib/enrollment/reconciler";
-
-const PLACEHOLDER_NAME = "unknown";
-
-function hasPlaceholderName(first: string | null, last: string | null): boolean {
-  return (
-    (first ?? "").trim().toLowerCase() === PLACEHOLDER_NAME ||
-    (last ?? "").trim().toLowerCase() === PLACEHOLDER_NAME
-  );
-}
+import { hasPlaceholderName } from "@/lib/participants/placeholder";
 
 async function fulfillInvitation(
   serviceClient: ReturnType<typeof createServiceClient>,

--- a/app/api/participants/[participant_id]/route.ts
+++ b/app/api/participants/[participant_id]/route.ts
@@ -3,6 +3,9 @@ import { withAuth } from "@/lib/auth/middleware";
 import { isAdmin } from "@/lib/auth/roles";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 import { parseIntParam } from "@/lib/api/params";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { dbError } from "@/lib/api/errors";
+import { participantsUpdateSchema } from "@/lib/validations/participants-update";
 
 export const GET = withAuth(
   async (_request: NextRequest, auth: AuthenticatedRequest, params: Record<string, string>) => {
@@ -50,5 +53,59 @@ export const GET = withAuth(
       work_style: grouped["work_style"] || [],
       group_strengths: grouped["group_strengths"] || [],
     });
+  }
+);
+
+/**
+ * PATCH /api/participants/[participant_id]
+ *
+ * Partial update of a participant row. Powers three Phase B affordances
+ * that share this single endpoint:
+ *   - Mode A: voluntary self-edit from /profile/edit (auth = self)
+ *   - Mode B: forced placeholder-name completion via layout redirect (auth = self)
+ *   - Admin name-edit from /admin/participants/[id]/permissions (auth = admin)
+ *
+ * Authorization is application-layer (isSelf || isAdmin) with RLS as defense
+ * in depth — migration 00021's WITH CHECK on participants_update_own enforces
+ * the same predicate at the database level. The cookie-bound client is used
+ * deliberately so RLS fires: if the application check ever drifted, the
+ * write would still fail at the database layer rather than silently succeed.
+ *
+ * Body validation: lib/validations/participants-update.ts. The schema uses
+ * .partial().strict() so only whitelisted fields can be touched (no
+ * auth_user_id / email / id / etc. hijacking via tampered request bodies).
+ */
+export const PATCH = withAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest, params: Record<string, string>) => {
+    const targetId = parseIntParam(params.participant_id, "participant_id");
+    if (targetId instanceof NextResponse) return targetId;
+
+    const isSelf = auth.user.participantId === targetId;
+    if (!isSelf && !isAdmin(auth.user)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = await parseBody(request, participantsUpdateSchema);
+    if (isErrorResponse(body)) return body;
+
+    if (Object.keys(body).length === 0) {
+      return NextResponse.json(
+        { error: "No fields to update" },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await auth.supabase
+      .from("participants")
+      .update(body)
+      .eq("id", targetId)
+      .select("id, first_name, last_name, preferred_name, email")
+      .single();
+
+    if (error) {
+      return dbError(error, "patch-participant");
+    }
+
+    return NextResponse.json(data);
   }
 );

--- a/app/api/pods/[pod_id]/project-votes/route.ts
+++ b/app/api/pods/[pod_id]/project-votes/route.ts
@@ -6,6 +6,7 @@ import { dbError } from "@/lib/api/errors";
 import { parseIntParam } from "@/lib/api/params";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { projectBallotSchema } from "@/lib/validations/pods";
+import { requireCompleteProfile } from "@/lib/participants/placeholder";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 
 export const GET = withAuth(
@@ -74,6 +75,9 @@ export const POST = withAuth(
     if (!voterId) {
       return NextResponse.json({ error: "Not a registered participant" }, { status: 403 });
     }
+
+    const guard = await requireCompleteProfile(auth.supabase, voterId);
+    if (guard) return guard;
 
     const body = await parseBody(request, projectBallotSchema);
     if (isErrorResponse(body)) return body;

--- a/app/api/pods/[pod_id]/register/route.ts
+++ b/app/api/pods/[pod_id]/register/route.ts
@@ -8,6 +8,7 @@ import {
   reconcileEnrollmentActivation,
   reconcilePodMembers,
 } from "@/lib/enrollment/reconciler";
+import { requireCompleteProfile } from "@/lib/participants/placeholder";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 
 export const POST = withAuth(
@@ -19,6 +20,9 @@ export const POST = withAuth(
     if (!participantId) {
       return NextResponse.json({ error: "Not a registered participant" }, { status: 403 });
     }
+
+    const guard = await requireCompleteProfile(auth.supabase, participantId);
+    if (guard) return guard;
 
     // Get pod to check status and cycle
     const { data: pod } = await auth.supabase

--- a/app/api/pods/[pod_id]/solution-proposals/route.ts
+++ b/app/api/pods/[pod_id]/solution-proposals/route.ts
@@ -5,6 +5,7 @@ import { dbError } from "@/lib/api/errors";
 import { parseIntParam } from "@/lib/api/params";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { solutionProposalSchema } from "@/lib/validations/pods";
+import { requireCompleteProfile } from "@/lib/participants/placeholder";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 
 export const GET = withAuth(
@@ -37,6 +38,9 @@ export const POST = withAuth(
     if (!participantId) {
       return NextResponse.json({ error: "Not a registered participant" }, { status: 403 });
     }
+
+    const guard = await requireCompleteProfile(auth.supabase, participantId);
+    if (guard) return guard;
 
     const body = await parseBody(request, solutionProposalSchema);
     if (isErrorResponse(body)) return body;

--- a/app/api/pulse-checks/route.ts
+++ b/app/api/pulse-checks/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from "@/lib/auth/middleware";
 import { dbError } from "@/lib/api/errors";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { pulseCheckWithNominationsSchema } from "@/lib/validations/pulse-checks";
+import { requireCompleteProfile } from "@/lib/participants/placeholder";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 
 export const POST = withAuth(
@@ -22,6 +23,9 @@ export const POST = withAuth(
     if (!participant_id) {
       return NextResponse.json({ error: "Not a registered participant" }, { status: 403 });
     }
+
+    const guard = await requireCompleteProfile(auth.supabase, participant_id);
+    if (guard) return guard;
 
     const dupeQuery = auth.supabase
       .from("pulse_checks")

--- a/app/api/votes/route.ts
+++ b/app/api/votes/route.ts
@@ -5,6 +5,7 @@ import { checkWindow } from "@/lib/auth/windows";
 import { dbError } from "@/lib/api/errors";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { voteSchema } from "@/lib/validations/votes";
+import { requireCompleteProfile } from "@/lib/participants/placeholder";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 
 export const POST = withAuth(
@@ -17,6 +18,9 @@ export const POST = withAuth(
     if (!voter_id) {
       return NextResponse.json({ error: "Not a registered participant" }, { status: 403 });
     }
+
+    const guard = await requireCompleteProfile(auth.supabase, voter_id);
+    if (guard) return guard;
 
     // Check window
     const window = await checkWindow(auth.supabase, cycle_id, "voting");

--- a/lib/participants/placeholder.ts
+++ b/lib/participants/placeholder.ts
@@ -1,0 +1,30 @@
+/**
+ * Placeholder-name detection helpers.
+ *
+ * The migration script at scripts/migration/migrate.py:711-716 (Pass 1 —
+ * missing names) and :884-885 (Pass 1.5 — orphan-email stubs) writes
+ * first_name='Unknown' / last_name='Unknown' when source data lacks names.
+ * Three prod participants currently carry these values; the consolidated
+ * onboarding work (#110) ensures they self-fix or get fixed by an admin
+ * before they can engage with cycle activity.
+ *
+ * Centralized here so the auth callback's invitation guard, the dashboard
+ * layout's redirect, the /profile/edit page header copy, and any future
+ * submission-endpoint guards all match the same predicate. Mirrors the
+ * .refine() in lib/validations/participants-update.ts.
+ */
+
+const PLACEHOLDER_PATTERN = /^unknown$/i;
+
+/** True if the value is the literal 'Unknown' placeholder (case-insensitive, trimmed). */
+export function isPlaceholderValue(value: string | null | undefined): boolean {
+  return PLACEHOLDER_PATTERN.test((value ?? "").trim());
+}
+
+/** True if either name field is the placeholder. */
+export function hasPlaceholderName(
+  first: string | null | undefined,
+  last: string | null | undefined
+): boolean {
+  return isPlaceholderValue(first) || isPlaceholderValue(last);
+}

--- a/lib/participants/placeholder.ts
+++ b/lib/participants/placeholder.ts
@@ -9,10 +9,12 @@
  * before they can engage with cycle activity.
  *
  * Centralized here so the auth callback's invitation guard, the dashboard
- * layout's redirect, the /profile/edit page header copy, and any future
+ * layout's redirect, the /profile/edit page header copy, and the
  * submission-endpoint guards all match the same predicate. Mirrors the
  * .refine() in lib/validations/participants-update.ts.
  */
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 const PLACEHOLDER_PATTERN = /^unknown$/i;
 
@@ -27,4 +29,44 @@ export function hasPlaceholderName(
   last: string | null | undefined
 ): boolean {
   return isPlaceholderValue(first) || isPlaceholderValue(last);
+}
+
+/**
+ * Server-side guard for participant-submission endpoints. Defense-in-depth
+ * partner to the dashboard-layout redirect in app/(dashboard)/layout.tsx —
+ * the layout protects browser navigation; this protects direct API calls
+ * (curl, scripts, anything that skips the layout).
+ *
+ * Returns a 403 NextResponse with a redirect hint when the participant has
+ * a placeholder name; returns null when the profile is complete and the
+ * caller should proceed. Pattern matches parseBody + isErrorResponse.
+ *
+ * Caller idiom:
+ *   const guard = await requireCompleteProfile(auth.supabase, participantId);
+ *   if (guard) return guard;
+ *
+ * The 'redirect_hint' field tells the client where to send the user to fix
+ * the problem. Used by participant-facing UI components that wrap fetch
+ * calls; ignored by raw consumers (curl).
+ */
+export async function requireCompleteProfile(
+  supabase: SupabaseClient,
+  participantId: number
+): Promise<NextResponse | null> {
+  const { data } = await supabase
+    .from("participants")
+    .select("first_name, last_name")
+    .eq("id", participantId)
+    .maybeSingle();
+
+  if (data && hasPlaceholderName(data.first_name, data.last_name)) {
+    return NextResponse.json(
+      {
+        error: "profile_incomplete",
+        redirect_hint: "/profile/edit?required=true",
+      },
+      { status: 403 }
+    );
+  }
+  return null;
 }

--- a/lib/validations/admin-pod-membership.ts
+++ b/lib/validations/admin-pod-membership.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+/**
+ * Body schema for POST /api/admin/pods/[pod_id]/memberships.
+ * The admin supplies a participant_id; pod_id comes from the route param.
+ */
+export const adminAddPodMembershipSchema = z.object({
+  participant_id: z.number().int().positive(),
+});
+
+export type AdminAddPodMembership = z.infer<typeof adminAddPodMembershipSchema>;

--- a/lib/validations/admin-pod-status.ts
+++ b/lib/validations/admin-pod-status.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/**
+ * Body schema for PATCH /api/admin/pods/[pod_id].
+ *
+ * pods.status is constrained to 'forming' and 'active' per architecture
+ * brief §Cycle-Pod-Project model. The schema reflects only the values
+ * the model supports — no 'archived' / 'closed' here even though the
+ * UI types union mentions them (architecture review broken edge #21
+ * notes that mismatch as pre-existing dead-code; not in this scope).
+ */
+export const adminPodStatusSchema = z.object({
+  status: z.enum(["forming", "active"]),
+});
+
+export type AdminPodStatusUpdate = z.infer<typeof adminPodStatusSchema>;

--- a/lib/validations/admin-reconcile.ts
+++ b/lib/validations/admin-reconcile.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+/**
+ * Body schema for POST /api/admin/participants/[participant_id]/reconcile.
+ * The admin supplies the cycle_id; participant_id comes from the URL.
+ */
+export const adminReconcileSchema = z.object({
+  cycle_id: z.number().int().positive(),
+});
+
+export type AdminReconcileBody = z.infer<typeof adminReconcileSchema>;

--- a/lib/validations/participants-update.ts
+++ b/lib/validations/participants-update.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+// Reject the literal placeholder value 'Unknown' (case-insensitive, trimmed)
+// that scripts/migration/migrate.py wrote for participants missing name data.
+// The architecture review at docs/architecture-review-onboarding-state-machine.md
+// (broken edges #3 and #4) flags this as the value Mode B is designed to eliminate.
+const PLACEHOLDER_NAME = /^unknown$/i;
+
+const nameField = z
+  .string()
+  .min(1, "cannot be empty")
+  .max(100)
+  .refine((s) => !PLACEHOLDER_NAME.test(s.trim()), {
+    message: "cannot be 'Unknown'",
+  });
+
+/**
+ * Partial-update schema for PATCH /api/participants/[participant_id].
+ *
+ * - `.partial()` makes every top-level field optional (PATCH semantic: send
+ *   only the fields you're changing).
+ * - `.strict()` rejects unknown keys, preventing a client from PATCHing
+ *   sensitive fields not in this whitelist (email, auth_user_id, google_id,
+ *   id, created_at, etc.). RLS migration 00021 is the second line of defense.
+ * - Name fields reject the placeholder string so Mode B's purpose is preserved.
+ *
+ * Whitelist of editable fields (intentionally narrow for Phase B):
+ *   - first_name, last_name, preferred_name
+ *
+ * Profile-expansion fields (neighborhood, work_situation, linkedin, etc.) can
+ * be added to this schema in a follow-up without changing the route logic.
+ */
+export const participantsUpdateSchema = z
+  .object({
+    first_name: nameField,
+    last_name: nameField,
+    preferred_name: z.string().min(1).max(100).nullable(),
+  })
+  .partial()
+  .strict();
+
+export type ParticipantsUpdate = z.infer<typeof participantsUpdateSchema>;


### PR DESCRIPTION
## Summary

Phase B of [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110) — the consolidated onboarding state-machine work. Eight commits across self-service and admin tooling that complete the placeholder-name remediation surface (closes #102, #98, #103, #94 — already closed-as-superseded; this PR delivers the actual code) and ship the admin pod-management + reconciler-trigger UI that closes architecture review broken edges #4, #5, #13, #14, #15.

## What ships

| Commit | Layer | Description |
|---|---|---|
| [\`0420867\`](https://github.com/TheUpskillingLabs/OLOS/commit/0420867) | B.1 Foundation | PATCH /api/participants/[id] + partial-update zod schema. One endpoint for self + admin. |
| [\`ad53799\`](https://github.com/TheUpskillingLabs/OLOS/commit/ad53799) | B.2 Self-service UI | /profile/edit page + dual-mode form (Mode A voluntary, Mode B forced) |
| [\`6df4576\`](https://github.com/TheUpskillingLabs/OLOS/commit/6df4576) | B.3 Layout gate | Dashboard-layout placeholder-name redirect + DRY helper (lib/participants/placeholder.ts) consolidating 3 prior inline copies |
| [\`3f56846\`](https://github.com/TheUpskillingLabs/OLOS/commit/3f56846) | B.4 Defense in depth | Server-side requireCompleteProfile guard on 5 submission endpoints (pulse-checks, votes, solution-proposals, project-votes, pod-register) |
| [\`e8c5f77\`](https://github.com/TheUpskillingLabs/OLOS/commit/e8c5f77) | B.5 Admin name-edit | Form on /admin/participants/[id]/permissions sharing the PATCH endpoint with self-edit |
| [\`17c8fec\`](https://github.com/TheUpskillingLabs/OLOS/commit/17c8fec) | B.6 Admin pod-membership | POST + DELETE /api/admin/pods/[id]/memberships routes; reconciler integration on both |
| [\`7c03771\`](https://github.com/TheUpskillingLabs/OLOS/commit/7c03771) | B.7 Admin pod-status | PATCH /api/admin/pods/[id]; forming→active with reconcilePodMembers fan-out |
| [\`d3065c6\`](https://github.com/TheUpskillingLabs/OLOS/commit/d3065c6) | B.8 Stuck-inactive | Filter toggle + Run reconciler button on participants-table; POST /api/admin/participants/[id]/reconcile |

Plus cleanup commit [\`a169b08\`](https://github.com/TheUpskillingLabs/OLOS/commit/a169b08) removing an accidentally-tracked zero-byte file.

## Architectural through-line

One PATCH endpoint serves three UI surfaces. One reconciler from Phase A is called by every lifecycle path. One shared placeholder-name predicate (\`hasPlaceholderName\`) is consumed by the auth callback, the layout redirect, the /profile/edit page, and the submission guards. The leverage from Phase A's centralization is the architectural payoff Phase B materializes — and that pattern carries forward into Phase C.

## Defense in depth

Placeholder-name protection now has four walls:

| Wall | Where | Catches |
|---|---|---|
| Invitation guard | fulfillInvitation (Phase A) | Bulk invites for placeholder-named participants |
| Layout redirect | app/(dashboard)/layout.tsx | Browser navigation by placeholder participants |
| Submission guards | 5 POST routes | Direct API calls (curl, scripts) bypassing the layout |
| Admin operator path | /admin/participants/[id]/permissions name-edit | When the participant won't or can't self-fix |

## Known gap (deferred to [#115](https://github.com/TheUpskillingLabs/OLOS/issues/115))

Every admin write surface in this PR (B.5 name-edit, B.6 add/remove, B.7 pod-status, B.8 reconciler-trigger) intentionally **omits actor-level audit columns**. #115 tracks the coordinated migration that adds them all in one pass:

\`\`\`sql
ALTER TABLE pod_memberships
  ADD COLUMN added_by_admin_id   INT REFERENCES participants(id),
  ADD COLUMN removed_by_admin_id INT REFERENCES participants(id),
  ADD COLUMN removal_reason      VARCHAR(255),
  ADD COLUMN admin_action_at     TIMESTAMP;
\`\`\`

Plus a parallel \`admin_actions\` log for non-row-bound operations (the reconciler trigger). Deferred because the audit pattern should land coherently across all four surfaces, not piecemeal per route. Each route's file comment references #115 inline so the gap is documented in code, not just tracker history.

## Trade-offs explicitly considered (highlights)

The B.8 commit message contains the most thorough trade-off discussion for the interactive surfaces. Headline choices:

- **Filter as useState vs URL query** — chose state for simplicity; lose shareable URLs but gain less wiring
- **Per-row reconciler button vs bulk-select** — chose per-row; revisit if stuck-inactive count grows past ~30
- **\`router.refresh()\` vs optimistic UI** — chose refresh; the reconciler outcome depends on data we can't replicate client-side
- **Reconciler button on every inactive row vs only stuck rows** — chose every; idempotent + safe to click
- **\`requireCompleteProfile\` helper vs 5 inline checks** — chose helper; if the predicate evolves (e.g. add 'email verified') it's one place to change
- **B.6/B.7 service-client writes vs cookie-bound** — chose service client; matches Phase A's pattern after we discovered cookie-bound writes silently RLS-fail on cycle_enrollments/pods

## Verification

- [x] \`npx tsc --noEmit\` clean across all 7 commits
- [x] Dev server running cleanly throughout (Turbopack, no compile errors)
- [x] Lint baseline unchanged: same 3 pre-existing errors + 11 warnings from PR #104, no new issues introduced
- [x] Each commit individually buildable (each phase B.N could ship independently if Phase B were split into N PRs — chosen instead as one PR because the surfaces are conceptually one feature)
- [ ] Manual smoke test on dev preview after merge: complete a placeholder-name profile via Mode B, admin-add a participant to a pod, admin-flip Pod 8 to active, run reconciler on a stuck inactive participant
- [ ] Verify access_revocations rows are NOT written by the admin-triggered reconciler (only the cron-driven path writes them, per the logRevocation contract)

## Out of scope (Phase C)

- Revocation cron v2: cycle-scoped checks, baseline = MAX(activated_at, pod_registration_open_at), warned_at + grace period, idempotency indexes
- Re-register cron in vercel.json after ≥48h staging soak

## Related

- Parent: [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110)
- Audit follow-up: [#115](https://github.com/TheUpskillingLabs/OLOS/issues/115)
- Prior phase: PR [#111](https://github.com/TheUpskillingLabs/OLOS/pull/111) (Phase A reconciler + RLS hardening)
- Architecture review: \`docs/architecture-review-onboarding-state-machine.md\`
- Roadmap §3.7: cross-cutting consolidation entry