### PR TITLE
feat(#110 Phase C): two-stage revocation cron v2 (route + migration, unscheduled)

### DIFF
--- a/app/api/cron/revocation-check/route.ts
+++ b/app/api/cron/revocation-check/route.ts
@@ -1,98 +1,358 @@
 import { NextResponse, NextRequest } from "next/server";
 import { createServiceClient } from "@/lib/supabase/server";
+import { getResendClient, FROM_EMAIL } from "@/lib/email";
+import {
+  revocationWarningHtml,
+  revocationWarningText,
+  revocationWarningSubject,
+  type RevocationWarningReason,
+} from "@/lib/email/revocation-warning-template";
+import { reconcileEnrollmentActivation } from "@/lib/enrollment/reconciler";
+// Intentional cross-module import: the at-risk predicate is canonical in
+// lib/moderator/nudges.ts (it powers the poderator dashboard's nudge
+// surface). Reusing it here means the cron's revocation-candidate
+// identification matches what the moderator already sees flagged. If a
+// third caller emerges, extract to lib/engagement/at-risk.ts; YAGNI for
+// now. See roadmap §3.7 (Phase C design decisions).
+import { deriveAtRiskRun } from "@/lib/moderator/nudges";
 
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
+const SEND_DELAY_MS = 200;
 
+type Outcome = {
+  participant_id: number;
+  cycle_id: number;
+  action: "warned" | "revoked" | "recovered" | "skipped";
+  reason?: RevocationWarningReason;
+  detail?: string;
+};
+
+/**
+ * GET /api/cron/revocation-check
+ *
+ * Two-stage revocation cron rewriting the original buggy implementation
+ * (architecture review broken edges #1, #2, #7, #8, #9, #10, #11). The
+ * cron is currently UNSCHEDULED in vercel.json (PR #108 removed it
+ * during the May Energy hot-fix). Phase C.3 re-registers it after a
+ * ≥48h staging soak.
+ *
+ * What's different from the old route
+ * -----------------------------------
+ *   1. Cycle-scoped queries. The old route's not_in_pod check counted
+ *      pod_memberships across ALL cycles; this one joins to
+ *      pods.cycle_id = current_cycle.id (broken edge #1).
+ *   2. Window-aware not_in_pod. Only fires AFTER pod_registration_close.
+ *      During the open window, being pod-less is expected, not
+ *      revocation-worthy. This addresses the launch-time scenario where
+ *      late-joiners were getting revoked before they had a chance to
+ *      pick a pod.
+ *   3. deriveAtRiskRun-driven missed-pulses detection. Uses the canonical
+ *      predicate from lib/moderator/nudges.ts compared against
+ *      cycle_config.at_risk_consecutive_misses (default 2). Replaces
+ *      the old "7 days from created_at fallback" rule.
+ *   4. Two-stage warn → revoke with 3-day grace. The cron sends a
+ *      warning email and stamps warned_at on the first hit; subsequent
+ *      ticks check whether warned_at + 3 days has passed before
+ *      calling the reconciler.
+ *   5. State changes via reconcileEnrollmentActivation. The cron
+ *      doesn't directly mutate cycle_enrollments / pod_memberships /
+ *      access_revocations — it asks the Phase A reconciler to demote
+ *      the enrollment with logRevocation=true, and the reconciler
+ *      handles all the side effects atomically via service client.
+ *   6. Admin/owner exemption. Admins and owners with active enrollments
+ *      are never revoked by this cron — admins typically have no pod,
+ *      and that's by design. (The proper fix for admin participation
+ *      tracking lives in #122.)
+ *   7. Recovery clears warned_at. If a previously-warned participant
+ *      joins a pod or submits a pulse, the next cron tick clears
+ *      warned_at so a future warning starts fresh. This is what makes
+ *      admin-driven rescue via POST /api/admin/pods/[id]/memberships
+ *      compose correctly with the cron — see #123 for the parallel
+ *      moderator-add design question.
+ *   8. DB-enforced revocation idempotency. Migration 00030 adds a
+ *      unique partial index on access_revocations(participant_id,
+ *      cycle_id, reason) WHERE revocation_scope = 'full' so the
+ *      reconciler's INSERT can safely retry.
+ *
+ * Auth + observability are unchanged from the existing pattern:
+ *   - Bearer CRON_SECRET (same as pulse-check-reminder)
+ *   - console.log lines for each outcome (visible in Vercel logs)
+ *   - JSON response body summarizes counts + outcomes for monitoring
+ *
+ * Out of scope (filed separately)
+ * --------------------------------
+ *   - Admin pulse-check tracking via secret pod or role exemption (#122)
+ *   - pulse-check-reminder cron idempotency (#121)
+ *   - Moderator pod-membership add power (#123)
+ *   - Admin audit columns covering #115's scope
+ */
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrl) {
+    console.error(
+      "[revocation-check] NEXT_PUBLIC_APP_URL is not set — aborting before any action"
+    );
+    return NextResponse.json(
+      { error: "NEXT_PUBLIC_APP_URL is not set" },
+      { status: 500 }
+    );
+  }
+
   const supabase = createServiceClient();
   const now = new Date();
   const nowIso = now.toISOString();
