### PR TITLE
fix(00030): tighten idempotency-index predicate to exclude reason='reactivated'

### DIFF
--- a/supabase/migrations/00030_revocation_warnings_and_idempotency.sql
+++ b/supabase/migrations/00030_revocation_warnings_and_idempotency.sql
@@ -49,6 +49,25 @@
 -- route.ts has a related but separate idempotency gap (no DB-backed
 -- per-send tracking; in-run Set<number> dedup only). Tracked as a
 -- follow-up; out of scope for Phase C.
+--
+-- Predicate detail — exclude reason='reactivated'
+-- -----------------------------------------------
+-- The index predicate excludes `reason='reactivated'` because the existing
+-- admin reactivate route at
+-- app/api/revocations/reactivate/[participant_id]/route.ts writes audit
+-- markers to this table with that reason value (semantic misuse — those
+-- are reactivation events, not revocations). At least two duplicate pairs
+-- exist on prod from the May 2026 hot-fix work where participants were
+-- cycled revoke → reactivate → revoke → reactivate. The cron only writes
+-- 'not_in_pod' and 'missed_pulses', so excluding 'reactivated' preserves
+-- the idempotency guarantee for the cron's writes without touching the
+-- existing audit data. The semantic cleanup (move 'reactivated' to a
+-- different table or scope) is tracked at #125.
+--
+-- DROP-then-CREATE: this migration uses an explicit DROP IF EXISTS so it's
+-- safe to re-apply against any environment that may have an earlier
+-- broader-predicate version of the index (e.g. from an in-flight feature
+-- branch). Idempotent against fresh installs too.
 
 ALTER TABLE cycle_enrollments
   ADD COLUMN IF NOT EXISTS warned_at      TIMESTAMP,
@@ -59,12 +78,14 @@ COMMENT ON COLUMN cycle_enrollments.warned_at IS
 COMMENT ON COLUMN cycle_enrollments.warning_reason IS
   'Reason identifier matching the cron''s revocation rules. v1 values: ''missed_pulses''. Future values may include ''not_in_pod''. Mirrors the convention in access_revocations.reason.';
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_access_revocations_unique_full
+DROP INDEX IF EXISTS idx_access_revocations_unique_full;
+
+CREATE UNIQUE INDEX idx_access_revocations_unique_full
   ON access_revocations (participant_id, cycle_id, reason)
-  WHERE revocation_scope = 'full';
+  WHERE revocation_scope = 'full' AND reason <> 'reactivated';
 
 COMMENT ON INDEX idx_access_revocations_unique_full IS
-  'Idempotency guard for the revocation cron. Allows INSERT ... ON CONFLICT DO NOTHING to safely retry without producing duplicate revocation rows for the same (participant, cycle, reason). Partial on revocation_scope = ''full'' so future non-full scopes (per-subsystem) can write multiple rows for the same participant.';
+  'Idempotency guard for the revocation cron. Excludes reason=''reactivated'' to avoid collision with admin-reactivate audit markers (semantic-misuse cleanup tracked at #125). Partial on revocation_scope = ''full'' so future non-full scopes (per-subsystem) can write multiple rows for the same participant.';
 
 -- DOWN (manual rollback — forward-only repo policy):
 -- DROP INDEX IF EXISTS idx_access_revocations_unique_full;


### PR DESCRIPTION
## Why

During Phase C migration application on prod (2026-06-04), the original `00030_revocation_warnings_and_idempotency.sql` failed at the `CREATE UNIQUE INDEX` step. Prod had pre-existing duplicate rows in `access_revocations` with `reason='reactivated'`:

- participant 52, cycle 3: rows 7 + 10
- participant 62, cycle 3: rows 6 + 9

These were created by the admin reactivate route writing audit markers to `access_revocations` (semantic misuse — those are reactivation events, not revocations). The duplicates exist because both participants were cycled revoke → reactivate → revoke → reactivate during the May hot-fix work.

## What changed

The unique partial index predicate now excludes `reason='reactivated'`:

```diff
- WHERE revocation_scope = 'full'
+ WHERE revocation_scope = 'full' AND reason <> 'reactivated'
```

Plus a `DROP INDEX IF EXISTS` before the `CREATE` so the migration is idempotent against any environment that may have applied the earlier broader-predicate version (relevant for dev, which got the broader version applied via MCP on 2026-06-03 and was reconciled to the tight version via direct SQL on 2026-06-04).

## Why edit the file (not ship a new 00031 migration)

- 00030 was merged via PR #124 only hours before this fix
- The tightened predicate IS what got applied to both dev and prod via MCP during this same session
- The file now matches the actual schema state on both environments
- `DROP INDEX IF EXISTS` keeps the migration replay-safe for future fresh installs
- A separate forward-migration 00031 would have introduced unnecessary tracker noise for a same-day fix

## Cron impact

Phase C's cron writes reasons `'not_in_pod'` and `'missed_pulses'` — never `'reactivated'`. The idempotency guarantee for the cron's writes is preserved unchanged. This refinement only affects the index's behavior toward the pre-existing audit-marker rows that aren't cron-driven.

## Verification

Both DBs already reflect the tight predicate (applied via MCP during the prod-promotion sequence). Verified via `pg_indexes`:

```
indexdef:
  CREATE UNIQUE INDEX idx_access_revocations_unique_full
    ON public.access_revocations USING btree (participant_id, cycle_id, reason)
    WHERE (((revocation_scope)::text = 'full'::text)
       AND ((reason)::text <> 'reactivated'::text));
```

Identical output on dev and prod.

## Related

- Parent: #110 Phase C
- Sister: #124 (the original 00030 PR)
- Follow-up: #125 — semantic cleanup of 'reactivated' rows so the predicate exception can eventually be removed