### PR TITLE
fix: cycle-wide project list on register-projects page

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/register-projects/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-projects/page.tsx
@@ -37,12 +37,14 @@ export default async function RegisterProjectsPage({
     now >= new Date(config.project_registration_open) &&
     now <= new Date(config.project_registration_close);
 
-  // Get user's pods for this cycle
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
-  let myPods: { id: number; name: string | null }[] = [];
+  // Project registration is cycle-wide (not pod-scoped). The eligibility
+  // gate is an active cycle_enrollment row, mirroring the server check in
+  // app/api/projects/[project_id]/register/route.ts.
+  let enrollmentActive = false;
   let currentProjectId: number | null = null;
 
   if (user) {
@@ -53,19 +55,15 @@ export default async function RegisterProjectsPage({
       .single();
 
     if (participant) {
-      const { data: memberships } = await supabase
-        .from("pod_memberships")
-        .select("pod_id, pods!inner(id, name, cycle_id)")
+      const { data: enrollment } = await supabase
+        .from("cycle_enrollments")
+        .select("status")
+        .eq("cycle_id", cycleId)
         .eq("participant_id", participant.id)
-        .eq("pods.cycle_id", cycleId)
-        .is("inactive_at", null);
+        .maybeSingle();
 
-      myPods = (memberships || []).map((m) => {
-        const pod = m.pods as unknown as { id: number; name: string | null };
-        return { id: pod.id, name: pod.name };
-      });
+      enrollmentActive = enrollment?.status === "active";
 
-      // Check current project registration
       const { data: existingReg } = await supabase
         .from("project_memberships")
         .select("project_id")
@@ -78,38 +76,43 @@ export default async function RegisterProjectsPage({
     }
   }
 
-  // Fetch projects for the user's pods
-  const podIds = myPods.map((p) => p.id);
+  // All pods in this cycle — needed to label projects with their originating
+  // pod name in the grouped view (a participant may see projects from pods
+  // they're not in).
+  const { data: allPods } = await supabase
+    .from("pods")
+    .select("id, name")
+    .eq("cycle_id", cycleId);
+  const cyclePods = allPods ?? [];
+
+  // Fetch all projects in this cycle (any pod).
   let projects: { id: number; name: string | null; status: string; pod_id: number; member_count: number }[] = [];
-  if (podIds.length > 0) {
-    const { data: projectData } = await supabase
-      .from("projects")
-      .select("id, name, status, pod_id")
-      .in("pod_id", podIds)
-      .order("created_at");
+  const { data: projectData } = await supabase
+    .from("projects")
+    .select("id, name, status, pod_id")
+    .eq("cycle_id", cycleId)
+    .order("created_at");
 
-    if (projectData) {
-      // Get member counts
-      const projectIds = projectData.map((p) => p.id);
-      const { data: projectMemberships } = await supabase
-        .from("project_memberships")
-        .select("project_id")
-        .in("project_id", projectIds.length > 0 ? projectIds : [0])
-        .is("left_at", null);
+  if (projectData && projectData.length > 0) {
+    const projectIds = projectData.map((p) => p.id);
+    const { data: projectMemberships } = await supabase
+      .from("project_memberships")
+      .select("project_id")
+      .in("project_id", projectIds)
+      .is("left_at", null);
 
-      const countMap: Record<number, number> = {};
-      for (const m of projectMemberships || []) {
-        countMap[m.project_id] = (countMap[m.project_id] || 0) + 1;
-      }
-
-      projects = projectData.map((p) => ({
-        id: p.id,
-        name: p.name,
-        status: p.status,
-        pod_id: p.pod_id,
-        member_count: countMap[p.id] || 0,
-      }));
+    const countMap: Record<number, number> = {};
+    for (const m of projectMemberships || []) {
+      countMap[m.project_id] = (countMap[m.project_id] || 0) + 1;
     }
+
+    projects = projectData.map((p) => ({
+      id: p.id,
+      name: p.name,
+      status: p.status,
+      pod_id: p.pod_id,
+      member_count: countMap[p.id] || 0,
+    }));
   }
 
   return (
@@ -126,7 +129,7 @@ export default async function RegisterProjectsPage({
           Register for a project
         </h1>
         <p className="mt-1 text-sm text-cloud/80">
-          Join a project within your pod. You can register for one project per
+          Join any project in this cycle. You can register for one project per
           cycle.
         </p>
       </div>
@@ -147,10 +150,10 @@ export default async function RegisterProjectsPage({
               </p>
             )}
         </div>
-      ) : myPods.length === 0 ? (
+      ) : !enrollmentActive ? (
         <div className="rounded-md border border-whisper bg-white/[0.02] p-6 text-center">
           <p className="text-cloud/80">
-            You are not a member of any pods in this cycle.
+            You are not an active participant in this cycle.
           </p>
           <Link
             href={`/cycles/${cycle.id}`}
@@ -161,7 +164,7 @@ export default async function RegisterProjectsPage({
         </div>
       ) : (
         <ProjectRegistration
-          pods={myPods}
+          pods={cyclePods}
           projects={projects}
           initialCurrentProjectId={currentProjectId}
           projectMax={config?.project_max ?? 7}

--- a/app/(dashboard)/cycles/[cycle_id]/register-projects/project-registration.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-projects/project-registration.tsx
@@ -186,7 +186,7 @@ export default function ProjectRegistration({
                         </button>
                       ) : isFull ? (
                         <span className="rounded bg-white/[0.04] px-3 py-1 text-xs font-medium tracking-tight text-cloud/50">
-                          Pod full
+                          Project full
                         </span>
                       ) : (
                         <button


### PR DESCRIPTION
## Why

Companion fix to #128 / PR #129.

That fix made the server-side register endpoint cycle-scoped, but the participant-facing list view at \`/cycles/[id]/register-projects\` still filtered projects by the user's own pod memberships. So even though the server would accept a cross-pod registration, the UI never offered cross-pod projects as options — meaning Energy Cycle 3 participants couldn't actually use the new behavior.

Reported by @adm-2k while testing post-#129 deploy.

## What changes

\`app/(dashboard)/cycles/[cycle_id]/register-projects/page.tsx\`:
- Projects query: \`.in("pod_id", podIds)\` → \`.eq("cycle_id", cycleId)\`
- Eligibility gate: \`myPods.length === 0\` → \`enrollment.status === 'active'\` (mirrors the server route)
- Fetch **all** cycle pods (not just the user's) so the grouped view can label projects with their originating pod name
- Header copy: "Join a project within your pod" → "Join any project in this cycle"

\`app/(dashboard)/cycles/[cycle_id]/register-projects/project-registration.tsx\`:
- "Pod full" label → "Project full" (\`project_max\` is the cap, not a pod cap)

No server-route changes. No schema changes. Type-check clean.

## Timing

Project registration window for Energy Cycle 3 closes **2026-06-04 23:59** — this needs to land + promote to main + deploy before then if participants are to use it tonight. Otherwise we extend the window tomorrow.