### PR TITLE
feat: retire Learning Library placeholders — Coming Soon until real content

### DIFF
--- a/app/(public)/library/page.tsx
+++ b/app/(public)/library/page.tsx
@@ -28,7 +28,9 @@ export default async function LibraryPage() {
           <div className="section-head">
             <div>
               <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
-                Learning Library · {resources.length}
+                {resources.length
+                  ? `Learning Library · ${resources.length}`
+                  : "Learning Library"}
               </div>
               <h1 className="t-h2">Learn by doing</h1>
             </div>
@@ -37,11 +39,17 @@ export default async function LibraryPage() {
             Everything here is free and open — including what cycle teams
             returned to the commons.
           </p>
-          <div className="cards dense all">
-            {resources.map((r) => (
-              <ResourceTeaser key={r.slug} resource={r} />
-            ))}
-          </div>
+          {resources.length ? (
+            <div className="cards dense all">
+              {resources.map((r) => (
+                <ResourceTeaser key={r.slug} resource={r} />
+              ))}
+            </div>
+          ) : (
+            <div className="lcard" style={{ padding: 48, textAlign: "center" }}>
+              <div className="t-h3">Coming Soon</div>
+            </div>
+          )}
         </div>
       </section>
     </>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -163,15 +163,23 @@ export default async function LandingPage() {
               </div>
               <h2 className="t-h2">Learn at your own pace</h2>
             </div>
-            <Link className="see" href="/library">
-              Full library →
-            </Link>
+            {landingResources.length > 0 && (
+              <Link className="see" href="/library">
+                Full library →
+              </Link>
+            )}
           </div>
-          <div className="cards dense">
-            {landingResources.map((r) => (
-              <ResourceTeaser key={r.slug} resource={r} />
-            ))}
-          </div>
+          {landingResources.length ? (
+            <div className="cards dense">
+              {landingResources.map((r) => (
+                <ResourceTeaser key={r.slug} resource={r} />
+              ))}
+            </div>
+          ) : (
+            <div className="lcard" style={{ padding: 48, textAlign: "center" }}>
+              <div className="t-h3">Coming Soon</div>
+            </div>
+          )}
         </div>
       </section>
 

--- a/supabase/migrations/00036_retire_placeholder_resources.sql
+++ b/supabase/migrations/00036_retire_placeholder_resources.sql
@@ -1,0 +1,6 @@
+-- Retire the Learning Library placeholder items (owner decision, July
+-- 2026): the library launches empty with a Coming Soon state until real
+-- resources exist. 00034 stays in the chain as history; this forward
+-- delete runs after it, so a fresh chain (e.g. the prod promotion) also
+-- ends with zero resources. Nothing references resources by FK.
+DELETE FROM resources;


### PR DESCRIPTION
Owner decision: the Learning Library launches empty rather than with placeholder content.

- **Migration `00036_retire_placeholder_resources.sql`** — deletes the 15 placeholder resources seeded by 00034. Forward-only: 00034 stays in the chain as history, and a fresh chain (the prod promotion) nets zero rows. Nothing references `resources` by FK. **Already applied to OLOS-dev.**
- The landing's Learning Library section and `/library` render a **"Coming Soon"** card when the table is empty; the landing's "Full library →" link hides until there's something behind it. Section headers and ledes stay in place, so the section returns to life automatically the moment a published resource exists.
- Resource detail routes 404 naturally for deleted slugs.

Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_