### PR TITLE
feat: header Donate button replaces Join

### DIFF
--- a/app/components/chrome/public-nav.tsx
+++ b/app/components/chrome/public-nav.tsx
@@ -6,11 +6,16 @@ import { usePathname } from "next/navigation";
 import { useState } from "react";
 
 /* The public bar — ported from onboarding-proto chrome.js publicNavHTML
-   (.sitenav): logo · destinations · quiet Log in · red Join. Auth-aware:
-   signed-in visitors get Home + their avatar instead of the CTAs. Collapses
-   to the hamburger below 1024px (the public bar needs the room — deliberate
+   (.sitenav): logo · destinations · quiet Log in · red Donate (owner
+   decision, July 2026: Join retired from the bar — the hero and the upsell
+   band carry the join ask; the bar's button raises money). Donate opens
+   every.org's hosted checkout (#/donate deep link — no API needed here).
+   Auth-aware: signed-in visitors get Home + their avatar. Collapses to the
+   hamburger below 1024px (the public bar needs the room — deliberate
    breakpoint, distinct from the app bar's 768px).
    The Work ▾ menu and the search field arrive with their stages. */
+
+const DONATE_URL = "https://www.every.org/theupskillinglabs#/donate";
 
 const DESTS = [
   { key: "events", label: "Events", href: "/events" },
@@ -66,9 +71,14 @@ export default function PublicNav({
             <Link className="nav-link pn-login" href="/login">
               Log in
             </Link>
-            <Link className="sitenav-cta" href="/login">
-              Join
-            </Link>
+            <a
+              className="sitenav-cta"
+              href={DONATE_URL}
+              target="_blank"
+              rel="noopener"
+            >
+              Donate
+            </a>
           </span>
         )}
         <button
@@ -108,12 +118,7 @@ export default function PublicNav({
         {!signedIn && (
           <Link className="nav-link" href="/login">Log in</Link>
         )}
-        <a
-          className="nav-link"
-          href="https://www.every.org/theupskillinglabs"
-          target="_blank"
-          rel="noopener"
-        >
+        <a className="nav-link" href={DONATE_URL} target="_blank" rel="noopener">
           Donate
         </a>
       </nav>


### PR DESCRIPTION
Owner decision: the public bar's red CTA now raises money instead of duplicating the join ask.

- **Join removed** from the header — the quiet **Log in** link stays. The join ask still lives in the landing hero ("Join The Labs") and the signed-out upsell band ("Create account"), so nothing about signup discoverability changes.
- **Donate** takes the red `.sitenav-cta` slot, opening every.org's hosted checkout directly via the `#/donate` deep link (new tab). The hamburger menu's Donate entry points at the same URL.
- No API usage here — every.org's hosted checkout needs no key. The newly-added every.org API credentials become useful for a later stage (donation webhooks → donor records/thank-yous in-app).

Build clean; one file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_