### PR TITLE
copy: rename tester reset button to "Reset Test Account"

### DIFF
--- a/app/(dashboard)/dashboard/tester-reset-card.tsx
+++ b/app/(dashboard)/dashboard/tester-reset-card.tsx
@@ -53,7 +53,7 @@ export default function TesterResetCard() {
             className="btn btn-ghost btn-sm"
             onClick={() => setConfirming(true)}
           >
-            Reset my journey
+            Reset Test Account
           </button>
         ) : (
           <div className="flex items-center gap-2">


### PR DESCRIPTION
One-word copy change: the tester reset button now reads **"Reset Test Account"** (was "Reset my journey").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_