### PR TITLE
style: Donate button white instead of red

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -613,7 +613,7 @@ button:focus-visible {
 @layer components {
   /* ── public nav trimmings (the .sitenav base lives in layer II) ── */
   .sitenav-auth { align-items: center; gap: 10px; display: flex; }
-  .sitenav-cta { background: var(--red); color: #fff; padding: 11px 18px; border-radius: var(--r); font-size: 14px; font-weight: 600; text-decoration: none; flex-shrink: 0; }
+  .sitenav-cta { background: #fff; color: var(--ink); padding: 11px 18px; border-radius: var(--r); font-size: 14px; font-weight: 600; text-decoration: none; flex-shrink: 0; }
   .pg-avatar { width: 36px; height: 36px; border-radius: 50%; background: var(--teal-deep); color: #fff; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 700; letter-spacing: 0.02em; text-decoration: none; flex-shrink: 0; }
   .sitenav .pn-login { display: none; }
   .sitenav .ham-btn { display: flex; align-items: center; justify-content: center; width: 42px; height: 42px; background: none; border: none; cursor: pointer; color: var(--od1); flex-shrink: 0; margin-left: auto; }


### PR DESCRIPTION
## What changed
- `.sitenav-cta` (the header Donate button) now uses a white background with `--ink` text instead of red, matching the existing `.btn-white` convention already used for buttons on dark surfaces.

## Verification
- `next build` passes.
- Not visually screenshotted — this sandbox has no Supabase credentials configured, so the dev server can't render pages that query content. Low-risk, one-line CSS change reusing an established pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_