### PR TITLE
fix: project registration is cycle-wide, not pod-scoped

### DIFF
--- a/app/api/projects/[project_id]/register/route.ts
+++ b/app/api/projects/[project_id]/register/route.ts
@@ -32,18 +32,37 @@ export const POST = withAuth(
       return NextResponse.json({ error: window.message }, { status: 403 });
     }
 
-    // Must be active pod member
-    const { data: podMembership } = await auth.supabase
-      .from("pod_memberships")
-      .select("id")
-      .eq("pod_id", project.pod_id)
+    // Must be an active participant in THIS CYCLE (any pod).
+    //
+    // Previously this route required active membership in the project's own
+    // pod, scoping registration to within-pod. That was a misread of the
+    // architecture brief: Phase 5 (solution voting) is intentionally
+    // within-pod, but Phase 7 (project self-registration) is meant to be
+    // cycle-wide — any participant who is active in the cycle can join any
+    // project that interests them. The pod-scope check was effectively
+    // siloing participants to their proposing pod's project set, which
+    // wasn't the intent.
+    //
+    // Authoritative check now: cycle_enrollments.status='active' for the
+    // project's cycle. Phase A's reconciler (lib/enrollment/reconciler.ts)
+    // keeps this status in sync with actual pod-membership reality, so an
+    // 'active' enrollment implies the participant has at least one active
+    // pod_membership in an active pod within the cycle — i.e. they're a
+    // bona fide cohort member, just not necessarily of THIS pod.
+    //
+    // The 1-project-per-cycle cap below still applies, so a participant
+    // can't register for more than one project per cycle regardless of
+    // which pod the projects belong to.
+    const { data: enrollment } = await auth.supabase
+      .from("cycle_enrollments")
+      .select("status")
+      .eq("cycle_id", project.cycle_id)
       .eq("participant_id", participantId)
-      .is("inactive_at", null)
       .maybeSingle();
 
-    if (!podMembership) {
+    if (!enrollment || enrollment.status !== "active") {
       return NextResponse.json(
-        { error: "You must be an active member of this pod to register." },
+        { error: "You must be an active participant in this cycle to register for a project." },
         { status: 400 }
       );
     }


### PR DESCRIPTION
## Why now

Surfaced during Energy Cycle 3 on 2026-06-04 when the cycle stalled at project-registration phase. The original route required the registering participant to be an active member of the project's specific pod — siloing participants to only register for projects in their proposing pod.

This contradicts the cycle-wide intent of Phase 7 (project self-registration) in the architecture brief. Phase 5 (solution voting) is intentionally within-pod, but project registration is meant to let any active cohort member opt into any project that interests them, regardless of which pod proposed it.

## What changes

```diff
- // Must be active pod member
- const { data: podMembership } = await auth.supabase
-   .from("pod_memberships")
-   .select("id")
-   .eq("pod_id", project.pod_id)
-   .eq("participant_id", participantId)
-   .is("inactive_at", null)
-   .maybeSingle();
- if (!podMembership) {
-   return 400 "You must be an active member of this pod to register."
- }

+ // Must be an active participant in THIS CYCLE (any pod).
+ const { data: enrollment } = await auth.supabase
+   .from("cycle_enrollments")
+   .select("status")
+   .eq("cycle_id", project.cycle_id)
+   .eq("participant_id", participantId)
+   .maybeSingle();
+ if (!enrollment || enrollment.status !== "active") {
+   return 400 "You must be an active participant in this cycle..."
+ }
```

Phase A's reconciler keeps `cycle_enrollments.status` synced with actual pod-membership reality, so `'active'` implies the participant has at least one active pod_membership in an active pod — they're a bona fide cohort member, just not necessarily of THIS pod.

## Constraints preserved unchanged

- **1-project-per-cycle cap** — still enforced by both the in-route check and the partial unique index on `project_memberships`
- **`project_max`** headcount cap per project
- **Window check** — `checkWindow(... 'project_registration')`
- **Project auto-activation** when `project_min` is reached on register

## Timing — urgent

- Cycle 3's `project_registration_close` is **today 2026-06-04 23:59**
- Without this fix, the moment we finalize Pod 5/6/8 and projects exist, participants would hit `400 "You must be an active member of this pod"` whenever they try to register for a project outside their own pod
- Will auto-flow into PR #127 (dev → main promotion already open) when this merges to dev

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Post-merge: a participant in Pod 5 registers for a Pod 8 project — succeeds (was previously a 400)
- [ ] Post-merge: a participant with `cycle_enrollments.status='inactive'` tries to register — gets the new 400 message
- [ ] Post-merge: the 1-project-per-cycle cap still rejects a second registration

## Trade-off acknowledged

Pod-scoped registration would have kept project teams within the proposing pod — useful for tight collaboration. Cycle-wide enables cross-pollination. The 1-project cap means no one over-commits; participants must still pick.

If pod-scoped registration is ever the right semantic for a future cycle, it'd land as a `cycle_config.project_registration_scope` flag rather than re-baked into the route. Not in scope for this fix.

## Related

- Parent: #110 onboarding state machine (Phase A reconciler is what makes this check trustworthy)
- Blocks: cycle 3 phase advance from voting → project registration
- Will auto-include in [PR #127](https://github.com/TheUpskillingLabs/OLOS/pull/127) (dev → main promotion already open)