### PR TITLE
feat: Luma events integration — Luma is the source of truth

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -444,6 +444,8 @@ erDiagram
         jsonb gallery
         boolean anchor
         varchar status
+        timestamptz synced_at
+        varchar luma_url
     }
 
     resources {
@@ -496,6 +498,8 @@ erDiagram
 ```
 
 **`events.start_at` / `end_at`:** plain `TIMESTAMP` holding local wall time, rendered as written — the prototype's Luma-shaped date strings. `anchor = TRUE` marks the cycle's six anchor events (✦ in the UI). `location_type`: `in_person` · `virtual`.
+
+**Luma sync (migration `00035`, `lib/integrations/luma.ts`):** Luma is the source of truth for ALL events. The scheduled sync (`/api/cron/sync-luma-events`, every 6h in production; manual trigger `POST /api/admin/events/sync` for admins) upserts by `api_id`, overwriting only Luma-owned fields (name, times, location, cover `img`, `luma_url`, initial `description`) — local annotations (`slug`, `kind`, `anchor`, `grad`, `cost`, `host`, `bring`, `body`, `gallery`) are never touched. `synced_at` set = Luma-managed row. Reconciliation archives published *future* rows missing from a successful fetch (cancelled/unlisted on Luma); past rows are kept as history. Site RSVPs on Luma-managed events are forwarded to Luma's guest list (best-effort) so confirmations and calendar invites come from Luma.
 
 **`resources.content_type`:** `guide` · `recording` · `template` · `course` · `playbook`. `from_line` carries commons provenance ("BenefitsBot · Spring 2026 Cycle") — rendered as the "From the commons" band.
 

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -7,6 +7,7 @@ import { StatusBadge } from "@/app/components/ui";
 // as the route; removing the feature = delete this block + the two folders.
 import { ENTITY_EXPLORER_ENABLED } from "@/lib/entity-explorer/flag";
 import CreateCycleForm from "./cycles/create-cycle-form";
+import SyncEventsButton from "./sync-events-button";
 
 type CycleStatus = "active" | "closed" | "draft";
 
@@ -77,6 +78,7 @@ export default async function AdminPage() {
               </span>
             </Link>
           )}
+          <SyncEventsButton />
           <CreateCycleForm />
         </div>
       </div>

--- a/app/(dashboard)/admin/sync-events-button.tsx
+++ b/app/(dashboard)/admin/sync-events-button.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type SyncState =
+  | { phase: "idle" }
+  | { phase: "running" }
+  | { phase: "done"; note: string }
+  | { phase: "error"; note: string };
+
+/* Admin header action: pull the Luma calendar into the events cache now
+   instead of waiting for the production cron tick. */
+export default function SyncEventsButton() {
+  const router = useRouter();
+  const [state, setState] = useState<SyncState>({ phase: "idle" });
+
+  async function run() {
+    setState({ phase: "running" });
+    try {
+      const res = await fetch("/api/admin/events/sync", { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setState({
+          phase: "error",
+          note: data.error || `Sync failed (${res.status})`,
+        });
+        return;
+      }
+      const errs = data.errors?.length ? ` · ${data.errors.length} errors` : "";
+      setState({
+        phase: "done",
+        note: `${data.created ?? 0} new · ${data.updated ?? 0} updated${errs}`,
+      });
+      router.refresh();
+    } catch {
+      setState({ phase: "error", note: "Network error — try again." });
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        type="button"
+        className="btn btn-ghost px-4 py-2 text-sm"
+        onClick={run}
+        disabled={state.phase === "running"}
+      >
+        {state.phase === "running" ? "Syncing…" : "Sync events from Luma"}
+      </button>
+      {state.phase === "done" && (
+        <span className="text-sm text-teal-deep">{state.note} ✓</span>
+      )}
+      {state.phase === "error" && (
+        <span className="text-sm text-red" role="alert">
+          {state.note}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/app/(public)/events/[slug]/page.tsx
+++ b/app/(public)/events/[slug]/page.tsx
@@ -138,6 +138,18 @@ export default async function EventPage({
                   ? "Online — we'll send the link."
                   : "Free & public — we'll send the room details."}
               </p>
+              {e.luma_url && (
+                <p className="t-small" style={{ marginTop: 8 }}>
+                  <a
+                    className="see"
+                    href={e.luma_url}
+                    target="_blank"
+                    rel="noopener"
+                  >
+                    View on Luma →
+                  </a>
+                </p>
+              )}
             </div>
           </aside>
         </div>

--- a/app/api/admin/events/sync/route.ts
+++ b/app/api/admin/events/sync/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import { createServiceClient } from "@/lib/supabase/server";
+import { lumaEnabled, syncLumaEvents } from "@/lib/integrations/luma";
+
+/* Manual Luma sync trigger for admins — the on-demand twin of
+   /api/cron/sync-luma-events. Exists because Vercel Cron only runs on
+   production: this is how dev environments (and impatient admins) pull
+   the calendar now instead of at the next scheduled tick. */
+export const POST = withAdminAuth(async (_request: NextRequest) => {
+  if (!lumaEnabled()) {
+    return NextResponse.json(
+      {
+        error:
+          "LUMA_API_KEY is not configured in this environment — add it in Vercel project settings and redeploy.",
+      },
+      { status: 501 }
+    );
+  }
+
+  try {
+    const summary = await syncLumaEvents(createServiceClient());
+    console.log(
+      `[admin-events-sync] fetched=${summary.fetched} created=${summary.created} updated=${summary.updated} errors=${summary.errors.length}`
+    );
+    return NextResponse.json({
+      ...summary,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error(`[admin-events-sync] failed: ${message}`);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+});

--- a/app/api/cron/sync-luma-events/route.ts
+++ b/app/api/cron/sync-luma-events/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, NextRequest } from "next/server";
+import { createServiceClient } from "@/lib/supabase/server";
+import { lumaEnabled, syncLumaEvents } from "@/lib/integrations/luma";
+
+/* Scheduled Luma → events cache sync (backend doc §3: never call Luma per
+   page view). Registered in vercel.json; Vercel Cron only fires against
+   production deployments — on dev, use the admin trigger
+   (POST /api/admin/events/sync) instead. */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Not an error: environments without a key (or before Luma Plus is
+  // active) skip quietly rather than alarming the cron dashboard.
+  if (!lumaEnabled()) {
+    console.log("[sync-luma-events] LUMA_API_KEY not set — skipping");
+    return NextResponse.json({
+      skipped: true,
+      reason: "LUMA_API_KEY not set",
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  try {
+    const summary = await syncLumaEvents(createServiceClient());
+    console.log(
+      `[sync-luma-events] fetched=${summary.fetched} created=${summary.created} updated=${summary.updated} errors=${summary.errors.length}`
+    );
+    return NextResponse.json({
+      ...summary,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error(`[sync-luma-events] failed: ${message}`);
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/app/api/events/[event_id]/rsvp/route.ts
+++ b/app/api/events/[event_id]/rsvp/route.ts
@@ -4,12 +4,18 @@ import { dbError } from "@/lib/api/errors";
 import { parseIntParam } from "@/lib/api/params";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { eventRsvpSchema } from "@/lib/validations/event-rsvp";
+import { lumaEnabled, addLumaGuest } from "@/lib/integrations/luma";
 
 // The public event RSVP — deliberately unauthenticated (owner rule: public
 // event RSVPs are email-only, never account-gated). The production twin of
 // the prototype's #rsvp-modal submit. Repeat RSVPs for the same event+email
 // are absorbed silently (UNIQUE(event_id, email), migration 00033) so the
 // caller always sees the same "Spot saved" outcome.
+//
+// Luma is the source of truth for events, so a saved RSVP is forwarded to
+// Luma's guest list — confirmations, reminders, and calendar invites come
+// from Luma. Forwarding is best-effort: the local row is the fallback
+// record and a Luma hiccup never costs anyone their spot.
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ event_id: string }> }
@@ -22,7 +28,7 @@ export async function POST(
 
   const { data: event } = await supabase
     .from("events")
-    .select("id")
+    .select("id, api_id, synced_at")
     .eq("id", eventId)
     .eq("status", "published")
     .maybeSingle();
@@ -34,11 +40,29 @@ export async function POST(
   if (isErrorResponse(body)) return body;
 
   // Lowercase so the unique constraint dedupes case variants of one inbox.
+  const email = body.email.toLowerCase();
   const { error } = await supabase.from("event_rsvps").upsert(
-    { event_id: eventId, email: body.email.toLowerCase() },
+    { event_id: eventId, email },
     { onConflict: "event_id,email", ignoreDuplicates: true }
   );
   if (error) return dbError(error, "event-rsvp");
 
-  return NextResponse.json({ saved: true }, { status: 200 });
+  // Only Luma-managed rows (synced_at set) have a real Luma event behind
+  // their api_id — seeded/editorial rows keep their RSVPs local-only.
+  let forwardedToLuma = false;
+  if (lumaEnabled() && event.synced_at && event.api_id) {
+    try {
+      await addLumaGuest(event.api_id, email);
+      forwardedToLuma = true;
+    } catch (e) {
+      console.error(
+        `[event-rsvp] Luma forward failed event_id=${eventId}: ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+  }
+
+  return NextResponse.json(
+    { saved: true, forwarded_to_luma: forwardedToLuma },
+    { status: 200 }
+  );
 }