+  const dashboardUrl = `${appUrl}/dashboard`;
+  const pulseUrl = `${appUrl}/pulse-check`;
+  const resend = getResendClient();
 
+  const outcomes: Outcome[] = [];
+
+  // Active cycles with their config (pod_registration_close + threshold)
   const { data: cycles } = await supabase
     .from("cycles")
-    .select("id")
+    .select(
+      "id, cycle_config(pod_registration_close, at_risk_consecutive_misses)"
+    )
     .eq("status", "active");
 
-  let totalRevoked = 0;
+  for (const cycle of cycles ?? []) {
+    const cycleId = cycle.id;
+    const config = Array.isArray(cycle.cycle_config)
+      ? cycle.cycle_config[0]
+      : cycle.cycle_config;
+    if (!config) {
+      console.warn(
+        `[revocation-check] cycle ${cycleId} has no cycle_config; skipping`
+      );
+      continue;
+    }
+    const podRegistrationClosed =
+      config.pod_registration_close !== null &&
+      new Date(config.pod_registration_close).getTime() < now.getTime();
+    const missThreshold = config.at_risk_consecutive_misses ?? 2;
 
-  for (const cycle of cycles || []) {
+    // Active enrollments in this cycle, with the participant's identity,
+    // email, current warning state, and role list (for admin exemption).
+    // user_roles is filtered to non-revoked rows in the JS layer below;
+    // an empty roles array means the participant has no special privileges.
     const { data: enrollments } = await supabase
       .from("cycle_enrollments")
-      .select("participant_id, participants:participant_id(last_pulse_completed_at, created_at)")
-      .eq("cycle_id", cycle.id)
+      .select(
+        `participant_id,
+         warned_at,
+         warning_reason,
+         participants:participant_id(id, email, first_name, preferred_name,
+           user_roles(role, revoked_at))`
+      )
+      .eq("cycle_id", cycleId)
       .eq("status", "active");
 
-    for (const enrollment of enrollments || []) {
+    for (const enrollment of enrollments ?? []) {
       const pid = enrollment.participant_id;
       const participant = Array.isArray(enrollment.participants)
         ? enrollment.participants[0]
         : enrollment.participants;
-      let shouldRevoke = false;
-      let reason = "";
+      if (!participant) continue;
 
-      const { count: podCount } = await supabase
+      // Admin/owner exemption (interim until #122 ships the secret-pod
+      // or role-exemption design)
+      const roles = (participant.user_roles ?? []).filter(
+        (r: { role: string; revoked_at: string | null }) =>
+          r.revoked_at === null
+      );
+      const isAdminOrOwner = roles.some(
+        (r: { role: string }) => r.role === "admin" || r.role === "owner"
+      );
+      if (isAdminOrOwner) {
+        outcomes.push({
+          participant_id: pid,
+          cycle_id: cycleId,
+          action: "skipped",
+          detail: "admin_or_owner_exempt",
+        });
+        continue;
+      }
+
+      // === Reason determination ===
+
+      // Cycle-scoped active pod memberships (fixes architecture review
+      // broken edge #1 — old route counted across all cycles)
+      const { data: membershipRows } = await supabase
         .from("pod_memberships")
-        .select("id", { count: "exact", head: true })
+        .select("id, pods!inner(cycle_id)")
         .eq("participant_id", pid)
+        .eq("pods.cycle_id", cycleId)
         .is("inactive_at", null);
+      const activePodCount = (membershipRows ?? []).length;
 
-      if (!podCount || podCount === 0) {
-        shouldRevoke = true;
+      // Pulse history for at-risk run derivation
+      const { data: pulseRows } = await supabase
+        .from("pulse_checks")
+        .select("scheduled_date, completed_at")
+        .eq("participant_id", pid)
+        .eq("cycle_id", cycleId);
+
+      let reason: RevocationWarningReason | null = null;
+
+      // Reason A: not_in_pod — only AFTER pod_registration_close
+      // (window-aware; addresses launch-time late-joiner scenario)
+      if (podRegistrationClosed && activePodCount === 0) {
         reason = "not_in_pod";
       }
 
-      if (!shouldRevoke && participant) {
-        const baseline =
-          participant.last_pulse_completed_at ?? participant.created_at;
-        if (baseline) {
-          const baselineMs = new Date(baseline).getTime();
-          if (now.getTime() - baselineMs > SEVEN_DAYS_MS) {
-            shouldRevoke = true;
-            reason = "missed_pulse_check_7day";
-          }
+      // Reason B: missed_pulses — only when the participant DOES have a
+      // pod (otherwise reason A applies first) and the consecutive-miss
+      // run exceeds the cycle's threshold
+      if (!reason && activePodCount > 0) {
+        const run = deriveAtRiskRun(pid, pulseRows ?? []);
+        if (run && run.consecutiveMisses >= missThreshold) {
+          reason = "missed_pulses";
         }
       }
 
-      if (!shouldRevoke) continue;
+      // === Recovery: clear warned_at if no reason applies but warning was set
+      if (!reason && enrollment.warned_at !== null) {
+        await supabase
+          .from("cycle_enrollments")
+          .update({ warned_at: null, warning_reason: null })
+          .eq("participant_id", pid)
+          .eq("cycle_id", cycleId);
+        outcomes.push({
+          participant_id: pid,
+          cycle_id: cycleId,
+          action: "recovered",
+          detail: "warning_cleared",
+        });
+        continue;
+      }
 
-      await supabase
-        .from("pod_memberships")
-        .update({ inactive_at: nowIso })
-        .eq("participant_id", pid)
-        .is("inactive_at", null);
+      // Nothing to do for this participant
+      if (!reason) continue;
 
-      await supabase
-        .from("project_memberships")
-        .update({ left_at: nowIso })
-        .eq("participant_id", pid)
-        .eq("cycle_id", cycle.id)
-        .is("left_at", null);
+      // === Two-stage handler ===
 
-      await supabase
-        .from("cycle_enrollments")
-        .update({ status: "inactive", inactive_date: nowIso })
-        .eq("participant_id", pid)
-        .eq("cycle_id", cycle.id);
+      if (enrollment.warned_at === null) {
+        // Stage 1: send warning + stamp warned_at
+        const firstName =
+          participant.preferred_name || participant.first_name || "there";
+        const actionUrl = reason === "missed_pulses" ? pulseUrl : dashboardUrl;
+        if (!participant.email) {
+          outcomes.push({
+            participant_id: pid,
+            cycle_id: cycleId,
+            action: "skipped",
+            detail: "no_email",
+          });
+          continue;
+        }
+        try {
+          const { error: sendError } = await resend.emails.send({
+            from: FROM_EMAIL,
+            to: participant.email,
+            subject: revocationWarningSubject(reason),
+            html: revocationWarningHtml({ reason, actionUrl, firstName }),
+            text: revocationWarningText({ reason, actionUrl, firstName }),
+          });
+          if (sendError) {
+            console.error(
+              `[revocation-check] warning send failed participant_id=${pid} cycle_id=${cycleId} reason=${reason} error=${sendError.message ?? String(sendError)}`
+            );
+            outcomes.push({
+              participant_id: pid,
+              cycle_id: cycleId,
+              action: "skipped",
+              detail: `send_failed: ${sendError.message ?? "unknown"}`,
+            });
+            continue;
+          }
+          await supabase
+            .from("cycle_enrollments")
+            .update({ warned_at: nowIso, warning_reason: reason })
+            .eq("participant_id", pid)
+            .eq("cycle_id", cycleId);
+          outcomes.push({
+            participant_id: pid,
+            cycle_id: cycleId,
+            action: "warned",
+            reason,
+          });
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e);
+          console.error(
+            `[revocation-check] warning exception participant_id=${pid} cycle_id=${cycleId} reason=${reason} error=${message}`
+          );
+          outcomes.push({
+            participant_id: pid,
+            cycle_id: cycleId,
+            action: "skipped",
+            detail: `exception: ${message}`,
+          });
+        }
+        await new Promise((r) => setTimeout(r, SEND_DELAY_MS));
+        continue;
+      }
 
-      await supabase.from("access_revocations").insert({
-        participant_id: pid,
-        cycle_id: cycle.id,
+      // warned_at IS NOT NULL — check the grace period
+      const warnedAtMs = new Date(enrollment.warned_at).getTime();
+      if (now.getTime() - warnedAtMs < THREE_DAYS_MS) {
+        // Still in grace period
+        continue;
+      }
+
+      // Stage 2: grace expired — revoke via the reconciler.
+      // The reconciler reads current pod-membership reality and demotes
+      // cycle_enrollments.status to 'inactive' if appropriate. Setting
+      // logRevocation=true makes it INSERT the access_revocations row.
+      // Migration 00030's unique partial index means the INSERT is
+      // idempotent even if this cron retries.
+      const result = await reconcileEnrollmentActivation(pid, cycleId, {
         reason,
-        revocation_scope: "full",
-        revoked_systems: ["pod_membership", "project_membership", "enrollment"],
+        logRevocation: true,
       });
-
-      totalRevoked++;
+      console.log(
+        `[revocation-check] revoked participant_id=${pid} cycle_id=${cycleId} reason=${reason} before=${result.before} after=${result.after} audited=${result.audited}`
+      );
+      outcomes.push({
+        participant_id: pid,
+        cycle_id: cycleId,
+        action: "revoked",
+        reason,
+        detail: `before=${result.before} after=${result.after}`,
+      });
     }
   }
 
+  const warnedCount = outcomes.filter((o) => o.action === "warned").length;
+  const revokedCount = outcomes.filter((o) => o.action === "revoked").length;
+  const recoveredCount = outcomes.filter((o) => o.action === "recovered")
+    .length;
+  const skippedCount = outcomes.filter((o) => o.action === "skipped").length;
+
   return NextResponse.json({
-    revoked_count: totalRevoked,
-    timestamp: new Date().toISOString(),
+    warned_count: warnedCount,
+    revoked_count: revokedCount,
+    recovered_count: recoveredCount,
+    skipped_count: skippedCount,
+    breakdown: {
+      not_in_pod_warned: outcomes.filter(
+        (o) => o.action === "warned" && o.reason === "not_in_pod"
+      ).length,
+      missed_pulses_warned: outcomes.filter(
+        (o) => o.action === "warned" && o.reason === "missed_pulses"
+      ).length,
+      not_in_pod_revoked: outcomes.filter(
+        (o) => o.action === "revoked" && o.reason === "not_in_pod"
+      ).length,
+      missed_pulses_revoked: outcomes.filter(
+        (o) => o.action === "revoked" && o.reason === "missed_pulses"
+      ).length,
+    },
+    outcomes,
+    timestamp: nowIso,
   });
 }

--- a/docs/OLOS-roadmap.md
+++ b/docs/OLOS-roadmap.md
@@ -239,9 +239,31 @@ graph TD
 **Solution:** one `reconcileEnrollmentActivation` helper called by every lifecycle code path, plus admin/moderator UI for the manual fixes currently requiring SQL, plus a redesigned revocation cron with cycle-scoped checks and a warning state before revocation.
 
 **Three phases:**
-- **Phase A** (~half-day) — reconciler + auth-callback `ignoreDuplicates` fix + placeholder-name guard in `fulfillInvitation` + RLS `WITH CHECK` migration + `pod_memberships_select` tightening.
-- **Phase B** (~one day) — admin/moderator self-service UI: PATCH /api/participants/[id], `/profile/edit` dual mode (Mode A self-edit, Mode B forced completion), admin pod-membership add/remove, admin pod-status override, stuck-inactive filter.
-- **Phase C** (~1–2 days) — revocation cron v2: cycle-scoped queries, baseline = `MAX(activated_at, pod_registration_open_at)`, two-stage handler (warning + 3-day grace, then revoke), idempotency via unique partial index on `access_revocations`. Re-register cron in `vercel.json` after ≥48h staging soak.
+- **Phase A** ([PR #111](https://github.com/TheUpskillingLabs/OLOS/pull/111), merged) — reconciler + auth-callback `ignoreDuplicates` fix + placeholder-name guard in `fulfillInvitation` + RLS `WITH CHECK` migration + `pod_memberships_select` tightening.
+- **Phase B** ([PR #116](https://github.com/TheUpskillingLabs/OLOS/pull/116), merged) — admin/moderator self-service UI: PATCH /api/participants/[id], `/profile/edit` dual mode (Mode A self-edit, Mode B forced completion), admin pod-membership add/remove, admin pod-status override, stuck-inactive filter.
+- **Phase C** (in flight, branch `110-phase-c-cron-v2`) — revocation cron v2: cycle-scoped queries, baseline = `MAX(activated_at, pod_registration_open_at)`, two-stage handler (warning + 3-day grace, then revoke), idempotency via unique partial index on `access_revocations`. Re-register cron in `vercel.json` after ≥48h staging soak.
+
+### Phase C design decisions captured (2026-06-03)
+
+Scope-shrinking findings from a pre-Phase-C audit of Madhu's recent `feat/poderator-dashboard` work that landed on dev:
+
+- **Threshold config already exists.** Migration `00026_cycle_config_extensions.sql` added `at_risk_consecutive_misses INT NOT NULL DEFAULT 2`. Matches the architecture brief's "2+ consecutive missed pulses" rule verbatim. Phase C reads this column rather than creating a parallel one.
+- **At-risk predicate already exists.** `lib/moderator/nudges.ts` exports `deriveAtRiskRun(participantId, pulses)` which returns the current consecutive-miss run. Phase C imports this rather than reimplementing the logic — same predicate powers both the moderator's at-risk nudge AND the cron's revocation candidate identification. (If a third caller emerges, file a follow-up to extract to `lib/engagement/at-risk.ts`; YAGNI for now.)
+- **Warning state: column, not table.** Adding `warned_at` + `warning_reason` columns to `cycle_enrollments` (Option A) rather than a new `enrollment_warnings` table (Option B). Reasoning:
+  - One warning type today (missed_pulses); multi-reason warnings are hypothetical
+  - Cron is currently disabled — warning volume is zero, will be modest when re-enabled
+  - Email-send idempotency is solved separately by the planned `pulse_check_reminders_sent` ledger
+  - Forward-compatible: migration A → B is ~30 minutes when needs evolve (INSERT one row per existing `warned_at`, drop the columns)
+  - Accepted trade-off: warnings that resolve via recovery (not revocation) leave no historical row. `access_revocations` continues to log completed revocations. If "show me every warning we sent this cycle" becomes a real ask, Option B is the trigger.
+- **Migration numbering.** Phase C's migration is `00030_revocation_warnings_and_idempotency.sql` (after MJ's 00029_feedback). The `supabase/CLAUDE.md` renumber-history section captures the 00015→00028 lesson — Phase C's number is chosen by reading `ls supabase/migrations/ | tail -1` per that doc's guidance.
+
+### Phase C concrete deliverables
+
+1. **Migration 00030** — adds `warned_at TIMESTAMP NULL` and `warning_reason VARCHAR(100) NULL` to `cycle_enrollments`. Adds unique partial index on `access_revocations(participant_id, cycle_id, reason) WHERE revocation_scope = 'full'`.
+2. **Rewrite `app/api/cron/revocation-check/route.ts`** — service client (unchanged), CRON_SECRET auth (unchanged), cycle-scoped queries (fixed from cross-cycle bug), `deriveAtRiskRun` import (new), two-stage warn-then-revoke handler with 3-day grace (new), reconciler integration with `logRevocation=true` (new).
+3. **`pulse_check_reminders_sent` table or equivalent** — verify existing pulse-check-reminder cron's idempotency state before designing; reuse pattern if present.
+4. **Re-register cron in `vercel.json`** — last step, gated by ≥48h staging soak.
+
 
 **Subsumed tickets** (closed as completed via the link-back convention, since the work IS being done — in #110):
 - #102 (profile-completion redirect Mode B) → Phase B

--- a/lib/email/revocation-warning-template.ts
+++ b/lib/email/revocation-warning-template.ts
@@ -1,0 +1,158 @@
+/**
+ * Warning email sent by the two-stage revocation cron (#110 Phase C)
+ * three days before any actual revocation. Mirrors the structure of
+ * pulse-check-reminder-template.ts so subject/HTML/text are consumed
+ * the same way by the cron's Resend integration.
+ *
+ * Two variants today, distinguishing the WHY behind the warning:
+ *
+ *   - 'not_in_pod'    — pod_registration_close has passed and the
+ *                       participant still has no active pod
+ *   - 'missed_pulses' — participant has the configured number of
+ *                       consecutive missed pulses
+ *
+ * Tone is firm but recoverable. The deadline language is intentionally
+ * concrete: "your access will be paused in 3 days" rather than "your
+ * account will be revoked." Aligns with the architecture brief invariant
+ * #5 ("soft delete everywhere") and the architectural intent that an
+ * inactive participant can be reactivated by re-engagement.
+ */
+
+export type RevocationWarningReason = "not_in_pod" | "missed_pulses";
+
+type WarningProps = {
+  reason: RevocationWarningReason;
+  /** URL the participant should visit to act on the warning. */
+  actionUrl: string;
+  /** Display name to address the email to (preferred_name or first_name). */
+  firstName: string;
+};
+
+function variantCopy(reason: RevocationWarningReason): {
+  subject: string;
+  heading: string;
+  lede: string;
+  cta: string;
+} {
+  switch (reason) {
+    case "not_in_pod":
+      return {
+        subject: "Your Upskilling Labs cohort access pauses in 3 days",
+        heading: "You haven't joined a pod yet",
+        lede:
+          "Pod registration for this cycle has closed and you haven't joined a pod. To stay active in the cohort, please reach out to your cycle organizer or accept a pod invitation in the next <strong style=\"color:#ffffff;\">3 days</strong>. After that your cohort access will be paused.",
+        cta: "Open your dashboard →",
+      };
+    case "missed_pulses":
+      return {
+        subject: "Your Upskilling Labs cohort access pauses in 3 days",
+        heading: "We haven't heard from you in a while",
+        lede:
+          "You've missed your last two pulse checks. To stay active in the cohort, please submit a pulse check in the next <strong style=\"color:#ffffff;\">3 days</strong>. After that your cohort access will be paused — but you can rejoin anytime.",
+        cta: "Submit pulse check →",
+      };
+  }
+}
+
+function variantTextLede(reason: RevocationWarningReason): string {
+  switch (reason) {
+    case "not_in_pod":
+      return "Pod registration for this cycle has closed and you haven't joined a pod. To stay active in the cohort, please reach out to your cycle organizer or accept a pod invitation in the next 3 days. After that your cohort access will be paused.";
+    case "missed_pulses":
+      return "You've missed your last two pulse checks. To stay active in the cohort, please submit a pulse check in the next 3 days. After that your cohort access will be paused — but you can rejoin anytime.";
+  }
+}
+
+export function revocationWarningSubject(
+  reason: RevocationWarningReason
+): string {
+  return variantCopy(reason).subject;
+}
+
+export function revocationWarningHtml({
+  reason,
+  actionUrl,
+  firstName,
+}: WarningProps): string {
+  const { heading, lede, cta } = variantCopy(reason);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>${heading}</title>
+</head>
+<body style="margin:0;padding:0;background:#0b1016;font-family:-apple-system,BlinkMacSystemFont,'SF Pro Text','Helvetica Neue',sans-serif;color:#e6e6e6;-webkit-font-smoothing:antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0b1016;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.07);border-radius:12px;padding:32px;">
+          <tr>
+            <td>
+              <p style="margin:0 0 8px;font-size:12px;font-weight:500;letter-spacing:0.08em;text-transform:uppercase;color:#4dbbc2;">
+                Upskilling Labs
+              </p>
+              <h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:#ffffff;line-height:1.3;letter-spacing:-0.01em;">
+                ${heading}
+              </h1>
+              <p style="margin:0 0 16px;font-size:15px;color:#e6e6e6;line-height:1.6;">
+                Hi ${firstName},
+              </p>
+              <p style="margin:0 0 28px;font-size:15px;color:#e6e6e6;line-height:1.6;">
+                ${lede}
+              </p>
+
+              <!-- CTA -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 28px;">
+                <tr>
+                  <td align="left" style="background:#0094a0;border-radius:8px;">
+                    <a href="${actionUrl}"
+                       style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;letter-spacing:-0.01em;border-radius:8px;">
+                      ${cta}
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Fallback link -->
+              <p style="margin:0 0 16px;font-size:12px;color:rgba(200,210,230,0.45);line-height:1.6;">
+                If the button doesn't work, paste this link into your browser:<br />
+                <a href="${actionUrl}" style="color:#00b8c8;word-break:break-all;">${actionUrl}</a>
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top:24px;">
+              <p style="margin:0;font-size:12px;color:rgba(200,210,230,0.35);line-height:1.6;">
+                You're receiving this because you're enrolled in an active Upskilling Labs cycle. If you'd prefer to step away, no action needed — your access will pause automatically.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+export function revocationWarningText({
+  reason,
+  actionUrl,
+  firstName,
+}: WarningProps): string {
+  const { heading } = variantCopy(reason);
+  return `${heading}
+
+Hi ${firstName},
+
+${variantTextLede(reason)}
+
+Open the platform here:
+${actionUrl}
+
+You're receiving this because you're enrolled in an active Upskilling Labs cycle. If you'd prefer to step away, no action needed — your access will pause automatically.`;
+}

--- a/supabase/migrations/00030_revocation_warnings_and_idempotency.sql
+++ b/supabase/migrations/00030_revocation_warnings_and_idempotency.sql
@@ -1,0 +1,73 @@
+-- ROADMAP §3.7 / ISSUE #110 Phase C / Architecture review broken edges #10, #11
+--
+-- Two changes that together make the revocation cron safe to re-enable:
+--
+-- 1. Warning state on cycle_enrollments (architecture review broken edge #10).
+--    The redesigned cron is a two-stage handler: send a warning email and
+--    set `warned_at` first; then on a later tick, if the participant is
+--    still eligible for revocation AND warned_at + 3 days <= now(), revoke.
+--    This gives a 3-day grace period after the warning before any
+--    revocation fires. `warning_reason` distinguishes 'missed_pulses' from
+--    future reasons ('not_in_pod', etc.) without overloading one column.
+--
+-- 2. Idempotent access_revocations writes (architecture review broken edge #11).
+--    Unique partial index on (participant_id, cycle_id, reason) WHERE
+--    revocation_scope='full'. Without this, a cron retry / double-run could
+--    insert duplicate revocation rows. The partial scope clause keeps the
+--    constraint narrow: future non-full revocations (e.g. partial scope for
+--    a specific subsystem) aren't blocked from re-running.
+--
+-- Design note — warnings as columns, not a table
+-- -----------------------------------------------
+-- We considered two shapes for the warning state:
+--   (A, chosen): `warned_at` + `warning_reason` columns on cycle_enrollments
+--   (B):         A separate `enrollment_warnings` table with full history
+--
+-- Option A is sufficient for the current use case: one warning type
+-- (missed_pulses), at most one active warning per enrollment, cron volume
+-- is low. The architecture brief's audit precedent (access_revocations) only
+-- logs completed revocations; warnings that resolve via recovery leave no
+-- historical row. That trade-off is accepted for now and documented in
+-- roadmap §3.7's Phase C section.
+--
+-- Migration A → B is cheap if the use case evolves: INSERT one row per
+-- existing warned_at value into the new table, drop these columns. The
+-- triggers to revisit are: (1) a second warning type ships, OR (2) a
+-- program manager asks for warning-history reports across cycles, OR (3)
+-- compliance becomes a documented organizational need.
+--
+-- Design note — idempotency mechanism
+-- ------------------------------------
+-- The cron's email-send idempotency is state-driven via `warned_at`: if
+-- the column is set and warned_at + grace_period > now(), the warning is
+-- still active — don't re-warn. No separate `cron_runs` ledger needed.
+-- The unique partial index below provides DB-enforced idempotency for the
+-- final revocation step so that a retry can use INSERT ... ON CONFLICT
+-- DO NOTHING and not duplicate rows.
+--
+-- The pulse-check-reminder cron at app/api/cron/pulse-check-reminder/
+-- route.ts has a related but separate idempotency gap (no DB-backed
+-- per-send tracking; in-run Set<number> dedup only). Tracked as a
+-- follow-up; out of scope for Phase C.
+
+ALTER TABLE cycle_enrollments
+  ADD COLUMN IF NOT EXISTS warned_at      TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS warning_reason VARCHAR(100);
+
+COMMENT ON COLUMN cycle_enrollments.warned_at IS
+  'Set when the revocation cron sends a warning email. Cleared (or stays set, then ignored) when the participant recovers. Acts as the email-idempotency state for the warning stage of the two-stage revocation cron.';
+COMMENT ON COLUMN cycle_enrollments.warning_reason IS
+  'Reason identifier matching the cron''s revocation rules. v1 values: ''missed_pulses''. Future values may include ''not_in_pod''. Mirrors the convention in access_revocations.reason.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_access_revocations_unique_full
+  ON access_revocations (participant_id, cycle_id, reason)
+  WHERE revocation_scope = 'full';
+
+COMMENT ON INDEX idx_access_revocations_unique_full IS
+  'Idempotency guard for the revocation cron. Allows INSERT ... ON CONFLICT DO NOTHING to safely retry without producing duplicate revocation rows for the same (participant, cycle, reason). Partial on revocation_scope = ''full'' so future non-full scopes (per-subsystem) can write multiple rows for the same participant.';
+
+-- DOWN (manual rollback — forward-only repo policy):
+-- DROP INDEX IF EXISTS idx_access_revocations_unique_full;
+-- ALTER TABLE cycle_enrollments
+--   DROP COLUMN IF EXISTS warning_reason,
+--   DROP COLUMN IF EXISTS warned_at;


### PR DESCRIPTION
## Summary

Phase C of [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110) — the revocation cron redesign. Ships the route + email template + migration to dev so the architecture and behavior can be exercised in a controlled environment, but **deliberately does NOT re-register the cron in \`vercel.json\`**. That re-registration is Phase C.3, gated by a ≥48-hour staging soak per the architecture review's §7 plan.

## Commits

| Commit | Layer |
|---|---|
| [\`0c5dea9\`](https://github.com/TheUpskillingLabs/OLOS/commit/0c5dea9) | Roadmap §3.7 Phase C design decisions captured |
| [\`075b509\`](https://github.com/TheUpskillingLabs/OLOS/commit/075b509) | Migration 00030: \`warned_at\` + \`warning_reason\` columns on \`cycle_enrollments\` + unique partial index on \`access_revocations\` |
| [\`3409dbc\`](https://github.com/TheUpskillingLabs/OLOS/commit/3409dbc) | Rewrite \`app/api/cron/revocation-check/route.ts\` + new \`lib/email/revocation-warning-template.ts\` |

## What the cron does now (vs the old buggy version)

| Aspect | Old | Phase C |
|---|---|---|
| Pod-membership check | Cross-cycle ❌ | Cycle-scoped via \`pods.cycle_id\` join ✅ |
| not_in_pod window awareness | None — revoked during open window ❌ | Only fires after \`pod_registration_close\` ✅ |
| Missed-pulse rule | 7-day from \`created_at\` fallback ❌ | \`deriveAtRiskRun\` + \`cycle_config.at_risk_consecutive_misses\` ✅ |
| Stages | Single-stage immediate revoke ❌ | Two-stage: warn → 3-day grace → revoke ✅ |
| State mutations | Direct UPDATE on multiple tables | Routes through \`reconcileEnrollmentActivation(...)\` from Phase A |
| Admin/owner handling | Treated like participants | **Exempted** (interim until [#122](https://github.com/TheUpskillingLabs/OLOS/issues/122)) |
| Recovery handling | None | Clears \`warned_at\` when conditions no longer apply |
| Idempotency | None — duplicate revocations possible | DB unique partial index + INSERT ON CONFLICT |

## Phase C.3 — what's deliberately NOT in this PR

\`vercel.json\` is unchanged. The cron route exists and is callable manually with \`Bearer \$CRON_SECRET\`, but Vercel does not schedule it. Re-registration is a separate ~1-line PR after:

1. This PR merges to dev
2. **≥48 hours** of soak time on dev — manual invocation, observation, no surprises
3. Promotion sequence to main goes through the standard dev → main PR

Per architecture review §7: *\"Staging soak ≥ 48 hours before merging Phase C to main.\"*

## Verification

- [x] Migration 00030 applied to dev DB; columns + index live (verified via \`information_schema\` + \`pg_indexes\`)
- [x] \`npx tsc --noEmit\` clean across all three commits
- [x] Dev server compiles the new route cleanly via Turbopack
- [x] HTTP probe: \`GET /api/cron/revocation-check\` returns 401 unauthed (auth working)
- [ ] **Manual invocation on dev** (post-merge): \`curl -H \"Authorization: Bearer \$CRON_SECRET\" https://olos-git-dev-...vercel.app/api/cron/revocation-check\` and observe the outcomes JSON
- [ ] Confirm no participants warned/revoked unexpectedly during the soak period

## Out of scope (filed separately for clarity)

- [#121](https://github.com/TheUpskillingLabs/OLOS/issues/121) — pulse-check-reminder cron has its own idempotency gap (in-run \`Set<number>\` dedup only)
- [#122](https://github.com/TheUpskillingLabs/OLOS/issues/122) — admin pulse-check tracking via \"secret pod\" or role exemption (currently admins are interim-exempted from revocation)
- [#123](https://github.com/TheUpskillingLabs/OLOS/issues/123) — moderator pod-membership add power (currently admin-only via Phase B.6)
- [#115](https://github.com/TheUpskillingLabs/OLOS/issues/115) — admin actor audit columns (coordinated migration covering B.6/B.7/B.8 + C)

## Coordination note

This PR lands alongside @inferno-gh's recent work on dev (poderator dashboard, feedback widget, entity explorer). The cron is purely server-side and doesn't touch any of those UIs; the only intentional cross-module dependency is the \`deriveAtRiskRun\` import from \`lib/moderator/nudges.ts\` which is documented at the import site.

## Trade-offs documented

The B.8 commit message established the pattern of explicit trade-off discussion. Phase C continues that — see \`3409dbc\`'s commit message for the five design choices recorded with their rejected alternatives:

1. Cross-module import vs duplicate predicate
2. Admin exemption mechanism (role check vs secret pod)
3. Warning state shape (column vs table)
4. Grace period constant vs configurable
5. Email template tone

## Related

- Parent: [#110](https://github.com/TheUpskillingLabs/OLOS/issues/110)
- Architecture review: \`docs/architecture-review-onboarding-state-machine.md\`
- Roadmap §3.7: Phase C design decisions captured in commit \`0c5dea9\`
- Prior phase: PR [#116](https://github.com/TheUpskillingLabs/OLOS/pull/116) (Phase B)