### PR TITLE
feat: square covers on event + library teaser cards (Luma card format)

### DIFF
--- a/app/components/content/teasers.tsx
+++ b/app/components/content/teasers.tsx
@@ -11,14 +11,17 @@ export function MediaFrame({
   img,
   grad,
   tag,
+  square,
 }: {
   img?: string | null;
   grad?: string | null;
   tag?: string | null;
+  square?: boolean;
 }) {
+  const sq = square ? " sq" : "";
   if (img) {
     return (
-      <div className="media">
+      <div className={`media${sq}`}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={/^https?:\/\//.test(img) ? img : `/${img.replace(/^\//, "")}`}
@@ -30,7 +33,7 @@ export function MediaFrame({
     );
   }
   return (
-    <div className={`media ${grad || "m-teal"}`}>
+    <div className={`media${sq} ${grad || "m-teal"}`}>
       <Orb />
       {tag && <div className="m-tag">{tag}</div>}
     </div>
@@ -44,6 +47,7 @@ export function EventTeaser({ event: e }: { event: EventRow }) {
         img={e.img}
         grad={e.grad}
         tag={e.kind || (e.location_type === "virtual" ? "Virtual" : "In person")}
+        square
       />
       <div className="card-body">
         <div className="lbl lbl-teal">{fmtDate(e.start_at)}</div>
@@ -61,7 +65,7 @@ export function ResourceTeaser({ resource: r }: { resource: ResourceRow }) {
   const typeLabel = CONTENT_TYPE_LABEL[r.content_type] || "Guide";
   return (
     <Link className="card tappable" href={`/library/${r.slug}`}>
-      <MediaFrame img={r.img} grad={r.grad} tag={typeLabel} />
+      <MediaFrame img={r.img} grad={r.grad} tag={typeLabel} square />
       <div className="card-body">
         <div className="lbl lbl-teal">{r.meta || ""}</div>
         <div className="t-h4" style={{ margin: "6px 0 4px" }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -466,6 +466,9 @@ button:focus-visible {
   .cards.dense { grid-template-columns: 1fr; gap: 14px; align-items: start; }
   .cards.dense .card-body { padding: 12px 14px; }
   .cards.dense .media { aspect-ratio: 4/3; }
+  /* Square teaser covers (owner decision: match Luma's card format — its
+     event covers are 1:1 natively, so synced images render uncropped). */
+  .media.sq, .cards.dense .media.sq { aspect-ratio: 1 / 1; }
   .cards.dense .t-h4 { font-size: 15px; line-height: 20px; }
   @media (min-width: 700px) { .cards.dense { grid-template-columns: repeat(2, 1fr); } }
   @media (min-width: 768px) {


### PR DESCRIPTION
Owner decision: event and Learning Library teaser images render 1:1, matching Luma's card format — Luma event covers are square natively, so every synced cover shows uncropped.

- New `.media.sq` variant in globals.css (specificity-paired with the `.cards.dense` 4:3 override so dense grids go square too).
- Applied via a `square` prop on `MediaFrame`, passed by `EventTeaser` and `ResourceTeaser` only — lab/city cards and the event-detail gallery keep their existing ratios.
- Gradient-orb placeholders (library items without images) render square as well, so the grids stay uniform.

Build clean; no copy or logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_