### PR TITLE
feat(entity-explorer): read-only admin entity browser (flagged OFF)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -20,3 +20,7 @@ NEXT_PUBLIC_APP_URL=https://app.theupskillinglabs.org
 # SLACK_BOT_TOKEN=
 # GITHUB_TOKEN=
 # GOOGLE_SERVICE_ACCOUNT=
+
+# Entity Explorer (read-only admin entity browser). Single flag, default OFF:
+# the route 404s and the nav link is hidden unless this is exactly "true".
+# ENTITY_EXPLORER_ENABLED=true

--- a/app/(dashboard)/admin/explore/[entity]/[id]/page.tsx
+++ b/app/(dashboard)/admin/explore/[entity]/[id]/page.tsx
@@ -11,6 +11,7 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
 import { fetchEntityDetail } from "@/lib/entity-explorer/fetch";
 import { getEntityConfig } from "@/lib/entity-explorer/registry";
+import { ENTITY_EXPLORER_ENABLED } from "@/lib/entity-explorer/flag";
 import { EnvBanner } from "../../env-banner";
 import { EntityDetail } from "../../entity-detail";
 
@@ -19,6 +20,9 @@ export default async function ExploreDetailPage({
 }: {
   params: Promise<{ entity: string; id: string }>;
 }) {
+  // Feature flag (DESIGN.md §4): off → the route doesn't exist.
+  if (!ENTITY_EXPLORER_ENABLED) notFound();
+
   const { entity: entityParam, id: idParam } = await params;
 
   // ── Auth: admin only (sole guard over service-role reads). ──

--- a/app/(dashboard)/admin/explore/[entity]/[id]/page.tsx
+++ b/app/(dashboard)/admin/explore/[entity]/[id]/page.tsx
@@ -1,0 +1,64 @@
+// Entity Explorer — detail / 360 view (DESIGN.md §6.1, §7).
+//
+// Guarded RSC, same admin gate as the list view (the service-role client bypasses
+// RLS, so this gate is the only protection — DESIGN.md §8). Fetches the base row
+// plus every reverse relation and renders the 360. Read-only.
+
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
+import { fetchEntityDetail } from "@/lib/entity-explorer/fetch";
+import { getEntityConfig } from "@/lib/entity-explorer/registry";
+import { EnvBanner } from "../../env-banner";
+import { EntityDetail } from "../../entity-detail";
+
+export default async function ExploreDetailPage({
+  params,
+}: {
+  params: Promise<{ entity: string; id: string }>;
+}) {
+  const { entity: entityParam, id: idParam } = await params;
+
+  // ── Auth: admin only (sole guard over service-role reads). ──
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const serviceClient = createServiceClient();
+  const userRoles = await resolveUserRoles(serviceClient, user.id);
+  if (!isAdmin(userRoles)) redirect("/cycles");
+
+  // ── Validate entity + id; unknown entity or non-numeric id → 404. ──
+  const config = getEntityConfig(entityParam);
+  if (!config) notFound();
+
+  const id = Number(idParam);
+  if (!Number.isFinite(id)) notFound();
+
+  const result = await fetchEntityDetail(serviceClient, config.key, id);
+  if (!result.row) notFound();
+
+  return (
+    <div>
+      <EnvBanner />
+
+      <p className="mb-4 text-sm text-cloud/60">
+        <Link
+          href={`/admin/explore?entity=${config.key}`}
+          className="inline-flex items-center gap-1.5 transition-colors hover:text-aqua"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden />
+          {config.label}
+        </Link>
+        <span className="mx-1.5 text-cloud/30">/</span>
+        <span className="text-cloud/85">#{id}</span>
+      </p>
+
+      <EntityDetail result={result} />
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/explore/[entity]/[id]/page.tsx
+++ b/app/(dashboard)/admin/explore/[entity]/[id]/page.tsx
@@ -4,14 +4,13 @@
 // RLS, so this gate is the only protection — DESIGN.md §8). Fetches the base row
 // plus every reverse relation and renders the 360. Read-only.
 
-import Link from "next/link";
-import { ChevronLeft } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
 import { fetchEntityDetail } from "@/lib/entity-explorer/fetch";
 import { getEntityConfig } from "@/lib/entity-explorer/registry";
 import { ENTITY_EXPLORER_ENABLED } from "@/lib/entity-explorer/flag";
+import { Breadcrumbs } from "../../breadcrumbs";
 import { EnvBanner } from "../../env-banner";
 import { EntityDetail } from "../../entity-detail";
 
@@ -50,17 +49,14 @@ export default async function ExploreDetailPage({
     <div>
       <EnvBanner />
 
-      <p className="mb-4 text-sm text-cloud/60">
-        <Link
-          href={`/admin/explore?entity=${config.key}`}
-          className="inline-flex items-center gap-1.5 transition-colors hover:text-aqua"
-        >
-          <ChevronLeft className="h-4 w-4" aria-hidden />
-          {config.label}
-        </Link>
-        <span className="mx-1.5 text-cloud/30">/</span>
-        <span className="text-cloud/85">#{id}</span>
-      </p>
+      <Breadcrumbs
+        items={[
+          { label: "Admin", href: "/admin" },
+          { label: "Entity Explorer", href: "/admin/explore" },
+          { label: config.label, href: `/admin/explore?entity=${config.key}` },
+          { label: `#${id}` },
+        ]}
+      />
 
       <EntityDetail result={result} />
     </div>

--- a/app/(dashboard)/admin/explore/breadcrumbs.tsx
+++ b/app/(dashboard)/admin/explore/breadcrumbs.tsx
@@ -9,7 +9,7 @@ export function Breadcrumbs({ items }: { items: Crumb[] }) {
   return (
     <nav
       aria-label="Breadcrumb"
-      className="mb-4 flex flex-wrap items-center gap-1.5 text-sm text-cloud/60"
+      className="mb-4 flex flex-wrap items-center gap-1.5 text-sm text-cloud/75"
     >
       {items.map((item, i) => {
         const isLast = i === items.length - 1;
@@ -18,12 +18,12 @@ export function Breadcrumbs({ items }: { items: Crumb[] }) {
             {item.href && !isLast ? (
               <Link
                 href={item.href}
-                className="transition-colors duration-150 hover:text-aqua focus-visible:text-aqua focus-visible:outline-none"
+                className="text-aqua/90 transition-colors duration-150 hover:text-aqua hover:brightness-110 focus-visible:text-aqua focus-visible:outline-none"
               >
                 {item.label}
               </Link>
             ) : (
-              <span className={isLast ? "text-cloud/85" : undefined}>{item.label}</span>
+              <span className={isLast ? "font-medium text-white" : undefined}>{item.label}</span>
             )}
             {!isLast && (
               <span aria-hidden className="text-cloud/30">

--- a/app/(dashboard)/admin/explore/breadcrumbs.tsx
+++ b/app/(dashboard)/admin/explore/breadcrumbs.tsx
@@ -1,0 +1,38 @@
+// Shared breadcrumb trail for the explorer pages, so every page can walk back up
+// to Admin (and any intermediate level), not just to the previous page.
+
+import Link from "next/link";
+
+export type Crumb = { label: string; href?: string };
+
+export function Breadcrumbs({ items }: { items: Crumb[] }) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="mb-4 flex flex-wrap items-center gap-1.5 text-sm text-cloud/60"
+    >
+      {items.map((item, i) => {
+        const isLast = i === items.length - 1;
+        return (
+          <span key={`${item.label}-${i}`} className="inline-flex items-center gap-1.5">
+            {item.href && !isLast ? (
+              <Link
+                href={item.href}
+                className="transition-colors duration-150 hover:text-aqua focus-visible:text-aqua focus-visible:outline-none"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span className={isLast ? "text-cloud/85" : undefined}>{item.label}</span>
+            )}
+            {!isLast && (
+              <span aria-hidden className="text-cloud/30">
+                ›
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/app/(dashboard)/admin/explore/cells.tsx
+++ b/app/(dashboard)/admin/explore/cells.tsx
@@ -63,23 +63,23 @@ export function renderCell(
     return (
       <Link
         href={detailHref(fk.target, value as number | string)}
-        className="text-aqua underline decoration-dotted underline-offset-2 hover:text-teal"
+        className="font-medium text-aqua underline decoration-dotted underline-offset-2 transition hover:decoration-solid hover:brightness-110"
       >
         {label}
       </Link>
     );
   }
 
-  if (value == null) return <span className="text-cloud/40">—</span>;
+  if (value == null) return <span className="text-cloud/45">—</span>;
 
   // JSONB → collapsed, pretty-printed (DESIGN.md §9.5).
   if (typeof value === "object") {
     return (
       <details className="group">
-        <summary className="cursor-pointer list-none font-mono text-xs text-cloud/60 hover:text-cloud">
-          {"{…}"} <span className="text-cloud/40">▸</span>
+        <summary className="cursor-pointer list-none font-mono text-xs text-aqua/90 hover:text-aqua">
+          {"{…}"} <span className="text-aqua/60">▸</span>
         </summary>
-        <pre className="mt-1 overflow-x-auto rounded border border-whisper bg-black/20 p-2 font-mono text-[11px] text-cloud/80">
+        <pre className="mt-1 overflow-x-auto rounded border border-teal/25 bg-black/30 p-2 font-mono text-[11px] text-cloud/90">
           {JSON.stringify(value, null, 2)}
         </pre>
       </details>
@@ -100,12 +100,12 @@ export function renderCell(
     return (
       <Link
         href={detailHref(config.key, value as number | string)}
-        className="font-mono text-xs text-aqua hover:text-teal"
+        className="font-mono text-xs text-aqua transition hover:brightness-110"
       >
         {String(value)}
       </Link>
     );
   }
 
-  return <span className="text-cloud/85">{String(value)}</span>;
+  return <span className="text-cloud">{String(value)}</span>;
 }

--- a/app/(dashboard)/admin/explore/cells.tsx
+++ b/app/(dashboard)/admin/explore/cells.tsx
@@ -1,0 +1,111 @@
+// Shared cell rendering for the list table and the detail/360 relation tables, so
+// both render foreign keys, JSONB, dates, status pills and ids identically.
+//
+// FK cells and id cells link to the detail route /admin/explore/<entity>/<id>
+// (DESIGN.md §12 step 4 — "FK links upgrade to detail-route links").
+
+import Link from "next/link";
+import { StatusBadge } from "@/app/components/ui";
+import type { EntityConfig, EntityRow } from "@/lib/entity-explorer/types";
+
+type BadgeVariant = "active" | "forming" | "inactive" | "draft" | "revoked";
+
+const STATUS_VARIANT: Record<string, BadgeVariant> = {
+  active: "active",
+  accepted: "active",
+  owner: "active",
+  admin: "active",
+  forming: "forming",
+  inactive: "inactive",
+  closed: "inactive",
+  observer: "inactive",
+  expired: "inactive",
+  pending: "draft",
+  draft: "draft",
+  developer: "draft",
+  revoked: "revoked",
+};
+
+export function detailHref(entity: string, id: number | string): string {
+  return `/admin/explore/${entity}/${id}`;
+}
+
+export function formatDate(value: unknown): string {
+  const d = new Date(String(value));
+  return Number.isNaN(d.getTime()) ? String(value) : d.toLocaleDateString();
+}
+
+function isDateColumn(column: string): boolean {
+  return column.endsWith("_at") || column.endsWith("_date");
+}
+
+/** Is this row soft-deleted, per its registry rule? */
+export function isRowDeleted(config: EntityConfig, row: EntityRow): boolean {
+  const rule = config.softDelete;
+  if (!rule) return false;
+  if (rule.kind === "timestamp") return row[rule.column] != null;
+  return rule.deletedValues.includes(String(row[rule.column]));
+}
+
+/** Render one cell. `config` is the entity the row belongs to. */
+export function renderCell(
+  column: string,
+  row: EntityRow,
+  config: EntityConfig,
+  foreignKeyLabels: Record<string, Record<string, string>>,
+): React.ReactNode {
+  const value = row[column];
+
+  // Foreign key → link to the target record's detail view, labeled by labelField.
+  const fk = config.foreignKeys.find((f) => f.column === column);
+  if (fk && value != null) {
+    const label = foreignKeyLabels[column]?.[String(value)] ?? `#${String(value)}`;
+    return (
+      <Link
+        href={detailHref(fk.target, value as number | string)}
+        className="text-aqua underline decoration-dotted underline-offset-2 hover:text-teal"
+      >
+        {label}
+      </Link>
+    );
+  }
+
+  if (value == null) return <span className="text-cloud/40">—</span>;
+
+  // JSONB → collapsed, pretty-printed (DESIGN.md §9.5).
+  if (typeof value === "object") {
+    return (
+      <details className="group">
+        <summary className="cursor-pointer list-none font-mono text-xs text-cloud/60 hover:text-cloud">
+          {"{…}"} <span className="text-cloud/40">▸</span>
+        </summary>
+        <pre className="mt-1 overflow-x-auto rounded border border-whisper bg-black/20 p-2 font-mono text-[11px] text-cloud/80">
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      </details>
+    );
+  }
+
+  if (column === "status" || column === "role") {
+    const variant = STATUS_VARIANT[String(value).toLowerCase()] ?? "inactive";
+    return <StatusBadge variant={variant}>{String(value)}</StatusBadge>;
+  }
+
+  if (isDateColumn(column)) {
+    return <span className="tabular-nums">{formatDate(value)}</span>;
+  }
+
+  // The primary key → link to this row's own detail view.
+  if (column === "id") {
+    return (
+      <Link
+        href={detailHref(config.key, value as number | string)}
+        className="font-mono text-xs text-aqua hover:text-teal"
+      >
+        {String(value)}
+      </Link>
+    );
+  }
+
+  return <span className="text-cloud/85">{String(value)}</span>;
+}

--- a/app/(dashboard)/admin/explore/entity-detail.tsx
+++ b/app/(dashboard)/admin/explore/entity-detail.tsx
@@ -1,0 +1,120 @@
+// Generic detail / 360 renderer (DESIGN.md §6.1): the base row up top, then every
+// table that references it as its own section — all assembled from the registry's
+// reverse relations, no bespoke query per entity. Empty relations render as
+// explicit "no rows" sections so nothing looks missing.
+
+import type { EntityRow, FetchDetailResult, RelationResult } from "@/lib/entity-explorer/types";
+import { renderCell } from "./cells";
+
+export function EntityDetail({ result }: { result: FetchDetailResult }) {
+  const { config, row, foreignKeyLabels, relations } = result;
+  // The route guarantees a non-null row before rendering.
+  const baseRow = row as EntityRow;
+  const id = String(baseRow.id);
+
+  const titleRaw = baseRow[config.labelField];
+  const title =
+    config.labelField !== "id" && titleRaw != null && titleRaw !== ""
+      ? String(titleRaw)
+      : `${config.label} #${id}`;
+
+  return (
+    <div>
+      {/* Base row header */}
+      <div className="mb-4 rounded-lg border border-teal/30 bg-teal/10 p-5">
+        <div className="flex flex-wrap items-baseline gap-3">
+          <span className="text-lg font-bold text-white">{title}</span>
+          <span className="rounded-full bg-white/10 px-2 py-0.5 text-xs text-cloud/70">
+            {config.label} #{id}
+          </span>
+        </div>
+        <dl className="mt-4 grid grid-cols-1 gap-x-8 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
+          {config.columns.map((c) => (
+            <div key={c} className="flex flex-col">
+              <dt className="text-[11px] font-semibold uppercase tracking-wider text-cloud/50">
+                {c}
+              </dt>
+              <dd className="text-sm">{renderCell(c, baseRow, config, foreignKeyLabels)}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      <p className="mb-4 text-sm text-cloud/60">
+        Base row up top; every table that references this record is rendered below as
+        its own section, assembled from the registry&rsquo;s reverse relations.
+      </p>
+
+      {relations.length === 0 ? (
+        <p className="text-sm text-cloud/50">
+          This entity declares no reverse relations.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {relations.map((rel) => (
+            <RelationCard key={rel.relation.entity + rel.relation.via} rel={rel} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RelationCard({ rel }: { rel: RelationResult }) {
+  const { relation, config, rows, total, truncated, foreignKeyLabels } = rel;
+  const empty = total === 0;
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-whisper bg-white/[0.02]">
+      <div className="flex items-center gap-2 border-b border-whisper bg-white/[0.04] px-4 py-2.5">
+        <span className="text-[11px] font-bold uppercase tracking-wider text-cloud/70">
+          {relation.label}
+        </span>
+        <span
+          className={`ml-auto rounded-full px-2 py-0.5 text-[10px] font-bold ${
+            empty ? "bg-white/10 text-cloud/50" : "bg-teal/20 text-aqua"
+          }`}
+        >
+          {total}
+        </span>
+      </div>
+
+      {empty ? (
+        <p className="px-4 py-4 text-xs italic text-cloud/40">No related rows.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead className="bg-white/[0.02]">
+              <tr>
+                {config.columns.map((c) => (
+                  <th
+                    key={c}
+                    className="whitespace-nowrap px-3 py-2 text-left text-[10px] font-medium uppercase tracking-wider text-cloud/50"
+                  >
+                    {c}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-whisper">
+              {rows.map((row, i) => (
+                <tr key={String(row.id ?? i)} className="hover:bg-white/[0.02]">
+                  {config.columns.map((c) => (
+                    <td key={c} className="px-3 py-2 align-top">
+                      {renderCell(c, row, config, foreignKeyLabels)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {truncated && (
+            <p className="px-3 py-2 text-[11px] text-cloud/50">
+              Showing first {rows.length} of {total}.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/explore/entity-detail.tsx
+++ b/app/(dashboard)/admin/explore/entity-detail.tsx
@@ -21,17 +21,17 @@ export function EntityDetail({ result }: { result: FetchDetailResult }) {
   return (
     <div>
       {/* Base row header */}
-      <div className="mb-4 rounded-lg border border-teal/30 bg-teal/10 p-5">
+      <div className="mb-4 rounded-lg border border-teal/40 bg-gradient-to-br from-teal/20 to-teal/5 p-5">
         <div className="flex flex-wrap items-baseline gap-3">
           <span className="text-lg font-bold text-white">{title}</span>
-          <span className="rounded-full bg-white/10 px-2 py-0.5 text-xs text-cloud/70">
+          <span className="rounded-full bg-teal/25 px-2 py-0.5 text-xs font-medium text-aqua">
             {config.label} #{id}
           </span>
         </div>
         <dl className="mt-4 grid grid-cols-1 gap-x-8 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
           {config.columns.map((c) => (
             <div key={c} className="flex flex-col">
-              <dt className="text-[11px] font-semibold uppercase tracking-wider text-cloud/50">
+              <dt className="text-[11px] font-semibold uppercase tracking-wider text-aqua/70">
                 {c}
               </dt>
               <dd className="text-sm">{renderCell(c, baseRow, config, foreignKeyLabels)}</dd>
@@ -40,7 +40,7 @@ export function EntityDetail({ result }: { result: FetchDetailResult }) {
         </dl>
       </div>
 
-      <p className="mb-4 text-sm text-cloud/60">
+      <p className="mb-4 text-sm text-cloud/70">
         Base row up top; every table that references this record is rendered below as
         its own section, assembled from the registry&rsquo;s reverse relations.
       </p>
@@ -65,14 +65,14 @@ function RelationCard({ rel }: { rel: RelationResult }) {
   const empty = total === 0;
 
   return (
-    <div className="overflow-hidden rounded-lg border border-whisper bg-white/[0.02]">
-      <div className="flex items-center gap-2 border-b border-whisper bg-white/[0.04] px-4 py-2.5">
-        <span className="text-[11px] font-bold uppercase tracking-wider text-cloud/70">
+    <div className="overflow-hidden rounded-lg border border-white/10 bg-white/[0.04]">
+      <div className="flex items-center gap-2 border-b border-teal/20 bg-teal/15 px-4 py-2.5">
+        <span className="text-[11px] font-bold uppercase tracking-wider text-aqua">
           {relation.label}
         </span>
         <span
           className={`ml-auto rounded-full px-2 py-0.5 text-[10px] font-bold ${
-            empty ? "bg-white/10 text-cloud/50" : "bg-teal/20 text-aqua"
+            empty ? "bg-white/10 text-cloud/50" : "bg-teal/30 text-aqua"
           }`}
         >
           {total}
@@ -80,25 +80,25 @@ function RelationCard({ rel }: { rel: RelationResult }) {
       </div>
 
       {empty ? (
-        <p className="px-4 py-4 text-xs italic text-cloud/40">No related rows.</p>
+        <p className="px-4 py-4 text-xs italic text-cloud/45">No related rows.</p>
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-xs">
-            <thead className="bg-white/[0.02]">
+            <thead className="bg-white/[0.03]">
               <tr>
                 {config.columns.map((c) => (
                   <th
                     key={c}
-                    className="whitespace-nowrap px-3 py-2 text-left text-[10px] font-medium uppercase tracking-wider text-cloud/50"
+                    className="whitespace-nowrap px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-wider text-aqua/70"
                   >
                     {c}
                   </th>
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-whisper">
+            <tbody className="divide-y divide-white/10">
               {rows.map((row, i) => (
-                <tr key={String(row.id ?? i)} className="hover:bg-white/[0.02]">
+                <tr key={String(row.id ?? i)} className="transition-colors hover:bg-teal/[0.07]">
                   {config.columns.map((c) => (
                     <td key={c} className="px-3 py-2 align-top">
                       {renderCell(c, row, config, foreignKeyLabels)}

--- a/app/(dashboard)/admin/explore/entity-picker.tsx
+++ b/app/(dashboard)/admin/explore/entity-picker.tsx
@@ -45,12 +45,12 @@ export function EntityPicker({
   };
 
   const selectClass =
-    "rounded-md border border-white/[0.10] bg-white/[0.04] px-3 py-2 text-sm text-white transition-colors duration-150 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal";
+    "rounded-md border border-white/15 bg-white/[0.06] px-3 py-2 text-sm text-white transition-colors duration-150 hover:border-teal/60 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal";
   const labelClass =
-    "text-[11px] font-semibold uppercase tracking-wider text-cloud/60";
+    "text-[11px] font-semibold uppercase tracking-wider text-aqua/80";
 
   return (
-    <div className="mb-4 flex flex-wrap items-end gap-4 rounded-md border border-whisper bg-white/[0.02] p-4">
+    <div className="mb-4 flex flex-wrap items-end gap-4 rounded-lg border border-white/10 bg-white/[0.04] p-4">
       {/* Entity */}
       <div className="flex flex-col gap-1">
         <label htmlFor="ee-entity" className={labelClass}>Entity</label>

--- a/app/(dashboard)/admin/explore/entity-picker.tsx
+++ b/app/(dashboard)/admin/explore/entity-picker.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+// Structural filters (DESIGN.md §11 "Data vs. filters"): entity selector, cycle
+// filter (auto-applied to cycleScoped entities), and the show-deleted toggle.
+// All state lives in the URL — changing any control navigates with new params and
+// resets to page 1. Free-text search is v2 (rendered disabled to mark placement).
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { REGISTRY } from "@/lib/entity-explorer/registry";
+import type { EntityKey } from "@/lib/entity-explorer/types";
+
+/** Entity dropdown groups, mirroring the mockup's optgroups. */
+const GROUPS: { label: string; keys: EntityKey[] }[] = [
+  { label: "Core", keys: ["cycles", "participants", "cycle_enrollments"] },
+  { label: "Pods", keys: ["problem_statements", "votes", "pods", "pod_memberships", "moderator_assignments"] },
+  { label: "Projects", keys: ["solution_proposals", "project_votes", "projects", "project_memberships"] },
+  { label: "Auth & engagement", keys: ["user_roles", "pulse_checks"] },
+];
+
+export type CycleOption = { id: number; name: string };
+
+export function EntityPicker({
+  entity,
+  cycles,
+  cycleId,
+  includeDeleted,
+}: {
+  entity: EntityKey;
+  cycles: CycleOption[];
+  cycleId: number | null;
+  includeDeleted: boolean;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Apply param updates and always reset to page 1 (filters changed).
+  const update = (changes: Record<string, string | null>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [key, value] of Object.entries(changes)) {
+      if (value === null || value === "") params.delete(key);
+      else params.set(key, value);
+    }
+    params.set("page", "1");
+    router.push(`/admin/explore?${params.toString()}`);
+  };
+
+  const selectClass =
+    "rounded-md border border-white/[0.10] bg-white/[0.04] px-3 py-2 text-sm text-white transition-colors duration-150 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal";
+  const labelClass =
+    "text-[11px] font-semibold uppercase tracking-wider text-cloud/60";
+
+  return (
+    <div className="mb-4 flex flex-wrap items-end gap-4 rounded-md border border-whisper bg-white/[0.02] p-4">
+      {/* Entity */}
+      <div className="flex flex-col gap-1">
+        <label htmlFor="ee-entity" className={labelClass}>Entity</label>
+        <select
+          id="ee-entity"
+          value={entity}
+          onChange={(e) => update({ entity: e.target.value })}
+          className={selectClass}
+        >
+          {GROUPS.map((group) => (
+            <optgroup key={group.label} label={group.label}>
+              {group.keys.map((key) => (
+                <option key={key} value={key}>{REGISTRY[key].label}</option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+      </div>
+
+      {/* Cycle */}
+      <div className="flex flex-col gap-1">
+        <label htmlFor="ee-cycle" className={labelClass}>Cycle</label>
+        <select
+          id="ee-cycle"
+          value={cycleId ?? ""}
+          onChange={(e) => update({ cycle: e.target.value || null })}
+          className={selectClass}
+        >
+          <option value="">All cycles</option>
+          {cycles.map((c) => (
+            <option key={c.id} value={c.id}>{c.name}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Show deleted */}
+      <label className="flex items-center gap-2 pb-2 text-sm text-cloud/85">
+        <input
+          type="checkbox"
+          checked={includeDeleted}
+          onChange={(e) => update({ deleted: e.target.checked ? "1" : null })}
+          className="h-4 w-4 rounded border-white/20 bg-white/[0.04] accent-teal"
+        />
+        Show deleted
+      </label>
+
+      {/* Search — v2, disabled, marks placement only (DESIGN.md §11). */}
+      <div className="ml-auto flex flex-col gap-1 opacity-50">
+        <label htmlFor="ee-search" className={labelClass}>
+          Search rows <span className="text-yellow-300/80">· v2</span>
+        </label>
+        <input
+          id="ee-search"
+          type="text"
+          placeholder="filter any column…"
+          disabled
+          className="rounded-md border border-white/[0.10] bg-white/[0.04] px-3 py-2 text-sm text-white placeholder:text-cloud/40"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/explore/entity-table.tsx
+++ b/app/(dashboard)/admin/explore/entity-table.tsx
@@ -40,9 +40,9 @@ export function EntityTable({
   return (
     <div>
       {/* Meta line */}
-      <div className="mb-2 flex items-center justify-between px-1 text-xs text-cloud/60">
+      <div className="mb-2 flex items-center justify-between px-1 text-xs text-cloud/70">
         <span>
-          Table <span className="font-mono text-cloud/85">{config.table}</span>
+          Table <span className="font-mono text-aqua">{config.table}</span>
           {config.cycleScoped && " · cycle-scoped"}
         </span>
         <span className="tabular-nums">
@@ -51,27 +51,27 @@ export function EntityTable({
       </div>
 
       {/* Table */}
-      <div className="overflow-x-auto rounded-md border border-whisper">
+      <div className="overflow-x-auto rounded-lg border border-white/10">
         <table className="w-full text-sm">
-          <thead className="bg-white/[0.04]">
+          <thead className="bg-teal/15">
             <tr>
               {config.columns.map((c) => (
                 <th
                   key={c}
-                  className="whitespace-nowrap px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60"
+                  className="whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-aqua"
                 >
                   {c}
                 </th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-whisper">
+          <tbody className="divide-y divide-white/10">
             {rows.map((row, i) => {
               const deleted = isRowDeleted(config, row);
               return (
                 <tr
                   key={String(row.id ?? i)}
-                  className={`transition-colors duration-150 hover:bg-white/[0.02] ${deleted ? "text-cloud/40" : ""}`}
+                  className={`transition-colors duration-150 hover:bg-teal/[0.07] ${deleted ? "text-cloud/40" : ""}`}
                 >
                   {config.columns.map((c, ci) => (
                     <td
@@ -99,7 +99,7 @@ export function EntityTable({
       </div>
 
       {/* Pagination */}
-      <div className="mt-3 flex items-center justify-between px-1 text-xs text-cloud/60">
+      <div className="mt-3 flex items-center justify-between px-1 text-xs text-cloud/70">
         <span>{pageSize} rows / page</span>
         <div className="flex gap-2">
           <PagerButton
@@ -129,12 +129,12 @@ function PagerButton({
   enabled: boolean;
   children: React.ReactNode;
 }) {
-  const base = "rounded-md border border-whisper px-3 py-1.5 text-xs transition-colors";
+  const base = "rounded-md border px-3 py-1.5 text-xs transition-colors";
   if (!enabled) {
-    return <span className={`${base} cursor-default text-cloud/30`} aria-disabled>{children}</span>;
+    return <span className={`${base} cursor-default border-white/10 text-cloud/30`} aria-disabled>{children}</span>;
   }
   return (
-    <Link href={href} className={`${base} text-cloud/85 hover:bg-white/[0.04] hover:text-cloud`}>
+    <Link href={href} className={`${base} border-teal/40 text-aqua hover:bg-teal/15 hover:text-aqua`}>
       {children}
     </Link>
   );

--- a/app/(dashboard)/admin/explore/entity-table.tsx
+++ b/app/(dashboard)/admin/explore/entity-table.tsx
@@ -1,0 +1,141 @@
+// Generic, registry-driven table (DESIGN.md §11). Dumb renderer: it shows exactly
+// the columns the registry declares, turns FK cells into links, collapses JSONB,
+// badges soft-deleted rows, and paginates. No entity-specific code.
+//
+// Server component: the only interactivity is JSONB expand (native <details>) and
+// navigation (<Link>), so no client JS is needed.
+
+import Link from "next/link";
+import type { FetchListResult } from "@/lib/entity-explorer/types";
+import { isRowDeleted, renderCell } from "./cells";
+
+function pagerHref(
+  entity: string,
+  cycleId: number | null,
+  includeDeleted: boolean,
+  page: number,
+): string {
+  const params = new URLSearchParams({ entity, page: String(page) });
+  if (cycleId != null) params.set("cycle", String(cycleId));
+  if (includeDeleted) params.set("deleted", "1");
+  return `/admin/explore?${params.toString()}`;
+}
+
+export function EntityTable({
+  result,
+  cycleId,
+  includeDeleted,
+}: {
+  result: FetchListResult;
+  cycleId: number | null;
+  includeDeleted: boolean;
+}) {
+  const { config, rows, page, pageSize, total, foreignKeyLabels } = result;
+
+  const firstRow = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const lastRow = (page - 1) * pageSize + rows.length;
+  const hasPrev = page > 1;
+  const hasNext = page * pageSize < total;
+
+  return (
+    <div>
+      {/* Meta line */}
+      <div className="mb-2 flex items-center justify-between px-1 text-xs text-cloud/60">
+        <span>
+          Table <span className="font-mono text-cloud/85">{config.table}</span>
+          {config.cycleScoped && " · cycle-scoped"}
+        </span>
+        <span className="tabular-nums">
+          {total === 0 ? "no rows" : `rows ${firstRow}–${lastRow} of ${total}`}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-md border border-whisper">
+        <table className="w-full text-sm">
+          <thead className="bg-white/[0.04]">
+            <tr>
+              {config.columns.map((c) => (
+                <th
+                  key={c}
+                  className="whitespace-nowrap px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-cloud/60"
+                >
+                  {c}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-whisper">
+            {rows.map((row, i) => {
+              const deleted = isRowDeleted(config, row);
+              return (
+                <tr
+                  key={String(row.id ?? i)}
+                  className={`transition-colors duration-150 hover:bg-white/[0.02] ${deleted ? "text-cloud/40" : ""}`}
+                >
+                  {config.columns.map((c, ci) => (
+                    <td
+                      key={c}
+                      className={`px-4 py-3 align-top ${ci === 0 && deleted ? "border-l-2 border-red" : ""}`}
+                    >
+                      {renderCell(c, row, config, foreignKeyLabels)}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+            {rows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={config.columns.length}
+                  className="px-4 py-8 text-center text-sm text-cloud/60"
+                >
+                  No rows.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="mt-3 flex items-center justify-between px-1 text-xs text-cloud/60">
+        <span>{pageSize} rows / page</span>
+        <div className="flex gap-2">
+          <PagerButton
+            href={pagerHref(config.key, cycleId, includeDeleted, page - 1)}
+            enabled={hasPrev}
+          >
+            ← Prev
+          </PagerButton>
+          <PagerButton
+            href={pagerHref(config.key, cycleId, includeDeleted, page + 1)}
+            enabled={hasNext}
+          >
+            Next →
+          </PagerButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PagerButton({
+  href,
+  enabled,
+  children,
+}: {
+  href: string;
+  enabled: boolean;
+  children: React.ReactNode;
+}) {
+  const base = "rounded-md border border-whisper px-3 py-1.5 text-xs transition-colors";
+  if (!enabled) {
+    return <span className={`${base} cursor-default text-cloud/30`} aria-disabled>{children}</span>;
+  }
+  return (
+    <Link href={href} className={`${base} text-cloud/85 hover:bg-white/[0.04] hover:text-cloud`}>
+      {children}
+    </Link>
+  );
+}

--- a/app/(dashboard)/admin/explore/env-banner.tsx
+++ b/app/(dashboard)/admin/explore/env-banner.tsx
@@ -23,7 +23,7 @@ export function EnvBanner() {
     return (
       <div
         role="status"
-        className="mb-6 flex items-center justify-center gap-2 rounded-md border border-red/40 bg-red/15 px-4 py-1.5 text-xs font-bold uppercase tracking-wider text-red-300"
+        className="mb-6 flex items-center justify-center gap-2 rounded-md border border-red/60 bg-red/25 px-4 py-2 text-xs font-bold uppercase tracking-wider text-red-200 shadow-[0_2px_10px_rgba(238,28,37,0.18)]"
       >
         <span aria-hidden>⚠</span>
         PROD — live participant data — {ref}
@@ -34,9 +34,9 @@ export function EnvBanner() {
   return (
     <div
       role="status"
-      className="mb-6 flex items-center justify-center gap-2 rounded-md border border-whisper bg-white/[0.04] px-4 py-1.5 text-xs font-bold uppercase tracking-wider text-cloud/60"
+      className="mb-6 flex items-center justify-center gap-2 rounded-md border border-teal/40 bg-teal/15 px-4 py-2 text-xs font-bold uppercase tracking-wider text-aqua"
     >
-      <span aria-hidden>●</span>
+      <span aria-hidden className="text-aqua">●</span>
       DEV — {ref}
     </div>
   );

--- a/app/(dashboard)/admin/explore/env-banner.tsx
+++ b/app/(dashboard)/admin/explore/env-banner.tsx
@@ -1,0 +1,43 @@
+// Environment banner (DESIGN.md §10).
+//
+// The same code serves dev and prod; only this banner changes. It reads the
+// deployment's own Supabase URL (and VERCEL_ENV as a fallback) so an organizer
+// can never confuse which database they're looking at. PROD is loud and red.
+
+/** OLOS production Supabase project ref (DESIGN.md §10). */
+const PROD_PROJECT_REF = "cdbgkgkjnomjnpicaxqe";
+
+/** Extract the project ref from a Supabase URL, e.g. https://<ref>.supabase.co. */
+function projectRef(url: string | undefined): string {
+  if (!url) return "unknown";
+  const match = url.match(/^https?:\/\/([^.]+)\./);
+  return match ? match[1] : "unknown";
+}
+
+export function EnvBanner() {
+  const ref = projectRef(process.env.NEXT_PUBLIC_SUPABASE_URL);
+  const isProd =
+    ref === PROD_PROJECT_REF || process.env.VERCEL_ENV === "production";
+
+  if (isProd) {
+    return (
+      <div
+        role="status"
+        className="mb-6 flex items-center justify-center gap-2 rounded-md border border-red/40 bg-red/15 px-4 py-1.5 text-xs font-bold uppercase tracking-wider text-red-300"
+      >
+        <span aria-hidden>⚠</span>
+        PROD — live participant data — {ref}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      className="mb-6 flex items-center justify-center gap-2 rounded-md border border-whisper bg-white/[0.04] px-4 py-1.5 text-xs font-bold uppercase tracking-wider text-cloud/60"
+    >
+      <span aria-hidden>●</span>
+      DEV — {ref}
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/explore/page.tsx
+++ b/app/(dashboard)/admin/explore/page.tsx
@@ -15,6 +15,7 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
 import { fetchEntityList } from "@/lib/entity-explorer/fetch";
 import { isEntityKey } from "@/lib/entity-explorer/registry";
+import { ENTITY_EXPLORER_ENABLED } from "@/lib/entity-explorer/flag";
 import type { EntityKey } from "@/lib/entity-explorer/types";
 import { EnvBanner } from "./env-banner";
 import { EntityPicker, type CycleOption } from "./entity-picker";
@@ -27,6 +28,9 @@ export default async function ExplorePage({
 }: {
   searchParams: Promise<{ entity?: string; cycle?: string; page?: string; deleted?: string }>;
 }) {
+  // Feature flag (DESIGN.md §4): off → the route doesn't exist.
+  if (!ENTITY_EXPLORER_ENABLED) notFound();
+
   const sp = await searchParams;
 
   // ── Auth: admin only. This is the sole guard over service-role reads. ──

--- a/app/(dashboard)/admin/explore/page.tsx
+++ b/app/(dashboard)/admin/explore/page.tsx
@@ -1,0 +1,98 @@
+// Entity Explorer — list view (DESIGN.md §7, §9).
+//
+// Guarded RSC. Reads ?entity, ?cycle, ?page, ?deleted; checks admin; fetches one
+// page via the registry-driven fetch; renders the generic table. The service-role
+// client bypasses RLS, so the isAdmin gate below is the ONLY thing protecting
+// every row — see DESIGN.md §8. Read-only: no mutation surface anywhere.
+//
+// NOTE: the ENTITY_EXPLORER_ENABLED flag + nav link land in step 4; until then
+// this route is reachable only by typing the URL and only by admins.
+
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
+import { fetchEntityList } from "@/lib/entity-explorer/fetch";
+import { isEntityKey } from "@/lib/entity-explorer/registry";
+import type { EntityKey } from "@/lib/entity-explorer/types";
+import { EnvBanner } from "./env-banner";
+import { EntityPicker, type CycleOption } from "./entity-picker";
+import { EntityTable } from "./entity-table";
+
+const DEFAULT_ENTITY: EntityKey = "pods";
+
+export default async function ExplorePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ entity?: string; cycle?: string; page?: string; deleted?: string }>;
+}) {
+  const sp = await searchParams;
+
+  // ── Auth: admin only. This is the sole guard over service-role reads. ──
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  const serviceClient = createServiceClient();
+  const userRoles = await resolveUserRoles(serviceClient, user.id);
+  if (!isAdmin(userRoles)) redirect("/cycles");
+
+  // ── Parse params. An explicit but unknown entity 404s (DESIGN.md §9.1). ──
+  let entity: EntityKey;
+  if (sp.entity == null) entity = DEFAULT_ENTITY;
+  else if (isEntityKey(sp.entity)) entity = sp.entity;
+  else notFound();
+
+  const cycleNum = sp.cycle != null ? Number(sp.cycle) : NaN;
+  const cycleId = Number.isFinite(cycleNum) ? cycleNum : null;
+  const page = Math.max(1, Number(sp.page) || 1);
+  const includeDeleted = sp.deleted === "1";
+
+  // ── Fetch the cycle list (for the filter) and the page in parallel. ──
+  const [{ data: cycles }, result] = await Promise.all([
+    serviceClient
+      .from("cycles")
+      .select("id, name")
+      .order("start_date", { ascending: false }),
+    fetchEntityList(serviceClient, { entity, cycleId, page, includeDeleted }),
+  ]);
+
+  const cycleOptions: CycleOption[] = (cycles ?? []).map((c) => ({
+    id: c.id as number,
+    name: (c.name as string) ?? `Cycle ${c.id}`,
+  }));
+
+  return (
+    <div>
+      <EnvBanner />
+
+      <div className="mb-6">
+        <Link
+          href="/admin"
+          className="inline-flex items-center gap-1.5 text-sm text-cloud/60 transition-colors duration-150 hover:text-aqua focus-visible:text-aqua focus-visible:outline-none"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden />
+          Admin
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight text-white">
+          Entity Explorer
+        </h1>
+        <p className="mt-1 text-sm text-cloud/60">
+          Browse raw records by entity. Read-only.
+        </p>
+      </div>
+
+      <EntityPicker
+        entity={entity}
+        cycles={cycleOptions}
+        cycleId={cycleId}
+        includeDeleted={includeDeleted}
+      />
+
+      <EntityTable result={result} cycleId={cycleId} includeDeleted={includeDeleted} />
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/explore/page.tsx
+++ b/app/(dashboard)/admin/explore/page.tsx
@@ -83,7 +83,7 @@ export default async function ExplorePage({
         <h1 className="text-2xl font-bold tracking-tight text-white">
           Entity Explorer
         </h1>
-        <p className="mt-1 text-sm text-cloud/60">
+        <p className="mt-1 text-sm text-cloud/70">
           Browse raw records by entity. Read-only.
         </p>
       </div>

--- a/app/(dashboard)/admin/explore/page.tsx
+++ b/app/(dashboard)/admin/explore/page.tsx
@@ -8,8 +8,6 @@
 // NOTE: the ENTITY_EXPLORER_ENABLED flag + nav link land in step 4; until then
 // this route is reachable only by typing the URL and only by admins.
 
-import Link from "next/link";
-import { ChevronLeft } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
@@ -17,6 +15,7 @@ import { fetchEntityList } from "@/lib/entity-explorer/fetch";
 import { isEntityKey } from "@/lib/entity-explorer/registry";
 import { ENTITY_EXPLORER_ENABLED } from "@/lib/entity-explorer/flag";
 import type { EntityKey } from "@/lib/entity-explorer/types";
+import { Breadcrumbs } from "./breadcrumbs";
 import { EnvBanner } from "./env-banner";
 import { EntityPicker, type CycleOption } from "./entity-picker";
 import { EntityTable } from "./entity-table";
@@ -73,15 +72,15 @@ export default async function ExplorePage({
     <div>
       <EnvBanner />
 
+      <Breadcrumbs
+        items={[
+          { label: "Admin", href: "/admin" },
+          { label: "Entity Explorer" },
+        ]}
+      />
+
       <div className="mb-6">
-        <Link
-          href="/admin"
-          className="inline-flex items-center gap-1.5 text-sm text-cloud/60 transition-colors duration-150 hover:text-aqua focus-visible:text-aqua focus-visible:outline-none"
-        >
-          <ChevronLeft className="h-4 w-4" aria-hidden />
-          Admin
-        </Link>
-        <h1 className="mt-2 text-2xl font-bold tracking-tight text-white">
+        <h1 className="text-2xl font-bold tracking-tight text-white">
           Entity Explorer
         </h1>
         <p className="mt-1 text-sm text-cloud/60">

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -3,6 +3,9 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
 import { StatusBadge } from "@/app/components/ui";
+// The one nav link into the Entity Explorer (DESIGN.md §4). Behind the same flag
+// as the route; removing the feature = delete this block + the two folders.
+import { ENTITY_EXPLORER_ENABLED } from "@/lib/entity-explorer/flag";
 import CreateCycleForm from "./cycles/create-cycle-form";
 
 type CycleStatus = "active" | "closed" | "draft";
@@ -63,6 +66,17 @@ export default async function AdminPage() {
           >
             All participants
           </Link>
+          {ENTITY_EXPLORER_ENABLED && (
+            <Link
+              href="/admin/explore"
+              className="inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold tracking-tight text-cloud/80 ring-1 ring-whisper transition-all duration-150 ease-spring hover:bg-white/[0.04] hover:text-cloud hover:ring-white/[0.12] active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2 focus-visible:ring-offset-midnight"
+            >
+              Explore
+              <span className="rounded bg-yellow-500/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-yellow-300">
+                flag
+              </span>
+            </Link>
+          )}
           <CreateCycleForm />
         </div>
       </div>

--- a/lib/entity-explorer/fetch.ts
+++ b/lib/entity-explorer/fetch.ts
@@ -1,0 +1,244 @@
+// Entity Explorer — generic, registry-driven fetch.
+//
+// A config-driven generalization of what app/(dashboard)/admin/participants/page.tsx
+// does by hand (DESIGN.md §5, §9): fetch a page of rows with the service-role
+// client, then batch-resolve foreign-key labels and join them in memory. Raw
+// supabase-js, no ORM.
+//
+// The query-building and join logic is split into small pure helpers
+// (exported for unit testing) from the single impure entry point fetchEntityList.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { DEFAULT_PAGE_SIZE, REGISTRY } from "./registry";
+import type {
+  EntityConfig,
+  EntityKey,
+  EntityRow,
+  FetchDetailResult,
+  FetchListParams,
+  FetchListResult,
+  Relation,
+  RelationResult,
+} from "./types";
+
+/** Max rows fetched per relation section in the detail view (DESIGN.md §6.1). */
+export const RELATION_ROW_LIMIT = 50;
+
+// ── Pure helpers ────────────────────────────────────────────────────────────
+
+/** Inclusive supabase `.range()` bounds for a 1-based page. */
+export function pageRange(
+  page: number,
+  pageSize: number,
+): { from: number; to: number } {
+  const safePage = Math.max(1, Math.floor(page) || 1);
+  const from = (safePage - 1) * pageSize;
+  return { from, to: from + pageSize - 1 };
+}
+
+/**
+ * The explicit column list to SELECT: displayed columns plus the columns the
+ * query needs even when not shown (id, FK columns, the soft-delete column, and
+ * cycle_id for the cycle filter). Deduped and order-stable. Never `select *`.
+ */
+export function buildSelectColumns(config: EntityConfig): string[] {
+  const cols = new Set<string>(["id", ...config.columns]);
+  for (const fk of config.foreignKeys) cols.add(fk.column);
+  if (config.softDelete) cols.add(config.softDelete.column);
+  if (config.cycleScoped) cols.add("cycle_id");
+  return [...cols];
+}
+
+/** Distinct, non-null values of `column` across the page's rows. */
+export function collectIds(
+  rows: EntityRow[],
+  column: string,
+): (number | string)[] {
+  const ids = new Set<number | string>();
+  for (const row of rows) {
+    const value = row[column];
+    if (value != null) ids.add(value as number | string);
+  }
+  return [...ids];
+}
+
+/**
+ * Build an `{ id -> label }` map from target rows. Falls back to `#<id>` when the
+ * label column is null/empty so a reference never renders blank.
+ */
+export function buildLabelMap(
+  targetRows: EntityRow[],
+  labelField: string,
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const row of targetRows) {
+    const id = row.id;
+    if (id == null) continue;
+    const key = String(id);
+    const raw = row[labelField];
+    map[key] = raw == null || raw === "" ? `#${key}` : String(raw);
+  }
+  return map;
+}
+
+/**
+ * The soft-delete filter to apply, as a description (pure & testable). The caller
+ * applies it to a query builder. Null when the entity has no soft delete.
+ */
+export function softDeleteFilter(
+  config: EntityConfig,
+):
+  | { kind: "isNull"; column: string }
+  | { kind: "notIn"; column: string; values: string }
+  | null {
+  const rule = config.softDelete;
+  if (!rule) return null;
+  if (rule.kind === "timestamp") return { kind: "isNull", column: rule.column };
+  return { kind: "notIn", column: rule.column, values: `(${rule.deletedValues.join(",")})` };
+}
+
+// ── Impure fetch ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolve FK-label maps for every foreign key on the page, one batched `.in()`
+ * query per FK column, run in parallel. Returns `{ fkColumn -> { id -> label } }`.
+ */
+async function resolveForeignKeyLabels(
+  supabase: SupabaseClient,
+  config: EntityConfig,
+  rows: EntityRow[],
+): Promise<Record<string, Record<string, string>>> {
+  const entries = await Promise.all(
+    config.foreignKeys.map(async (fk) => {
+      const ids = collectIds(rows, fk.column);
+      if (ids.length === 0) return [fk.column, {}] as const;
+
+      const target = REGISTRY[fk.target];
+      const { data, error } = await supabase
+        .from(target.table)
+        .select(`id, ${target.labelField}`)
+        .in("id", ids);
+      if (error) throw error;
+
+      // supabase-js can't statically type a dynamic select string, so it widens
+      // `data` to a ParserError shape — cast through unknown (the rows are plain).
+      return [
+        fk.column,
+        buildLabelMap((data ?? []) as unknown as EntityRow[], target.labelField),
+      ] as const;
+    }),
+  );
+  return Object.fromEntries(entries);
+}
+
+/**
+ * Fetch one page of an entity: server-side pagination, optional cycle filter,
+ * soft-delete filter, and batched FK-label resolution. The caller is responsible
+ * for the admin guard — this trusts that it runs behind it (DESIGN.md §8).
+ */
+export async function fetchEntityList(
+  supabase: SupabaseClient,
+  params: FetchListParams,
+): Promise<FetchListResult> {
+  const config = REGISTRY[params.entity];
+  const page = Math.max(1, params.page ?? 1);
+  const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
+  const includeDeleted = params.includeDeleted ?? false;
+  const { from, to } = pageRange(page, pageSize);
+
+  let query = supabase
+    .from(config.table)
+    .select(buildSelectColumns(config).join(", "), { count: "exact" })
+    .order(config.defaultSort.column, {
+      ascending: config.defaultSort.direction === "asc",
+    })
+    .range(from, to);
+
+  if (config.cycleScoped && params.cycleId != null) {
+    query = query.eq("cycle_id", params.cycleId);
+  }
+  const sd = includeDeleted ? null : softDeleteFilter(config);
+  if (sd) {
+    // NOT-IN (status) keeps unknown future statuses visible rather than hidden.
+    query = sd.kind === "isNull"
+      ? query.is(sd.column, null)
+      : query.not(sd.column, "in", sd.values);
+  }
+
+  const { data, count, error } = await query;
+  if (error) throw error;
+
+  // Dynamic select string → supabase-js infers a ParserError shape; cast through
+  // unknown. The runtime value is a plain array of rows.
+  const rows = (data ?? []) as unknown as EntityRow[];
+  const foreignKeyLabels = await resolveForeignKeyLabels(supabase, config, rows);
+
+  return { config, rows, page, pageSize, total: count ?? 0, foreignKeyLabels };
+}
+
+/** Fetch one reverse-relation section: rows that point back at `id` via `rel.via`. */
+async function fetchRelation(
+  supabase: SupabaseClient,
+  rel: Relation,
+  id: number | string,
+): Promise<RelationResult> {
+  const config = REGISTRY[rel.entity];
+
+  let query = supabase
+    .from(config.table)
+    .select(buildSelectColumns(config).join(", "), { count: "exact" })
+    .eq(rel.via, id)
+    .order(config.defaultSort.column, {
+      ascending: config.defaultSort.direction === "asc",
+    })
+    .range(0, RELATION_ROW_LIMIT - 1);
+
+  // Relation sections always hide soft-deleted rows (DESIGN.md §6.1).
+  const sd = softDeleteFilter(config);
+  if (sd) {
+    query = sd.kind === "isNull"
+      ? query.is(sd.column, null)
+      : query.not(sd.column, "in", sd.values);
+  }
+
+  const { data, count, error } = await query;
+  if (error) throw error;
+
+  const rows = (data ?? []) as unknown as EntityRow[];
+  const total = count ?? rows.length;
+  const foreignKeyLabels = await resolveForeignKeyLabels(supabase, config, rows);
+
+  return { relation: rel, config, rows, total, truncated: total > rows.length, foreignKeyLabels };
+}
+
+/**
+ * Fetch a record's detail / 360 view: the base row plus every reverse relation
+ * fetched in parallel and rendered as its own section (DESIGN.md §6.1). The caller
+ * is responsible for the admin guard. Returns `row: null` when the id doesn't exist.
+ */
+export async function fetchEntityDetail(
+  supabase: SupabaseClient,
+  entity: EntityKey,
+  id: number | string,
+): Promise<FetchDetailResult> {
+  const config = REGISTRY[entity];
+
+  const { data, error } = await supabase
+    .from(config.table)
+    .select(buildSelectColumns(config).join(", "))
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw error;
+
+  const row = (data ?? null) as unknown as EntityRow | null;
+  if (!row) {
+    return { config, row: null, foreignKeyLabels: {}, relations: [] };
+  }
+
+  const [foreignKeyLabels, relations] = await Promise.all([
+    resolveForeignKeyLabels(supabase, config, [row]),
+    Promise.all(config.relations.map((rel) => fetchRelation(supabase, rel, id))),
+  ]);
+
+  return { config, row, foreignKeyLabels, relations };
+}

--- a/lib/entity-explorer/flag.ts
+++ b/lib/entity-explorer/flag.ts
@@ -1,0 +1,13 @@
+// The single feature flag for the entire Entity Explorer (DESIGN.md §4).
+//
+// Default OFF: unless ENTITY_EXPLORER_ENABLED is exactly "true", the route 404s
+// and the nav link is hidden — the feature is invisible and inert. Flipping this
+// to expose the explorer is a separate decision from merging the code to dev
+// (DESIGN.md §12), so the merged code can sit dormant until deliberately enabled.
+//
+// Server-only (not NEXT_PUBLIC): the route guards and the nav link are all RSCs,
+// so the flag never needs to reach the client.
+//
+// Removal: drop this env var (DESIGN.md §4 removal checklist, step 3).
+export const ENTITY_EXPLORER_ENABLED =
+  process.env.ENTITY_EXPLORER_ENABLED === "true";

--- a/lib/entity-explorer/registry.ts
+++ b/lib/entity-explorer/registry.ts
@@ -1,0 +1,295 @@
+// Entity Explorer — the registry (the allowlist).
+//
+// This is the only non-generic part of the explorer (DESIGN.md §6). Every entity,
+// every displayed column, every FK target, and every reverse relation is listed by
+// hand. We never reflect the schema, so a future migration cannot silently surface
+// a new table or a sensitive column in the UI — a new entry has to be added here.
+//
+// Columns were verified against supabase/migrations/00001_initial_schema.sql plus
+// later additive migrations (00007, 00018, 00011) — NOT against the mockup, whose
+// column lists contain a few illustrative/fictional names. Deviations from the
+// mockup and from DESIGN.md §6 are flagged inline with `NOTE:`.
+
+import type { EntityConfig, EntityKey } from "./types";
+
+/** Server-side page size. Pagination is in from day one (DESIGN.md §11). */
+export const DEFAULT_PAGE_SIZE = 50;
+
+export const REGISTRY: Record<EntityKey, EntityConfig> = {
+  cycles: {
+    key: "cycles",
+    label: "Cycles",
+    table: "cycles",
+    columns: ["id", "name", "slug", "status", "start_date", "end_date"],
+    labelField: "name",
+    cycleScoped: false,
+    softDelete: null,
+    foreignKeys: [],
+    defaultSort: { column: "id", direction: "desc" },
+    relations: [],
+  },
+
+  participants: {
+    key: "participants",
+    label: "Participants",
+    table: "participants",
+    // NOTE: the participants table has ~40 columns, many sensitive (phone_number,
+    // dcpl_card, gender, neighborhood, linkedin, notes, …). We deliberately
+    // allowlist only the five the mockup shows. PII that IS shown (email,
+    // google_id) is intentional — organizers = admins already see it (DESIGN.md §6).
+    columns: ["id", "preferred_name", "email", "google_id", "created_at"],
+    labelField: "preferred_name",
+    cycleScoped: false,
+    softDelete: null,
+    foreignKeys: [],
+    defaultSort: { column: "created_at", direction: "desc" },
+    // Reverse relations for the participant 360 (DESIGN.md §6.1).
+    relations: [
+      { entity: "user_roles", via: "participant_id", label: "Roles" },
+      { entity: "cycle_enrollments", via: "participant_id", label: "Cycle enrollments" },
+      { entity: "pod_memberships", via: "participant_id", label: "Pod memberships" },
+      { entity: "moderator_assignments", via: "participant_id", label: "Moderator assignments" },
+      { entity: "problem_statements", via: "participant_id", label: "Problem statements" },
+      { entity: "votes", via: "voter_id", label: "Votes cast" },
+      { entity: "solution_proposals", via: "participant_id", label: "Solution proposals" },
+      { entity: "project_votes", via: "voter_id", label: "Project votes" },
+      { entity: "project_memberships", via: "participant_id", label: "Project memberships" },
+      { entity: "pulse_checks", via: "participant_id", label: "Pulse checks" },
+    ],
+  },
+
+  cycle_enrollments: {
+    key: "cycle_enrollments",
+    label: "Cycle enrollments",
+    table: "cycle_enrollments",
+    columns: ["id", "participant_id", "cycle_id", "status", "enrolled_at"],
+    labelField: "id",
+    cycleScoped: true,
+    // NOTE: soft delete here is the `status` flag, not a NULL-able timestamp.
+    // 'revoked' is treated as deleted (hidden by default, shown via the toggle);
+    // 'active' and 'inactive' stay visible — 'inactive' is the column default for
+    // a not-yet-activated enrollment, not a deletion.
+    softDelete: { kind: "status", column: "status", deletedValues: ["revoked"] },
+    foreignKeys: [
+      { column: "participant_id", target: "participants" },
+      { column: "cycle_id", target: "cycles" },
+    ],
+    defaultSort: { column: "enrolled_at", direction: "desc" },
+    relations: [],
+  },
+
+  problem_statements: {
+    key: "problem_statements",
+    label: "Problem statements",
+    table: "problem_statements",
+    // NOTE: mockup showed `name` and `votes` columns — neither exists. The real
+    // text column is `statement_text`; vote totals live in the `votes` table.
+    columns: ["id", "statement_text", "participant_id", "cycle_id", "created_at"],
+    labelField: "statement_text",
+    cycleScoped: true,
+    softDelete: null,
+    foreignKeys: [
+      { column: "participant_id", target: "participants" },
+      { column: "cycle_id", target: "cycles" },
+    ],
+    defaultSort: { column: "created_at", direction: "desc" },
+    relations: [],
+  },
+
+  votes: {
+    key: "votes",
+    label: "Votes",
+    table: "votes",
+    columns: ["id", "voter_id", "problem_statement_id", "vote_count", "created_at"],
+    labelField: "id",
+    cycleScoped: true,
+    softDelete: null,
+    foreignKeys: [
+      { column: "voter_id", target: "participants" },
+      { column: "problem_statement_id", target: "problem_statements" },
+      { column: "cycle_id", target: "cycles" },
+    ],
+    defaultSort: { column: "created_at", direction: "desc" },
+    relations: [],
+  },
+
+  pods: {
+    key: "pods",
+    label: "Pods",
+    table: "pods",
+    // NOTE: mockup showed a `members` column — that's a computed count, not a
+    // stored column, so it's omitted.
+    columns: ["id", "name", "status", "cycle_id", "created_at"],
+    labelField: "name",
+    cycleScoped: true,
+    softDelete: null,
+    foreignKeys: [{ column: "cycle_id", target: "cycles" }],
+    defaultSort: { column: "created_at", direction: "desc" },
+    // Reverse relations for the pod 360 (DESIGN.md §6.1 — "for free").
+    relations: [
+      { entity: "pod_memberships", via: "pod_id", label: "Pod memberships" },
+      { entity: "moderator_assignments", via: "pod_id", label: "Moderator assignments" },
+      { entity: "solution_proposals", via: "pod_id", label: "Solution proposals" },
+      { entity: "project_votes", via: "pod_id", label: "Project votes" },
+      { entity: "projects", via: "pod_id", label: "Projects" },
+    ],
+  },
+
+  pod_memberships: {
+    key: "pod_memberships",
+    label: "Pod memberships",
+    table: "pod_memberships",
+    // NOTE: mockup + DESIGN.md §6 call the soft-delete column `left_at`; the real
+    // column is `inactive_at` (migration 00001). Corrected here.
+    columns: ["id", "participant_id", "pod_id", "joined_at", "inactive_at"],
+    labelField: "id",
+    cycleScoped: false,
+    softDelete: { kind: "timestamp", column: "inactive_at" },
+    foreignKeys: [
+      { column: "participant_id", target: "participants" },
+      { column: "pod_id", target: "pods" },
+    ],
+    defaultSort: { column: "joined_at", direction: "desc" },
+    relations: [],
+  },
+
+  moderator_assignments: {
+    key: "moderator_assignments",
+    label: "Moderator assignments",
+    table: "moderator_assignments",
+    columns: ["id", "participant_id", "pod_id", "cycle_id", "assigned_at", "removed_at"],
+    labelField: "id",
+    cycleScoped: true,
+    softDelete: { kind: "timestamp", column: "removed_at" },
+    foreignKeys: [
+      { column: "participant_id", target: "participants" },
+      { column: "pod_id", target: "pods" },
+      { column: "cycle_id", target: "cycles" },
+    ],
+    defaultSort: { column: "assigned_at", direction: "desc" },
+    relations: [],
+  },
+
+  solution_proposals: {
+    key: "solution_proposals",
+    label: "Solution proposals",
+    table: "solution_proposals",
+    // `name` + `proposal_data` were added by migration 00018; `proposal_text`
+    // (a large text body) is deliberately omitted from the list view.
+    columns: ["id", "name", "pod_id", "participant_id", "proposal_data", "created_at"],
+    labelField: "name",
+    cycleScoped: true,
+    softDelete: null,
+    foreignKeys: [
+      { column: "cycle_id", target: "cycles" },
+      { column: "pod_id", target: "pods" },
+      { column: "participant_id", target: "participants" },
+    ],
+    defaultSort: { column: "created_at", direction: "desc" },
+    relations: [],
+  },
+
+  project_votes: {
+    key: "project_votes",
+    label: "Project votes",
+    table: "project_votes",
+    columns: ["id", "voter_id", "solution_proposal_id", "vote_count", "created_at"],
+    labelField: "id",
+    cycleScoped: true,
+    softDelete: null,
+    foreignKeys: [
+      { column: "voter_id", target: "participants" },
+      { column: "solution_proposal_id", target: "solution_proposals" },
+      { column: "cycle_id", target: "cycles" },
+    ],
+    defaultSort: { column: "created_at", direction: "desc" },
+    relations: [],
+  },
+
+  projects: {
+    key: "projects",
+    label: "Projects",
+    table: "projects",
+    columns: ["id", "name", "pod_id", "solution_proposal_id", "status", "cycle_id", "created_at"],
+    labelField: "name",
+    cycleScoped: true,
+    softDelete: null,
+    foreignKeys: [
+      { column: "cycle_id", target: "cycles" },
+      { column: "pod_id", target: "pods" },
+      { column: "solution_proposal_id", target: "solution_proposals" },
+    ],
+    defaultSort: { column: "created_at", direction: "desc" },
+    // Reverse relations for the project 360 (DESIGN.md §6.1 — "for free").
+    relations: [
+      { entity: "project_memberships", via: "project_id", label: "Project memberships" },
+    ],
+  },
+
+  project_memberships: {
+    key: "project_memberships",
+    label: "Project memberships",
+    table: "project_memberships",
+    // NOTE: mockup showed `joined_at`; the real column is `registered_at`.
+    columns: ["id", "participant_id", "project_id", "registered_at"],
+    labelField: "id",
+    // NOTE: DESIGN.md §6 marks this not-cycle-scoped with no soft delete, but the
+    // table DOES have `cycle_id` and `left_at` (migration 00001). Both are honored
+    // here so the cycle filter and show-deleted toggle work as elsewhere.
+    cycleScoped: true,
+    softDelete: { kind: "timestamp", column: "left_at" },
+    foreignKeys: [
+      { column: "participant_id", target: "participants" },
+      { column: "project_id", target: "projects" },
+    ],
+    defaultSort: { column: "registered_at", direction: "desc" },
+    relations: [],
+  },
+
+  user_roles: {
+    key: "user_roles",
+    label: "User roles",
+    table: "user_roles",
+    columns: ["id", "participant_id", "role", "granted_at", "revoked_at"],
+    labelField: "role",
+    cycleScoped: false,
+    softDelete: { kind: "timestamp", column: "revoked_at" },
+    foreignKeys: [{ column: "participant_id", target: "participants" }],
+    defaultSort: { column: "granted_at", direction: "desc" },
+    relations: [],
+  },
+
+  pulse_checks: {
+    key: "pulse_checks",
+    label: "Pulse checks",
+    table: "pulse_checks",
+    // NOTE: mockup showed `week` and `responses`; neither exists. The real
+    // columns are `scheduled_date`, `completed_at`, and `survey_responses` (JSONB).
+    columns: ["id", "participant_id", "cycle_id", "scheduled_date", "survey_responses", "created_at"],
+    labelField: "id",
+    // NOTE: pulse_checks.cycle_id was made nullable (migration 00004). The cycle
+    // filter (.eq) will therefore exclude rows with a null cycle_id when a cycle
+    // is selected; "All cycles" shows them.
+    cycleScoped: true,
+    softDelete: null,
+    foreignKeys: [
+      { column: "participant_id", target: "participants" },
+      { column: "cycle_id", target: "cycles" },
+    ],
+    defaultSort: { column: "created_at", direction: "desc" },
+    relations: [],
+  },
+};
+
+/** Ordered list of entity keys, for building the entity picker. */
+export const ENTITY_KEYS = Object.keys(REGISTRY) as EntityKey[];
+
+/** Runtime guard: is an arbitrary URL string an allowlisted entity key? */
+export function isEntityKey(value: string | null | undefined): value is EntityKey {
+  return value != null && Object.prototype.hasOwnProperty.call(REGISTRY, value);
+}
+
+/** Look up a config by (possibly untrusted) key; null when not allowlisted. */
+export function getEntityConfig(key: string | null | undefined): EntityConfig | null {
+  return isEntityKey(key) ? REGISTRY[key] : null;
+}

--- a/lib/entity-explorer/types.ts
+++ b/lib/entity-explorer/types.ts
@@ -1,0 +1,140 @@
+// Entity Explorer — module-internal types.
+//
+// Read-only admin entity browser (stopgap). See docs/entity-explorer/DESIGN.md.
+// Nothing outside lib/entity-explorer/ and app/(dashboard)/admin/explore/ should
+// import from this module — keeping it self-contained is what makes the feature
+// trivial to delete later (DESIGN.md §4).
+
+/**
+ * The closed set of entities the explorer can show. This union IS the allowlist:
+ * adding an entity means adding a key here and a matching REGISTRY entry. A new
+ * database table can never appear in the UI until someone edits this file
+ * (DESIGN.md §6.1 — "explicit allowlist, not schema reflection").
+ */
+export type EntityKey =
+  | "cycles"
+  | "participants"
+  | "cycle_enrollments"
+  | "problem_statements"
+  | "votes"
+  | "pods"
+  | "pod_memberships"
+  | "moderator_assignments"
+  | "solution_proposals"
+  | "project_votes"
+  | "projects"
+  | "project_memberships"
+  | "user_roles"
+  | "pulse_checks";
+
+export type SortDirection = "asc" | "desc";
+
+/**
+ * How an entity expresses "soft delete", so the show-deleted toggle can hide
+ * those rows by default and reveal them on demand (DESIGN.md §9.3):
+ *  - `timestamp`: deleted when `column` IS NOT NULL (e.g. removed_at, left_at).
+ *  - `status`: deleted when `column` is one of `deletedValues` (e.g.
+ *    cycle_enrollments.status = 'revoked'). NOT-IN, so unknown future statuses
+ *    stay visible rather than being silently hidden.
+ */
+export type SoftDeleteRule =
+  | { kind: "timestamp"; column: string }
+  | { kind: "status"; column: string; deletedValues: string[] };
+
+/** A forward foreign key: a column on this entity that points at another entity. */
+export interface ForeignKey {
+  /** Column on this entity holding the referenced row's id. */
+  column: string;
+  /** Registry key of the entity it points to. */
+  target: EntityKey;
+}
+
+/**
+ * A reverse relation: another entity whose rows point back at this one, used to
+ * assemble the detail / 360 view (DESIGN.md §6.1).
+ */
+export interface Relation {
+  /** Registry key of the entity that references this one. */
+  entity: EntityKey;
+  /** Column on that entity holding this entity's id. */
+  via: string;
+  /** Section heading in the 360 view. */
+  label: string;
+}
+
+/** How to display one entity. The only non-generic part of the explorer. */
+export interface EntityConfig {
+  /** URL slug, e.g. "pods". Matches the EntityKey. */
+  key: EntityKey;
+  /** UI display name, e.g. "Pods". */
+  label: string;
+  /** Supabase table name. */
+  table: string;
+  /** Ordered, explicit allowlist of columns to display. Never `select *`. */
+  columns: string[];
+  /** Column that best represents a row when it's referenced as a FK elsewhere. */
+  labelField: string;
+  /** True when the table has a `cycle_id` the global cycle filter applies to. */
+  cycleScoped: boolean;
+  /** How this entity soft-deletes rows, or null when it has no soft delete. */
+  softDelete: SoftDeleteRule | null;
+  /** Forward FK click-through map. */
+  foreignKeys: ForeignKey[];
+  /** Initial sort for the list view. `column` must appear in `columns`. */
+  defaultSort: { column: string; direction: SortDirection };
+  /** Reverse relations for the detail / 360 view (DESIGN.md §6.1). */
+  relations: Relation[];
+}
+
+/** A raw row as returned by supabase-js; values are untyped by design. */
+export type EntityRow = Record<string, unknown>;
+
+/** Parameters for a paginated list fetch. */
+export interface FetchListParams {
+  entity: EntityKey;
+  /** Applied as `.eq("cycle_id", …)` only when the entity is cycleScoped. */
+  cycleId?: number | null;
+  /** 1-based page number. */
+  page?: number;
+  /** Rows per page. Defaults to DEFAULT_PAGE_SIZE. */
+  pageSize?: number;
+  /** When false (default), soft-deleted rows are hidden. */
+  includeDeleted?: boolean;
+}
+
+/**
+ * Result of a list fetch. `foreignKeyLabels` maps an FK column on this entity to
+ * a `{ id -> display label }` map for the referenced rows present on this page,
+ * so the renderer can show a label instead of a bare id.
+ */
+export interface FetchListResult {
+  config: EntityConfig;
+  rows: EntityRow[];
+  page: number;
+  pageSize: number;
+  total: number;
+  foreignKeyLabels: Record<string, Record<string, string>>;
+}
+
+/** One reverse-relation section of a detail / 360 view (DESIGN.md §6.1). */
+export interface RelationResult {
+  relation: Relation;
+  /** Config of the related (referencing) entity. */
+  config: EntityConfig;
+  rows: EntityRow[];
+  /** Total matching rows; may exceed `rows.length` when capped. */
+  total: number;
+  /** True when more rows exist than were fetched. */
+  truncated: boolean;
+  foreignKeyLabels: Record<string, Record<string, string>>;
+}
+
+/** Result of a detail / 360 fetch: the base row plus every reverse relation. */
+export interface FetchDetailResult {
+  config: EntityConfig;
+  /** The base row, or null when no row has that id. */
+  row: EntityRow | null;
+  /** FK labels for the base row's own forward foreign keys. */
+  foreignKeyLabels: Record<string, Record<string, string>>;
+  relations: RelationResult[];
+}


### PR DESCRIPTION
Read-only admin **Entity Explorer** — a config-driven, disposable stopgap for browsing DB records by entity. Implements the approved `docs/entity-explorer/DESIGN.md`.

## What it does
- One screen: pick an entity → paginated table of its rows, with FK click-through, JSONB collapse, status pills, soft-delete handling, and a cycle filter.
- A record **360 / detail view**: base row + every reverse relation as its own section.
- Breadcrumb trail (`Admin › Entity Explorer › ‹Entity› › #id`) back to Admin from any page.
- DEV/PROD env banner so the viewer always knows which database they're in.

## Safety / scope
- **Read-only.** No writes/edits/deletes anywhere. Reads use `createServiceClient()` (RLS bypassed), so the **`isAdmin` route guard is the only protection** — applied on both routes.
- **No DB changes.** No new tables, no migrations, nothing to revert.
- **Off by default.** Gated behind a single `ENTITY_EXPLORER_ENABLED` flag (must be exactly `"true"`). Merging this leaves the feature **dormant** — exposing it to organizers is a separate decision (flip the env var).
- **Loosely coupled & removable.** All code lives in `app/(dashboard)/admin/explore/` and `lib/entity-explorer/`; the only external touch-point is the one flag-gated nav link in `app/(dashboard)/admin/page.tsx`.
- **Explicit allowlist registry** (`lib/entity-explorer/registry.ts`) — 14 entities, columns verified against `supabase/migrations/` (not the mockup). A future migration can't surface a sensitive table/column without a registry edit.

## To enable on dev
Set `ENTITY_EXPLORER_ENABLED=true` in the dev/preview environment (a Vercel **env var** — not a DB change). Leave it unset in prod.

## Removal checklist (DESIGN.md §4)
1. `rm -rf app/(dashboard)/admin/explore lib/entity-explorer`
2. Delete the nav block in `app/(dashboard)/admin/page.tsx`
3. Drop the `ENTITY_EXPLORER_ENABLED` env var

## Commits (built as the 4 planned steps + a follow-up)
1. registry, types & generic fetch (data layer)
2. read-only list view
3. record detail / 360 view
4. feature flag + admin nav link (default OFF)
5. breadcrumb trail back to Admin

## Verification
- `tsc --noEmit` + `eslint` clean.
- Dependency-free registry/pure-logic smoke test (202 assertions) green.
- Booted locally with the flag on against the **dev** DB; routes gate correctly and render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)