### PR TITLE
feat: Donate opens every.org's popup instead of leaving the site

### DIFF
--- a/app/components/chrome/public-nav.tsx
+++ b/app/components/chrome/public-nav.tsx
@@ -4,18 +4,18 @@ import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import { DONATE_URL } from "@/lib/donate";
 
 /* The public bar — ported from onboarding-proto chrome.js publicNavHTML
    (.sitenav): logo · destinations · quiet Log in · red Donate (owner
    decision, July 2026: Join retired from the bar — the hero and the upsell
    band carry the join ask; the bar's button raises money). Donate opens
-   every.org's hosted checkout (#/donate deep link — no API needed here).
+   every.org's donation popup (button.js in the root layout intercepts the
+   coded link; plain hosted checkout is the no-script fallback).
    Auth-aware: signed-in visitors get Home + their avatar. Collapses to the
    hamburger below 1024px (the public bar needs the room — deliberate
    breakpoint, distinct from the app bar's 768px).
    The Work ▾ menu and the search field arrive with their stages. */
-
-const DONATE_URL = "https://www.every.org/theupskillinglabs#/donate";
 
 const DESTS = [
   { key: "events", label: "Events", href: "/events" },

--- a/app/components/chrome/site-footers.tsx
+++ b/app/components/chrome/site-footers.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { DONATE_URL } from "@/lib/donate";
 
 /* The two public footers, ported from onboarding-proto:
    - PgFoot: the compact content-page footer (chrome.js footerHTML)
@@ -18,7 +19,7 @@ export function PgFoot() {
           <Link href="/events">Events</Link> ·{" "}
           <Link href="/library">Library</Link> ·{" "}
           <Link href="/labs">Cities</Link> ·{" "}
-          <a href="https://www.every.org/theupskillinglabs" target="_blank" rel="noopener">
+          <a href={DONATE_URL} target="_blank" rel="noopener">
             Donate
           </a>
         </span>
@@ -59,7 +60,7 @@ export function OsFooter() {
             </p>
             <a
               className="btn btn-ghost-teal btn-sm"
-              href="https://www.every.org/theupskillinglabs"
+              href={DONATE_URL}
               target="_blank"
               rel="noopener"
             >

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Geologica } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 
 // Geologica is the only brand font (owner decision: no CDN — next/font
@@ -28,7 +29,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`h-full ${geologica.variable}`}>
-      <body className="flex min-h-full flex-col">{children}</body>
+      <body className="flex min-h-full flex-col">
+        {children}
+        {/* every.org's embed script: intercepts clicks on our donate links
+            (lib/donate.ts DONATE_URL) and opens the donation popup in place
+            instead of navigating to the hosted checkout. */}
+        <Script src="https://embeds.every.org/0.4/button.js" strategy="afterInteractive" />
+      </body>
     </html>
   );
 }

--- a/lib/donate.ts
+++ b/lib/donate.ts
@@ -1,0 +1,6 @@
+/* The every.org donate link — the ?code identifies our embed config, the
+   #/donate hash deep-links the hosted checkout. With button.js loaded
+   (root layout), clicks on this URL open every.org's popup in place;
+   without it the link still works as a plain hosted-checkout fallback. */
+export const DONATE_URL =
+  "https://www.every.org/theupskillinglabs?code=69265e4b#/donate";


### PR DESCRIPTION
Wires the Donate buttons to every.org's popup donation flow per their embed instructions.

## What changed
- **`lib/donate.ts`** (new) — the single source for the donate link, now the coded popup URL (`…?code=69265e4b#/donate`).
- **`app/layout.tsx`** — loads every.org's `button.js` embed script (`afterInteractive`) site-wide. It intercepts clicks on the coded link and opens the donation popup in place.
- **`app/components/chrome/public-nav.tsx`** — the header Donate button and hamburger Donate row now use the shared coded URL.
- **`app/components/chrome/site-footers.tsx`** — PgFoot's Donate link and OsFooter's "Support The Labs" button route through the same popup link (they previously went to the every.org profile page).

## Behavior
- With the script loaded: clicking any Donate link opens every.org's popup over the current page — no navigation away.
- No-script / script-blocked fallback: the links still open the hosted checkout in a new tab (`target="_blank"` kept).

## Verification
- `next build` passes; all routes compile.
- Lint: no new issues (the 5 pre-existing dashboard errors are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_