### PR TITLE
Renumber the cycle rail to weeks 0–12 (~3 months)

### DIFF
--- a/app/(dashboard)/cycles/cycle-phase-indicator.tsx
+++ b/app/(dashboard)/cycles/cycle-phase-indicator.tsx
@@ -24,9 +24,9 @@ type Cycle = {
   end_date: string;
 };
 
-/* ── The 12-week Build Cycle model ─────────────────────────────────── */
-/* Kickoff + Summit opens Week 1; Showcase + Summit closes Week 12 (owner
-   decision — twelve weeks and a day). Four weeks per phase. */
+/* ── The Build Cycle model — ~3 months / ~90 days ──────────────────── */
+/* Thirteen weekly markers numbered 0–12 (owner decision). Week 0 is the
+   kickoff/orientation week; Showcase + Summit closes Week 12. */
 
 const WEEKS: {
   num: number;
@@ -34,24 +34,25 @@ const WEEKS: {
   milestone: boolean;
   phase: 1 | 2 | 3;
 }[] = [
-  { num: 1, label: "Kickoff\n+ Summit", milestone: true, phase: 1 },
-  { num: 2, label: "Problem\nProposals", milestone: false, phase: 1 },
-  { num: 3, label: "Problem\nVoting", milestone: false, phase: 1 },
-  { num: 4, label: "Pod\nCreation", milestone: false, phase: 1 },
-  { num: 5, label: "Meet The\nPods", milestone: true, phase: 2 },
-  { num: 6, label: "Experiments", milestone: false, phase: 2 },
-  { num: 7, label: "Project\nPitches", milestone: false, phase: 2 },
-  { num: 8, label: "Project\nVoting", milestone: false, phase: 2 },
-  { num: 9, label: "Meet The\nProjects", milestone: true, phase: 3 },
+  { num: 0, label: "Kickoff\n+ Summit", milestone: true, phase: 1 },
+  { num: 1, label: "Problem\nProposals", milestone: false, phase: 1 },
+  { num: 2, label: "Problem\nVoting", milestone: false, phase: 1 },
+  { num: 3, label: "Pod\nCreation", milestone: false, phase: 1 },
+  { num: 4, label: "Meet The\nPods", milestone: true, phase: 2 },
+  { num: 5, label: "Experiments", milestone: false, phase: 2 },
+  { num: 6, label: "Project\nPitches", milestone: false, phase: 2 },
+  { num: 7, label: "Project\nVoting", milestone: false, phase: 2 },
+  { num: 8, label: "Meet The\nProjects", milestone: true, phase: 3 },
+  { num: 9, label: "Mentor\nIntensive", milestone: false, phase: 3 },
   { num: 10, label: "Mentor\nIntensive", milestone: false, phase: 3 },
   { num: 11, label: "Rehearsal", milestone: false, phase: 3 },
   { num: 12, label: "Showcase\n+ Summit", milestone: true, phase: 3 },
 ];
 
 const PHASES = [
-  { num: 1, title: "Problem Discovery & Definition", weeks: "1–4" },
-  { num: 2, title: "Exploration & Experimentation", weeks: "5–8" },
-  { num: 3, title: "Prototype Building & Iterating", weeks: "9–12" },
+  { num: 1, title: "Problem Discovery & Definition", weeks: "0–3" },
+  { num: 2, title: "Exploration & Experimentation", weeks: "4–7" },
+  { num: 3, title: "Prototype Building & Iterating", weeks: "8–12" },
 ];
 
 /* ── Helpers ───────────────────────────────────────────────────────── */
@@ -77,12 +78,12 @@ function daysUntil(from: Date, to: Date): number {
 }
 
 function getCurrentWeek(now: Date, start: Date, end: Date): number {
-  if (now < start) return 0;
-  if (now > end) return 13;
+  if (now < start) return -1; // not started — Week 0 (kickoff) hasn't begun
+  if (now > end) return 13; // past the Showcase (Week 12)
   const totalMs = end.getTime() - start.getTime();
   const elapsed = now.getTime() - start.getTime();
-  // 12 equal segments
-  const week = Math.floor((elapsed / totalMs) * 12) + 1;
+  // 13 weekly markers, numbered 0–12
+  const week = Math.floor((elapsed / totalMs) * 13);
   return Math.min(week, 12);
 }
 
@@ -147,7 +148,7 @@ export default function CyclePhaseIndicator({
 
   // Which phase are we in?
   const currentPhaseNum =
-    currentWeek <= 4 ? 1 : currentWeek <= 8 ? 2 : currentWeek <= 12 ? 3 : 0;
+    currentWeek < 0 ? 0 : currentWeek <= 3 ? 1 : currentWeek <= 7 ? 2 : 3;
 
   return (
     <div className="mb-10">
@@ -198,7 +199,7 @@ export default function CyclePhaseIndicator({
           {PHASES.map((p) => (
             <div
               key={p.num}
-              className={`flex-[4] ${
+              className={`${p.num === 3 ? "flex-[5]" : "flex-[4]"} ${
                 p.num > 1 ? "border-l border-ink/10 pl-4" : ""
               }`}
             >
@@ -222,14 +223,14 @@ export default function CyclePhaseIndicator({
 
         {/* Week timeline — staggered above/below rail */}
         <div className="relative min-w-[700px]">
-          {/* ── Top labels (odd weeks: 1,3,5,7,9,11,13) ───────── */}
+          {/* ── Top labels (even weeks — the milestones: 0,4,8,12) ── */}
           <div className="mb-1 flex">
             {WEEKS.map((w) => (
               <div
                 key={w.num}
                 className="flex flex-1 flex-col items-center"
               >
-                {w.num % 2 === 1 ? (
+                {w.num % 2 === 0 ? (
                   <>
                     <p
                       className={`mb-1 text-center text-[10px] font-semibold leading-tight ${
@@ -261,7 +262,7 @@ export default function CyclePhaseIndicator({
                     </p>
                   </>
                 ) : (
-                  /* Spacer for even weeks */
+                  /* Spacer for odd weeks */
                   <div className="h-8" />
                 )}
               </div>
@@ -278,7 +279,7 @@ export default function CyclePhaseIndicator({
               <div
                 className="absolute top-1/2 left-0 h-[3px] -translate-y-1/2 rounded-full bg-gradient-to-r from-teal-deep to-teal"
                 style={{
-                  width: `${((currentWeek - 0.5) / 12) * 100}%`,
+                  width: `${((currentWeek + 0.5) / 13) * 100}%`,
                 }}
               />
             )}
@@ -310,14 +311,14 @@ export default function CyclePhaseIndicator({
             })}
           </div>
 
-          {/* ── Bottom labels (even weeks: 2,4,6,8,10,12) ─────── */}
+          {/* ── Bottom labels (odd weeks: 1,3,5,7,9,11) ───────── */}
           <div className="mt-1 flex">
             {WEEKS.map((w) => (
               <div
                 key={w.num}
                 className="flex flex-1 flex-col items-center"
               >
-                {w.num % 2 === 0 ? (
+                {w.num % 2 === 1 ? (
                   <>
                     <p
                       className={`mt-1 text-center text-[10px] font-semibold leading-tight ${
@@ -347,7 +348,7 @@ export default function CyclePhaseIndicator({
                     </p>
                   </>
                 ) : (
-                  /* Spacer for odd weeks */
+                  /* Spacer for even weeks */
                   <div className="h-8" />
                 )}
               </div>


### PR DESCRIPTION
The Build Cycle runs ~3 months (~90 days) with **thirteen weekly markers numbered 0–12** (owner decision). Week 0 is the kickoff/orientation week; Showcase + Summit closes Week 12.

- `CyclePhaseIndicator`: WEEKS 0–12 (13 markers, the second Mentor Intensive week returns), phases 0–3 / 4–7 / 8–12, 0-indexed week math (13 segments), progress fill over 13, Month 3 column widened to five weeks.
- "Not started" returns week `-1` (Week 0 is a real week now), so nothing reads as current before the cycle opens.
- Milestones (weeks 0/4/8/12) move to the top label row.

Marketing copy still reads "twelve weeks" — Kickoff (Week 0) to Showcase (Week 12) is twelve weeks of work.

**Verification:** lint 0 errors · `next build` 45 routes · 21 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_