### PR TITLE
Copy: the Build Cycle reads "three months"

### DIFF
--- a/app/(auth)/register/funnel.tsx
+++ b/app/(auth)/register/funnel.tsx
@@ -144,7 +144,7 @@ const ROLE_OPTIONS: {
     v: "cycle",
     title: "Join a Cycle",
     badge: "Heart of the Labs",
-    sub: "Join a pod, take on a real problem, and ship something you’re proud of. Twelve weeks.",
+    sub: "Join a pod, take on a real problem, and ship something you’re proud of. Three months.",
   },
   {
     v: "events",

--- a/app/(dashboard)/cycles/[cycle_id]/join/ceremony.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/join/ceremony.tsx
@@ -184,7 +184,7 @@ export default function CycleCeremony({
                open with where THEY end up, then the path, then what it takes. */
             <div>
               <h1 className="t-display" style={{ marginBottom: 14 }}>
-                Twelve weeks from now, you’ll have built something real.
+                Three months from now, you’ll have built something real.
               </h1>
               <p className="t-lede" style={{ color: "var(--od2)", marginBottom: 28 }}>
                 You’ll pick a problem that matters to you, team up, and see it

--- a/app/(public)/about/page.tsx
+++ b/app/(public)/about/page.tsx
@@ -33,7 +33,7 @@ const BELIEFS = [
 ];
 
 const BUILT: [string, string][] = [
-  ["Build Cycles", "Twelve weeks, a real problem, a small team that ships."],
+  ["Build Cycles", "Three months, a real problem, a small team that ships."],
   ["Pods", "A handful of people who dig into a problem together."],
   ["Workshops", "Hands-on sessions led by practitioners, open to everyone."],
   ["Mentors", "People who’ve done the work, around when you’re stuck."],

--- a/app/(public)/build-cycles/page.tsx
+++ b/app/(public)/build-cycles/page.tsx
@@ -18,7 +18,7 @@ export const dynamic = "force-dynamic";
 export const metadata = {
   title: "Build Cycles · The Upskilling Labs",
   description:
-    "Twelve weeks from now, you’ll have built something real. Pick a problem, team up, and see it through — in the open.",
+    "Three months from now, you’ll have built something real. Pick a problem, team up, and see it through — in the open.",
 };
 
 const TRAIL: [string, string | null][] = [
@@ -106,7 +106,7 @@ export default async function BuildCyclesPage() {
             Build Cycles · 4 a year
           </div>
           <h1 className="t-h1" style={{ maxWidth: "22ch" }}>
-            Twelve weeks from now, you’ll have built something real.
+            Three months from now, you’ll have built something real.
           </h1>
           <p className="t-lede" style={{ marginTop: 18, maxWidth: "52ch", color: "var(--od2)" }}>
             You’ll pick a problem that matters to you, team up, and see it through —

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -113,7 +113,7 @@ export default async function LandingPage() {
               </div>
               <h3 className="t-h2">Civic &amp; Elections Cycle</h3>
               <p className="t-body" style={{ marginTop: 8, maxWidth: "52ch" }}>
-                Kicks off July 14, 2026 · a 12-week cohort shipping a real
+                Kicks off July 14, 2026 · a three-month cohort shipping a real
                 civic project.
               </p>
               <p className="t-small" style={{ marginTop: 6, color: "var(--od2)", maxWidth: "52ch" }}>


### PR DESCRIPTION
Match the member-facing duration to the ~3-month / ~90-day framing (owner decision). Replaces "twelve weeks" / "12-week" across:

- Landing hero (`a three-month cohort`)
- About (`Three months, a real problem…`)
- Build Cycles — page title + hero (`Three months from now…`)
- Signup funnel intro
- Cycle join ceremony hero

Copy-only; no logic touched. Lint 0 errors · `next build` compiled · 21 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_