### PR TITLE
Promote dev → main: cycle-scoped project registration fix (#128)

### DIFF
--- a/app/api/projects/[project_id]/register/route.ts
+++ b/app/api/projects/[project_id]/register/route.ts
@@ -32,18 +32,37 @@ export const POST = withAuth(
       return NextResponse.json({ error: window.message }, { status: 403 });
     }
 
-    // Must be active pod member
-    const { data: podMembership } = await auth.supabase
-      .from("pod_memberships")
-      .select("id")
-      .eq("pod_id", project.pod_id)
+    // Must be an active participant in THIS CYCLE (any pod).
+    //
+    // Previously this route required active membership in the project's own
+    // pod, scoping registration to within-pod. That was a misread of the
+    // architecture brief: Phase 5 (solution voting) is intentionally
+    // within-pod, but Phase 7 (project self-registration) is meant to be
+    // cycle-wide — any participant who is active in the cycle can join any
+    // project that interests them. The pod-scope check was effectively
+    // siloing participants to their proposing pod's project set, which
+    // wasn't the intent.
+    //
+    // Authoritative check now: cycle_enrollments.status='active' for the
+    // project's cycle. Phase A's reconciler (lib/enrollment/reconciler.ts)
+    // keeps this status in sync with actual pod-membership reality, so an
+    // 'active' enrollment implies the participant has at least one active
+    // pod_membership in an active pod within the cycle — i.e. they're a
+    // bona fide cohort member, just not necessarily of THIS pod.
+    //
+    // The 1-project-per-cycle cap below still applies, so a participant
+    // can't register for more than one project per cycle regardless of
+    // which pod the projects belong to.
+    const { data: enrollment } = await auth.supabase
+      .from("cycle_enrollments")
+      .select("status")
+      .eq("cycle_id", project.cycle_id)
       .eq("participant_id", participantId)
-      .is("inactive_at", null)
       .maybeSingle();
 
-    if (!podMembership) {
+    if (!enrollment || enrollment.status !== "active") {
       return NextResponse.json(
-        { error: "You must be an active member of this pod to register." },
+        { error: "You must be an active participant in this cycle to register for a project." },
         { status: 400 }
       );
     }


### PR DESCRIPTION
## Summary

Promotes PR #128 (cycle-scoped project registration) from dev to main. Needed for Energy Cycle 3 project-registration phase — the previous dev→main promotion (#127) merged before #128 was opened, so this is a small follow-on.

## What ships

Single commit: cycle-wide eligibility check on `POST /api/projects/[project_id]/register`. Previously gated on active pod membership in the project's own pod; now gated on active enrollment in the project's cycle.

See PR #128 for the full rationale.

## Risk

Minimal — one route, type-check clean, no schema changes, no new dependencies. Rollback path is Vercel deployment revert.

## Post-merge

1. Wait for Vercel prod deploy READY
2. Manually flip Pod 6 → active (Phase B.7 admin route)
3. Run finalize on Pods 5, 6, 8 to create project rows from top-voted proposals
4. Decide on `project_registration_close` extension based on engagement