### PR TITLE
fix: robust toggle switch + tester toggle in the permissions panel

### DIFF
--- a/app/(dashboard)/admin/participants/[participant_id]/permissions/page.tsx
+++ b/app/(dashboard)/admin/participants/[participant_id]/permissions/page.tsx
@@ -27,7 +27,7 @@ export default async function ParticipantPermissionsPage({
   const [userRoles, { data: participant }, { data: permRows }, { data: roleRows }, { data: modAssignments }] =
     await Promise.all([
       resolveUserRoles(serviceClient, user.id),
-      serviceClient.from("participants").select("id, first_name, last_name, preferred_name, email").eq("id", participantId).single(),
+      serviceClient.from("participants").select("id, first_name, last_name, preferred_name, email, is_test").eq("id", participantId).single(),
       serviceClient.from("participant_permissions").select("permission").eq("participant_id", participantId).is("revoked_at", null),
       serviceClient.from("user_roles").select("role").eq("participant_id", participantId).is("revoked_at", null),
       serviceClient.from("moderator_assignments").select("pod_id, pods (name, cycle_id, cycles (name))").eq("participant_id", participantId).is("removed_at", null),
@@ -104,6 +104,7 @@ export default async function ParticipantPermissionsPage({
         initialPermissions={currentPermissions}
         canManageRoles={canManageRoles}
         podAssignments={podAssignments}
+        initialIsTest={!!participant.is_test}
       />
     </div>
   );

--- a/app/(dashboard)/admin/participants/[participant_id]/permissions/permissions-editor.tsx
+++ b/app/(dashboard)/admin/participants/[participant_id]/permissions/permissions-editor.tsx
@@ -8,6 +8,7 @@ import {
   activePresets,
   type Permission,
 } from "@/lib/auth/permissions";
+import { ToggleSwitch } from "@/app/components/ui";
 
 const PRESET_COLORS: Record<string, string> = {
   owner: "bg-ink/10 text-ink ring-ink/30",
@@ -22,11 +23,13 @@ export default function PermissionsEditor({
   initialPermissions,
   canManageRoles,
   podAssignments,
+  initialIsTest,
 }: {
   participantId: number;
   initialPermissions: Permission[];
   canManageRoles: boolean;
   podAssignments: { pod_id: number; pod_name: string; cycle_name: string }[];
+  initialIsTest: boolean;
 }) {
   const [permissions, setPermissions] = useState<Set<Permission>>(
     new Set(initialPermissions)
@@ -34,6 +37,26 @@ export default function PermissionsEditor({
   const [loading, setLoading] = useState<Set<string>>(new Set());
   const [presetLoading, setPresetLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isTest, setIsTest] = useState(initialIsTest);
+  const [testerBusy, setTesterBusy] = useState(false);
+
+  async function toggleTester() {
+    setTesterBusy(true);
+    setError(null);
+    const res = await fetch("/api/admin/testers", {
+      method: isTest ? "DELETE" : "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ participant_id: participantId }),
+    });
+    setTesterBusy(false);
+    if (res.ok) {
+      const data = await res.json();
+      setIsTest(!!data.tester);
+    } else {
+      const data = await res.json().catch(() => null);
+      setError(data?.error ?? "Failed to update tester status");
+    }
+  }
 
   const currentPresets = activePresets([...permissions]);
 
@@ -142,6 +165,31 @@ export default function PermissionsEditor({
         </div>
       )}
 
+      {/* Tester status — grants the self-reset pathway (migration 00042).
+          Email-keyed, so the flag survives a full account reset. */}
+      <section>
+        <h2 className="lbl mb-3">Tester Account</h2>
+        <div className="flex items-center justify-between rounded-card border border-dashed border-ink/20 bg-paper px-4 py-3">
+          <div className="pr-4">
+            <span className="text-sm font-semibold text-ink">
+              Testing pathway
+            </span>
+            <p className="mt-0.5 text-xs text-meta">
+              Lets this account reset its own journey and re-run the whole
+              onboarding. Hidden from Poderator rosters and excluded from pod
+              health. The grant is keyed to their email, so it survives a
+              reset.
+            </p>
+          </div>
+          <ToggleSwitch
+            checked={isTest}
+            onChange={toggleTester}
+            busy={testerBusy}
+            label="Tester account"
+          />
+        </div>
+      </section>
+
       {/* Individual Permissions */}
       <section>
         <h2 className="lbl mb-3">
@@ -172,22 +220,13 @@ export default function PermissionsEditor({
                           {perm}
                         </span>
                       </div>
-                      <button
-                        onClick={() => togglePermission(perm)}
-                        disabled={isLoading || isRestricted}
-                        role="switch"
-                        aria-checked={enabled}
-                        aria-label={permissionLabel(perm)}
-                        className={`relative h-6 w-11 rounded-full transition-colors duration-150 ease-out disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal ${
-                          enabled ? "bg-teal" : "bg-ink/15"
-                        }`}
-                      >
-                        <span
-                          className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform duration-150 ease-spring ${
-                            enabled ? "translate-x-[1.375rem]" : "translate-x-0.5"
-                          }`}
-                        />
-                      </button>
+                      <ToggleSwitch
+                        checked={enabled}
+                        onChange={() => togglePermission(perm)}
+                        disabled={isRestricted}
+                        busy={isLoading}
+                        label={permissionLabel(perm)}
+                      />
                     </div>
                   );
                 })}

--- a/app/(dashboard)/admin/participants/participants-global-table.tsx
+++ b/app/(dashboard)/admin/participants/participants-global-table.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import type { GlobalParticipant } from "./page";
 
 const ROLE_COLORS: Record<string, string> = {
@@ -20,25 +19,6 @@ export default function ParticipantsGlobalTable({
 }) {
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState<string>("all");
-  const [togglingId, setTogglingId] = useState<number | null>(null);
-  const router = useRouter();
-
-  // The testing pathway (00042): grant/revoke tester. Testers can reset
-  // their own account to replay the whole onboarding; the grant is
-  // email-keyed so it survives the reset.
-  async function toggleTester(p: GlobalParticipant) {
-    setTogglingId(p.id);
-    try {
-      await fetch("/api/admin/testers", {
-        method: p.is_test ? "DELETE" : "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ participant_id: p.id }),
-      });
-      router.refresh();
-    } finally {
-      setTogglingId(null);
-    }
-  }
 
   const filtered = participants.filter((p) => {
     const name = p.preferred_name
@@ -203,18 +183,6 @@ export default function ParticipantsGlobalTable({
                     {new Date(p.created_at).toLocaleDateString()}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <button
-                      type="button"
-                      onClick={() => toggleTester(p)}
-                      disabled={togglingId === p.id}
-                      className="mr-2 rounded-card border border-ink/15 px-3 py-1 text-xs font-semibold tracking-tight text-charcoal transition-all duration-150 hover:border-teal hover:text-teal-deep active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal disabled:opacity-50"
-                    >
-                      {togglingId === p.id
-                        ? "…"
-                        : p.is_test
-                          ? "Remove tester"
-                          : "Make tester"}
-                    </button>
                     <Link
                       href={`/admin/participants/${p.id}/permissions`}
                       className="rounded-card bg-teal/10 px-3 py-1 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -9,3 +9,4 @@ export { Field, Input, Textarea, Select } from "./form";
 export type { FieldProps, InputProps, TextareaProps, SelectProps } from "./form";
 export { Sheet } from "./sheet";
 export { Tooltip, TooltipIcon } from "./tooltip";
+export { ToggleSwitch } from "./toggle-switch";

--- a/app/components/ui/toggle-switch.tsx
+++ b/app/components/ui/toggle-switch.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+/* A single, bulletproof toggle switch. The knob's travel is driven by an
+   inline transform (2px off → 22px on inside a 44×24 track) rather than an
+   arbitrary Tailwind class, so it can never silently fail to compile — the
+   bug that left the permission toggles stuck. Genuine circle knob (allowed
+   under the one-radius rule; switches are circles, like avatars). */
+export function ToggleSwitch({
+  checked,
+  onChange,
+  disabled = false,
+  busy = false,
+  label,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  disabled?: boolean;
+  busy?: boolean;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled || busy}
+      onClick={onChange}
+      className={`relative inline-block h-6 w-11 flex-shrink-0 rounded-full transition-colors duration-150 ease-out disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2 ${
+        checked ? "bg-teal" : "bg-ink/20"
+      }`}
+    >
+      <span
+        aria-hidden="true"
+        className="absolute top-0.5 left-0 h-5 w-5 rounded-full bg-white shadow transition-transform duration-150 ease-spring"
+        style={{ transform: `translateX(${checked ? 22 : 2}px)` }}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
Two things, per request: fix the permissions-panel toggle switches, and move the tester grant into that panel.

## The toggle fix
The permission-row switches drove the knob with an arbitrary Tailwind class (`translate-x-[1.375rem]`) — a compile-time dependency that's the fragile point when a switch renders "stuck." Replaced with a single shared **`ToggleSwitch`** component (`app/components/ui/toggle-switch.tsx`) whose knob moves via a **deterministic inline transform** (2px ↔ 22px inside a 44×24 track). It can't silently fail to compile, and every permission row now uses it.

## Tester toggle → permissions
The tester grant/revoke moves **out of the participants table and into the permissions panel**, as a proper labeled toggle using the same fixed component (with a short explanation of what tester status does). The table keeps the at-a-glance "tester" badge, but the *action* now lives behind **Permissions**, alongside the rest of the account controls — one place to manage an account.

## Verification
- `next build` green (45 routes), 21 unit tests pass, lint at the pre-existing baseline.
- No API or schema change — reuses `POST/DELETE /api/admin/testers` and the `is_test` column already on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_