### PR TITLE
fix: tester reset button always reachable

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -6,7 +6,6 @@ import { StatusBadge, EmptyState } from "@/app/components/ui";
 import CyclePhaseIndicator from "../cycles/cycle-phase-indicator";
 import PodJoinSection from "./pod-join-section";
 import LearningLogCard from "./learning-log-card";
-import TesterResetCard from "./tester-reset-card";
 import { learningLogGate } from "@/lib/learning-logs/gate";
 
 type CycleStatus = "active" | "closed" | "draft";
@@ -28,7 +27,7 @@ export default async function DashboardPage() {
   const serviceClient = createServiceClient();
 
   const [{ data: participant }, { data: cycles }] = await Promise.all([
-    serviceClient.from("participants").select("id, preferred_name, first_name, is_test").eq("auth_user_id", user.id).maybeSingle(),
+    serviceClient.from("participants").select("id, preferred_name, first_name").eq("auth_user_id", user.id).maybeSingle(),
     serviceClient.from("cycles").select("id, name, slug, start_date, end_date, status").order("start_date", { ascending: false }),
   ]);
 
@@ -170,8 +169,6 @@ export default async function DashboardPage() {
       <h1 className="t-h1 mb-6 text-ink">
         Welcome back, {displayName}
       </h1>
-
-      {participant.is_test && <TesterResetCard />}
 
       {/* Phase timeline for active cycle */}
       {activeCycle && activeCycleConfig && (

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -8,6 +8,7 @@ import TabBar from "@/app/components/chrome/tab-bar";
 import OrbDefs from "@/app/components/chrome/orb-defs";
 import FeedbackWidget from "@/app/components/feedback/feedback-widget";
 import { learningLogGate } from "@/lib/learning-logs/gate";
+import TesterResetCard from "@/app/(dashboard)/dashboard/tester-reset-card";
 
 export default async function DashboardLayout({
   children,
@@ -27,7 +28,7 @@ export default async function DashboardLayout({
   const serviceClient = createServiceClient();
   const { data: participant } = await serviceClient
     .from("participants")
-    .select("id, preferred_name, first_name, last_name")
+    .select("id, preferred_name, first_name, last_name, is_test")
     .eq("auth_user_id", user.id)
     .maybeSingle();
 
@@ -125,7 +126,14 @@ export default async function DashboardLayout({
         hasEnrollment={hasEnrollment}
         logDue={logGate.active}
       />
-      <main className="app-main container w-full flex-1 py-8">{children}</main>
+      <main className="app-main container w-full flex-1 py-8">
+        {/* Tester reset — always present for tester accounts, on every
+            dashboard route, so it's reachable in the no-cycle / no-enrollment
+            states a tester lands in right after re-onboarding (where the
+            dashboard page's own render never fired). */}
+        {participant?.is_test && <TesterResetCard />}
+        {children}
+      </main>
       <TabBar initials={initials} hasEnrollment={hasEnrollment} />
       <FeedbackWidget />
     </div>


### PR DESCRIPTION
The tester reset card only rendered in the dashboard's fully-engaged state (active cycle member with pods). But a tester in the **no-cycle** or **no-enrollment** state — exactly where you land right after re-onboarding — hit an early return that never showed it. So the reset button vanished precisely when you needed it to loop again.

## Fix
Moved the reset card into the **dashboard layout**, so it's present for tester accounts on every dashboard route in every state. Removed the now-duplicate render (and the unused `is_test` select) from the dashboard page.

## Verification
- `next build` green (45 routes), 21 tests pass, lint at the pre-existing baseline.
- No schema/API change — reuses `is_test` and `POST /api/testing/reset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_