--- a/app/components/content/teasers.tsx
+++ b/app/components/content/teasers.tsx
@@ -21,7 +21,7 @@ export function MediaFrame({
       <div className="media">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src={`/${img.replace(/^\//, "")}`}
+          src={/^https?:\/\//.test(img) ? img : `/${img.replace(/^\//, "")}`}
           alt=""
           style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }}
         />

--- a/lib/content/queries.ts
+++ b/lib/content/queries.ts
@@ -22,6 +22,8 @@ export interface EventRow {
   body: string[] | null;
   gallery: string[] | null;
   anchor: boolean;
+  luma_url: string | null;
+  synced_at: string | null; // set = Luma-managed row (migration 00035)
 }
 
 export interface ResourceRow {

--- a/lib/integrations/luma.ts
+++ b/lib/integrations/luma.ts
@@ -1,0 +1,295 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/* Luma events integration (backend doc §3) — server-side only. LUMA_API_KEY
+   must never reach the client; that is why the prototype shipped mock data.
+
+   Luma is the source of truth for ALL events (owner decision, July 2026):
+   the events table is a cache of the Luma calendar, and the site never
+   invents events Luma doesn't have. Concretely:
+   - Luma owns existence + the fields it knows: name, times, location,
+     cover image, event URL, and the initial description.
+   - OLOS keeps local presentation annotations layered on Luma rows — slug
+     (the URL), kind/anchor tagging, grad, cost/host display, editorial
+     body/gallery. The sync NEVER overwrites those, so ✦ anchors and edited
+     copy survive every run.
+   - Reconciliation: a published FUTURE event missing from a successful
+     fetch was cancelled or unlisted on Luma — it gets archived here (past
+     rows stay as history; Luma's listing may not include them).
+   - RSVPs taken on the site are forwarded to Luma as guests (addLumaGuest)
+     so attendance, confirmations, and calendar invites live in Luma.
+
+   The API base is overridable because the Luma reference 403'd automated
+   fetching during planning (backend doc §1.6) — if the documented base is
+   wrong, fix it with an env var instead of a deploy. */
+
+const LUMA_API_BASE =
+  process.env.LUMA_API_BASE || "https://public-api.luma.com/v1";
+
+// Luma's documented list-events shape, held loosely: entries may nest the
+// event under .event or be the event itself.
+interface LumaEvent {
+  api_id: string;
+  name: string;
+  description?: string | null;
+  start_at: string; // ISO 8601 UTC instant
+  end_at?: string | null;
+  timezone?: string | null;
+  cover_url?: string | null;
+  url?: string | null;
+  meeting_url?: string | null;
+  geo_address_json?: {
+    name?: string | null;
+    place_name?: string | null;
+    full_address?: string | null;
+    address?: string | null;
+    city?: string | null;
+  } | null;
+}
+
+export function lumaEnabled(): boolean {
+  return Boolean(process.env.LUMA_API_KEY);
+}
+
+async function lumaGet(path: string): Promise<unknown> {
+  const res = await fetch(`${LUMA_API_BASE}${path}`, {
+    headers: {
+      accept: "application/json",
+      "x-luma-api-key": process.env.LUMA_API_KEY as string,
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Luma API ${res.status} on ${path}: ${body.slice(0, 300)}`
+    );
+  }
+  return res.json();
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+/* Fetch every event on the calendar, following pagination. Returns the raw
+   Luma event objects. */
+export async function fetchLumaEvents(): Promise<LumaEvent[]> {
+  const events: LumaEvent[] = [];
+  let cursor: string | null = null;
+
+  // 200 req/min rate limit is far above anything a paginated listing needs;
+  // the page cap is a runaway guard, not a throughput concern.
+  for (let page = 0; page < 50; page++) {
+    const qs = new URLSearchParams({ pagination_limit: "100" });
+    if (cursor) qs.set("pagination_cursor", cursor);
+    const data = asRecord(await lumaGet(`/calendar/list-events?${qs}`));
+    if (!data) break;
+
+    const entries = Array.isArray(data.entries) ? data.entries : [];
+    for (const entry of entries) {
+      const rec = asRecord(entry);
+      if (!rec) continue;
+      const ev = asRecord(rec.event) ?? rec; // nested or flat
+      if (typeof ev.api_id === "string" && typeof ev.name === "string") {
+        events.push(ev as unknown as LumaEvent);
+      }
+    }
+
+    cursor = typeof data.next_cursor === "string" ? data.next_cursor : null;
+    if (!data.has_more || !cursor) break;
+  }
+
+  return events;
+}
+
+/* The events table stores local wall time rendered as written (00033);
+   Luma sends UTC instants plus the event's IANA timezone. */
+export function toWallTime(iso: string, timezone?: string | null): string {
+  const tz = timezone || "America/New_York";
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(new Date(iso));
+  const get = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? "00";
+  return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}`;
+}
+
+function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .normalize("NFKD")
+      .replace(/[̀-ͯ]/g, "")
+      .replace(/&/g, " and ")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80) || "event"
+  );
+}
+
+function locationOf(ev: LumaEvent): {
+  location_type: "in_person" | "virtual";
+  location_name: string;
+} {
+  const geo = ev.geo_address_json;
+  if (geo) {
+    const name =
+      geo.name || geo.place_name || geo.full_address || geo.address || geo.city;
+    if (name) return { location_type: "in_person", location_name: name };
+  }
+  return { location_type: "virtual", location_name: "Online" };
+}
+
+// A short plain lede for rows the sync creates (the detail page's t-lede);
+// editors refine it later. Cut at a sentence or word boundary.
+function ledeOf(description?: string | null): string | null {
+  if (!description) return null;
+  const text = description.replace(/\s+/g, " ").trim();
+  if (text.length <= 280) return text || null;
+  const cut = text.slice(0, 280);
+  const sentence = cut.lastIndexOf(". ");
+  return sentence > 120 ? cut.slice(0, sentence + 1) : `${cut.slice(0, cut.lastIndexOf(" "))}…`;
+}
+
+const GRAD_ROTATION = ["m-teal", "m-forest", "m-navy"];
+
+/* Forward a site RSVP to Luma so the guest list lives there. Callers treat
+   this as best-effort: the local event_rsvps row is already saved, and a
+   Luma hiccup must never cost someone their spot. */
+export async function addLumaGuest(
+  eventApiId: string,
+  email: string
+): Promise<void> {
+  const res = await fetch(`${LUMA_API_BASE}/event/add-guests`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      "x-luma-api-key": process.env.LUMA_API_KEY as string,
+    },
+    body: JSON.stringify({ event_api_id: eventApiId, guests: [{ email }] }),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Luma add-guests ${res.status} for ${eventApiId}: ${body.slice(0, 300)}`
+    );
+  }
+}
+
+export interface LumaSyncSummary {
+  fetched: number;
+  created: number;
+  updated: number;
+  archived: number;
+  errors: string[];
+}
+
+export async function syncLumaEvents(
+  supabase: SupabaseClient
+): Promise<LumaSyncSummary> {
+  const lumaEvents = await fetchLumaEvents();
+  const summary: LumaSyncSummary = {
+    fetched: lumaEvents.length,
+    created: 0,
+    updated: 0,
+    archived: 0,
+    errors: [],
+  };
+  // An empty fetch is left alone on purpose: reconciliation only runs on a
+  // non-trivial listing, so an API hiccup or shape change can never empty
+  // the public events section in one tick.
+  if (lumaEvents.length === 0) return summary;
+
+  const { data: existingRows, error: readError } = await supabase
+    .from("events")
+    .select("id, api_id, slug, status, start_at");
+  if (readError) throw new Error(`events read failed: ${readError.message}`);
+
+  const byApiId = new Map(
+    (existingRows ?? [])
+      .filter((r) => r.api_id)
+      .map((r) => [r.api_id as string, r])
+  );
+  const takenSlugs = new Set((existingRows ?? []).map((r) => r.slug as string));
+  const syncedAt = new Date().toISOString();
+
+  for (const [i, ev] of lumaEvents.entries()) {
+    try {
+      const lumaFields = {
+        name: ev.name,
+        start_at: toWallTime(ev.start_at, ev.timezone),
+        end_at: ev.end_at ? toWallTime(ev.end_at, ev.timezone) : null,
+        ...locationOf(ev),
+        img: ev.cover_url || null,
+        luma_url: ev.url || null,
+        synced_at: syncedAt,
+        updated_at: syncedAt,
+      };
+
+      const existing = byApiId.get(ev.api_id);
+      if (existing) {
+        const { error } = await supabase
+          .from("events")
+          .update(lumaFields)
+          .eq("id", existing.id);
+        if (error) throw new Error(error.message);
+        summary.updated++;
+      } else {
+        let slug = slugify(ev.name);
+        if (takenSlugs.has(slug)) slug = `${slug}-${ev.api_id.slice(-6).toLowerCase()}`;
+        takenSlugs.add(slug);
+
+        const { error } = await supabase.from("events").insert({
+          api_id: ev.api_id,
+          slug,
+          ...lumaFields,
+          description: ledeOf(ev.description),
+          grad: GRAD_ROTATION[i % GRAD_ROTATION.length],
+          status: "published",
+          anchor: false,
+        });
+        if (error) throw new Error(error.message);
+        summary.created++;
+      }
+    } catch (e) {
+      summary.errors.push(
+        `${ev.api_id} (${ev.name}): ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+  }
+
+  // Reconcile: Luma is the source of truth for ALL events — any published
+  // future row Luma didn't return (cancelled, unlisted, or a leftover seed)
+  // leaves the site. Archived, not deleted: history and RSVP rows survive,
+  // and un-archiving is one status flip.
+  const lumaIds = new Set(lumaEvents.map((ev) => ev.api_id));
+  const orphans = (existingRows ?? []).filter(
+    (r) =>
+      r.status === "published" &&
+      !lumaIds.has(r.api_id as string) &&
+      new Date(r.start_at).getTime() > Date.now()
+  );
+  for (const row of orphans) {
+    const { error } = await supabase
+      .from("events")
+      .update({ status: "archived", updated_at: syncedAt })
+      .eq("id", row.id);
+    if (error) {
+      summary.errors.push(`archive ${row.slug}: ${error.message}`);
+    } else {
+      summary.archived++;
+    }
+  }
+
+  return summary;
+}

--- a/supabase/migrations/00035_luma_sync.sql
+++ b/supabase/migrations/00035_luma_sync.sql
@@ -1,0 +1,7 @@
+-- Luma sync bookkeeping (backend doc §3: events is a cache, Luma stays
+-- authoritative once the live sync runs). synced_at marks a row as
+-- Luma-managed (NULL = editorial/seeded row the sync never created);
+-- luma_url links back to the event's Luma page for RSVP parity checks.
+ALTER TABLE events
+  ADD COLUMN IF NOT EXISTS synced_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS luma_url VARCHAR(500);

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/cron/pulse-check-reminder",
       "schedule": "0 9 * * *"
+    },
+    {
+      "path": "/api/cron/sync-luma-events",
+      "schedule": "0 */6 * * *"
     }
   ]
 }


### PR DESCRIPTION
Implements backend doc §3 with the ratified owner decision: **Luma is the source of truth for all events.** The `events` table becomes a cache of the Luma calendar; the site never invents events Luma doesn't have.

## The sync contract (`lib/integrations/luma.ts`)

- **Luma owns**: event existence, name, times, location, cover image, event URL, and the initial description.
- **OLOS keeps** local presentation annotations layered on Luma rows — `slug` (the URL), `kind`/`anchor` tagging (the ✦ six), `grad`, `cost`/`host` display, editorial `body`/`gallery`. The sync never overwrites these, so edited copy survives every run.
- **Reconciliation**: a published *future* event missing from a successful fetch was cancelled or unlisted on Luma → archived here (not deleted; RSVP rows and history survive, un-archiving is one status flip). Past rows are kept as history. An empty fetch skips reconciliation entirely, so an API hiccup can never empty the site.
- **RSVPs flow into Luma**: the site's email-only RSVP (still never account-gated — owner rule) forwards the guest to Luma's guest list on Luma-managed events, so confirmations, reminders, and calendar invites come from Luma. Best-effort: the local `event_rsvps` row is the fallback record.
- Times convert from Luma's UTC instants to the event-timezone wall time the table stores.

## Surfaces

- `/api/cron/sync-luma-events` — every 6h via `vercel.json`, `CRON_SECRET`-guarded like the existing crons. Skips quietly (200) where `LUMA_API_KEY` isn't set.
- `POST /api/admin/events/sync` + a **"Sync events from Luma"** button on the admin page — Vercel Cron only fires on production, so this is how dev (and impatient admins) pull the calendar on demand.
- Event detail pages show **"View on Luma →"** when the row carries `luma_url`; `MediaFrame` now passes absolute image URLs through for Luma cover images.

## DB

- Migration `00035_luma_sync.sql`: `events.synced_at` (set = Luma-managed row) + `events.luma_url`. **Already applied to OLOS-dev.** SCHEMA.md updated.

## Notes

- `LUMA_API_KEY` is already configured in Vercel. `LUMA_API_BASE` env override exists in case the documented base URL drifts (the Luma API reference 403'd automated fetching during planning — first manual sync on dev is the real API-shape test; errors surface in the sync response JSON, not silently).
- On the first sync against the real calendar, the reconciler archives the seeded prototype events (they're future-dated and not in Luma) — real Luma events take over the site, which is the point.
- Requires Luma Plus on the calendar for API access.

## Verification

- `npm run build` clean; only new lint note is the `_request` unused-param warning matching the identical pre-existing pattern in `/api/invitations`.
- Egress from the dev container can't reach Luma, so the live sync is verified on dev post-merge via the admin button (results render next to it: "N new · N updated ✓").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_