### PR TITLE
Lean, mobile-first cycle registration

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/join/ceremony.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/join/ceremony.tsx
@@ -31,6 +31,12 @@ import { OPEN_CYCLE_AGREEMENT_VERSION } from "@/lib/validations/cycle-agreement"
 const HOURS = ["2–4 hrs / week", "5–8 hrs / week", "8+ hrs / week"];
 
 function cycleSteps(cycleName: string, fullName: string): FlowStep[] {
+  // Compact dated recap of the presence commitment — the sign step restates
+  // the dates + open-source policy here so nothing is a surprise, without a
+  // wall of reading (owner decision).
+  const coreDated = coreEvents()
+    .map((e) => `${e.name} (${fmtEvt(e).split(" · ")[0]})`)
+    .join(", ");
   return [
     {
       id: "theme_interest",
@@ -69,7 +75,7 @@ function cycleSteps(cycleName: string, fullName: string): FlowStep[] {
       terms: [
         {
           title: "I’ll be there.",
-          body: "In person, at the five core events: the Problem Sprint, Meet the Pods, the Hackathon, Meet the Projects, and the Showcase Summit. My pod plans around me being there.",
+          body: `In person, at the five core events — ${coreDated}. My pod plans around me being there.`,
         },
         {
           title: "I’ll check in every week.",
@@ -104,8 +110,11 @@ export default function CycleCeremony({
   podRegistrationOpen: boolean;
 }) {
   const router = useRouter();
-  const [stage, setStage] = useState<"ts1" | "ts2" | "flow" | "signed">(
-    alreadySigned ? "signed" : "ts1"
+  // The cycle's purpose + dates + open-source policy now live on the public
+  // /build-cycles page; registration goes straight to the questions + sign
+  // (owner decision — read the pitch there, just agree + register here).
+  const [stage, setStage] = useState<"flow" | "signed">(
+    alreadySigned ? "signed" : "flow"
   );
   const [signedNow, setSignedNow] = useState<string | null>(signedAt);
   const steps = useMemo(
@@ -146,175 +155,25 @@ export default function CycleCeremony({
     return (
       <div className="fixed inset-0 z-[70]">
         <FlowScreen
-          eyebrow={`${cycleName} · An Open Cycle`}
+          eyebrow={eyebrow}
           steps={steps}
           finalLabel="Sign & register"
           finalClass="btn-red"
           submittingLabel="Signing…"
           onComplete={submit}
-          onExit={() => setStage("ts2")}
+          onExit={() => router.push("/dashboard")}
         />
       </div>
     );
   }
 
-  if (stage === "signed") {
-    return <SignedScreen cycleId={cycleId} signedAt={signedNow} podRegistrationOpen={podRegistrationOpen} />;
-  }
-
-  /* ── The threshold (dark cover, two beats) ── */
-  const kickoff = ANCHOR_EVENTS.find((e) => e.kickoff);
-  const kickoffShort = kickoff
-    ? fmtEvt(kickoff).split(" · ")[0] // "Jul 14"
-    : "Jul 14";
-
+  // stage === "signed" — the confirmation
   return (
-    <div className="fixed inset-0 z-[70] view s-cover grain on-dark" style={{ animation: "none" }}>
-      <div className="vscroll" style={{ flex: 1, minHeight: 0 }}>
-        <div className="container" style={{ maxWidth: 560, padding: "48px 24px 24px" }}>
-          <div className="lbl lbl-teal" style={{ marginBottom: 18 }}>
-            {eyebrow}
-          </div>
-
-          {stage === "ts1" && (
-            /* Beat 1 · Benefits first, rooted in the member's hero's journey:
-               open with where THEY end up, then the path, then what it takes. */
-            <div>
-              <h1 className="t-display" style={{ marginBottom: 14 }}>
-                Three months from now, you’ll have built something real.
-              </h1>
-              <p className="t-lede" style={{ color: "var(--od2)", marginBottom: 28 }}>
-                You’ll pick a problem that matters to you, team up, and see it
-                through — with mentors and a whole community behind you.
-              </p>
-              <ThCard label="What you walk away with">
-                Something real you helped build, proof of it on your profile,
-                and people who’ve seen what you can do.
-              </ThCard>
-              <ThCard label="How you get there">
-                Month one: dig into a real problem with your pod. Month two:
-                decide what to build at the Hackathon. Month three: build it,
-                test it, and show it.
-              </ThCard>
-              <ThCard label="What it takes">
-                Six in-person events, a five-minute check-in each week, and the
-                rest on your own time with your team.
-              </ThCard>
-            </div>
-          )}
-
-          {stage === "ts2" && (
-            /* Beat 2 · The deal (three commitments, plain speech) */
-            <div>
-              <h1 className="t-display" style={{ marginBottom: 14 }}>
-                Here’s the deal.
-              </h1>
-              <p className="t-lede" style={{ color: "var(--od2)", marginBottom: 28 }}>
-                Three things. They’re what makes a cycle work, and you’ll put
-                your name to them.
-              </p>
-              <div className="th-card">
-                <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
-                  1 · Show up
-                </div>
-                <div className="t-h4" style={{ marginBottom: 6 }}>
-                  Be at the five core events
-                </div>
-                <p className="t-small" style={{ color: "var(--od2)", marginBottom: 8 }}>
-                  Kickoff ({kickoffShort}) gets it started. These five are
-                  where the whole cycle happens in person — your pod plans
-                  around you being there.
-                </p>
-                <div>
-                  {coreEvents().map((e) => (
-                    <div className="th-ev" key={e.api_id}>
-                      <span className="t-small" style={{ color: "var(--od1)", fontWeight: 600 }}>
-                        ✦ {e.name}
-                      </span>
-                      <span className="t-small" style={{ color: "var(--od2)", flexShrink: 0 }}>
-                        {fmtEvt(e)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <div className="th-card">
-                <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
-                  2 · Check in
-                </div>
-                <div className="t-h4" style={{ marginBottom: 6 }}>
-                  Once a week, five minutes
-                </div>
-                <p className="t-small" style={{ color: "var(--od2)" }}>
-                  One short log each week so your pod knows where you’re at. If
-                  you skip it, the app pauses until you catch up. And if life
-                  gets busy, just tell your Poderator — that’s always okay.
-                </p>
-              </div>
-              <div className="th-card">
-                <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
-                  3 · Open source
-                </div>
-                <div className="t-h4" style={{ marginBottom: 6 }}>
-                  The projects belong to everyone
-                </div>
-                <p className="t-small" style={{ color: "var(--od2)" }}>
-                  Everything a team builds here is an open-source community
-                  project. When the cycle’s over, you’re free to do whatever
-                  you want with it — and so is everyone else. MIT for code, CC
-                  BY 4.0 for the rest, with everyone who worked on it credited.
-                </p>
-              </div>
-            </div>
-          )}
-
-        </div>
-      </div>
-      {/* Pinned action bar — the primary CTA stays in the thumb zone on
-          mobile (mirrors the account-creation flow's sticky .actionbar). */}
-      <div
-        className="actionbar"
-        style={{
-          background: "var(--ink)",
-          borderTop: "1px solid rgba(255,255,255,0.12)",
-        }}
-      >
-        <div style={{ maxWidth: 560, width: "100%", margin: "0 auto" }}>
-          <button
-            className="btn btn-red btn-lg btn-block"
-            onClick={() => setStage(stage === "ts1" ? "ts2" : "flow")}
-          >
-            {stage === "ts1" ? "See the commitment →" : "Begin registration →"}
-          </button>
-          <button
-            className="btn-link"
-            style={{
-              color: "var(--od2)",
-              marginTop: 12,
-              display: "block",
-              marginLeft: "auto",
-              marginRight: "auto",
-            }}
-            onClick={() => router.push("/dashboard")}
-          >
-            Not now — stay a member, browse the free events
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ThCard({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="th-card">
-      <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
-        {label}
-      </div>
-      <p className="t-small" style={{ color: "var(--od2)" }}>
-        {children}
-      </p>
-    </div>
+    <SignedScreen
+      cycleId={cycleId}
+      signedAt={signedNow}
+      podRegistrationOpen={podRegistrationOpen}
+    />
   );
 }
 

--- a/app/(dashboard)/cycles/[cycle_id]/join/ceremony.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/join/ceremony.tsx
@@ -28,34 +28,31 @@ import { OPEN_CYCLE_AGREEMENT_VERSION } from "@/lib/validations/cycle-agreement"
    plain language) — change it in the prototype first.
    ════════════════════════════════════════════════════════════════════════ */
 
-const LEVELS: [string, string][] = [
-  ["Beginner", "New to this area"],
-  ["Developing", "Some hands-on experience"],
-  ["Proficient", "Comfortable working solo"],
-  ["Advanced", "Deep experience, can guide others"],
-];
 const HOURS = ["2–4 hrs / week", "5–8 hrs / week", "8+ hrs / week"];
 
 function cycleSteps(cycleName: string, fullName: string): FlowStep[] {
   return [
     {
-      id: "problem",
+      id: "theme_interest",
       type: "textarea",
-      q: "What problem area excites you most?",
-      help: "A sentence or two is plenty.",
-      ph: "e.g. how AI can help DC residents navigate benefits eligibility...",
+      required: false,
+      q: "What draws you to this cycle’s theme?",
+      help: "No wrong answer — “the timing’s finally right for me” counts. Skip it if you’d rather.",
+      ph: "e.g. local elections have been on my mind for a while…",
     },
     {
-      id: "level",
-      type: "choice",
-      q: "Where are you at in your primary area?",
-      options: LEVELS.map((l) => ({ v: l[0], label: l[0], sub: l[1] })),
+      id: "learning_goals",
+      type: "textarea",
+      q: "What do you want to learn or get sharper at?",
+      help: "A line is plenty.",
+      ph: "e.g. get comfortable shipping a real data pipeline",
     },
     {
-      id: "goals",
+      id: "professional_goals",
       type: "textarea",
-      q: "What do you most want from this cycle?",
-      ph: "What would make this time well spent?",
+      q: "Where are you hoping this takes you?",
+      help: "A line is plenty — a job, a portfolio piece, a new direction.",
+      ph: "e.g. a project I can point employers to",
     },
     {
       id: "hours",
@@ -128,9 +125,9 @@ export default function CycleCeremony({
         signature_name: String(answers.signature ?? "").trim(),
         agreement_version: OPEN_CYCLE_AGREEMENT_VERSION,
         answers: {
-          problem: String(answers.problem ?? ""),
-          level: String(answers.level ?? ""),
-          goals: String(answers.goals ?? ""),
+          theme_interest: String(answers.theme_interest ?? ""),
+          learning_goals: String(answers.learning_goals ?? ""),
+          professional_goals: String(answers.professional_goals ?? ""),
           hours: String(answers.hours ?? ""),
         },
       }),
@@ -173,8 +170,8 @@ export default function CycleCeremony({
 
   return (
     <div className="fixed inset-0 z-[70] view s-cover grain on-dark" style={{ animation: "none" }}>
-      <div className="vscroll" style={{ height: "100%" }}>
-        <div className="container" style={{ maxWidth: 560, padding: "48px 24px 56px" }}>
+      <div className="vscroll" style={{ flex: 1, minHeight: 0 }}>
+        <div className="container" style={{ maxWidth: 560, padding: "48px 24px 24px" }}>
           <div className="lbl lbl-teal" style={{ marginBottom: 18 }}>
             {eyebrow}
           </div>
@@ -203,13 +200,6 @@ export default function CycleCeremony({
                 Six in-person events, a five-minute check-in each week, and the
                 rest on your own time with your team.
               </ThCard>
-              <button
-                className="btn btn-red btn-lg btn-block"
-                style={{ marginTop: 8 }}
-                onClick={() => setStage("ts2")}
-              >
-                See the commitment →
-              </button>
             </div>
           )}
 
@@ -275,21 +265,32 @@ export default function CycleCeremony({
                   BY 4.0 for the rest, with everyone who worked on it credited.
                 </p>
               </div>
-              <button
-                className="btn btn-red btn-lg btn-block"
-                style={{ marginTop: 8 }}
-                onClick={() => setStage("flow")}
-              >
-                Begin registration →
-              </button>
             </div>
           )}
 
+        </div>
+      </div>
+      {/* Pinned action bar — the primary CTA stays in the thumb zone on
+          mobile (mirrors the account-creation flow's sticky .actionbar). */}
+      <div
+        className="actionbar"
+        style={{
+          background: "var(--ink)",
+          borderTop: "1px solid rgba(255,255,255,0.12)",
+        }}
+      >
+        <div style={{ maxWidth: 560, width: "100%", margin: "0 auto" }}>
+          <button
+            className="btn btn-red btn-lg btn-block"
+            onClick={() => setStage(stage === "ts1" ? "ts2" : "flow")}
+          >
+            {stage === "ts1" ? "See the commitment →" : "Begin registration →"}
+          </button>
           <button
             className="btn-link"
             style={{
               color: "var(--od2)",
-              marginTop: 16,
+              marginTop: 12,
               display: "block",
               marginLeft: "auto",
               marginRight: "auto",
@@ -347,10 +348,11 @@ function SignedScreen({
       <div
         className="vscroll"
         style={{
+          flex: 1,
+          minHeight: 0,
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          minHeight: "100dvh",
         }}
       >
         <div className="container" style={{ maxWidth: 520, textAlign: "center", padding: "48px 24px" }}>
@@ -375,10 +377,15 @@ function SignedScreen({
           >
             Add the cycle&rsquo;s events to your calendar
           </a>
-          <p className="t-small" style={{ color: "var(--meta)", marginBottom: 12 }}>
+          <p className="t-small" style={{ color: "var(--meta)" }}>
             Your committed dates live on your cycle page and dashboard — find
             them there anytime.
           </p>
+        </div>
+      </div>
+      {/* Pinned action bar — primary CTA in the thumb zone on mobile. */}
+      <div className="actionbar light-bar">
+        <div style={{ maxWidth: 520, width: "100%", margin: "0 auto" }}>
           {podRegistrationOpen ? (
             <>
               <Link
@@ -389,7 +396,12 @@ function SignedScreen({
               </Link>
               <Link
                 className="btn-link"
-                style={{ color: "var(--meta)", marginTop: 16, display: "inline-block" }}
+                style={{
+                  color: "var(--meta)",
+                  marginTop: 12,
+                  display: "block",
+                  textAlign: "center",
+                }}
                 href={`/cycles/${cycleId}`}
               >
                 Go to your cycle →

--- a/app/(dashboard)/cycles/[cycle_id]/join/ceremony.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/join/ceremony.tsx
@@ -206,15 +206,15 @@ function SignedScreen({
     <div className="fixed inset-0 z-[70] view light s-paper" style={{ animation: "none" }}>
       <div
         className="vscroll"
-        style={{
-          flex: 1,
-          minHeight: 0,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
+        style={{ flex: 1, minHeight: 0, display: "flex" }}
       >
-        <div className="container" style={{ maxWidth: 520, textAlign: "center", padding: "48px 24px" }}>
+        {/* margin:auto (not flex centering) so a tall card on a short/landscape
+            viewport can still scroll to its top — auto margins collapse to 0
+            when space is tight, unlike align-items:center which clips upward. */}
+        <div
+          className="container"
+          style={{ maxWidth: 520, margin: "auto", padding: "48px 24px" }}
+        >
           <div className="lbl lbl-teal" style={{ marginBottom: 18 }}>
             Registration complete
           </div>
@@ -259,7 +259,6 @@ function SignedScreen({
                   color: "var(--meta)",
                   marginTop: 12,
                   display: "block",
-                  textAlign: "center",
                 }}
                 href={`/cycles/${cycleId}`}
               >

--- a/app/(public)/build-cycles/page.tsx
+++ b/app/(public)/build-cycles/page.tsx
@@ -35,7 +35,7 @@ const CYCLE = {
   theme: "Civic & Elections",
   city: "Washington, DC",
   kickoff: "2026-07-14T18:00",
-  weeks: 13,
+  weeks: 12,
 };
 
 const PHASES = [
@@ -51,7 +51,7 @@ const PHASES = [
   },
   {
     title: "Building",
-    when: "Weeks 10–13",
+    when: "Weeks 10–12",
     body: "Winning proposals become teams of 3–5. You build something real, test it with real people, and bring everything — the wins and the misses — back to the commons at the Showcase Summit.",
   },
 ];

--- a/lib/validations/cycle-agreement.ts
+++ b/lib/validations/cycle-agreement.ts
@@ -16,9 +16,9 @@ export const cycleAgreementSchema = z.object({
   agreement_version: z.literal(OPEN_CYCLE_AGREEMENT_VERSION),
   answers: z
     .object({
-      problem: z.string().max(2000).optional(),
-      level: z.string().max(100).optional(),
-      goals: z.string().max(2000).optional(),
+      theme_interest: z.string().max(2000).optional(),
+      learning_goals: z.string().max(2000).optional(),
+      professional_goals: z.string().max(2000).optional(),
       hours: z.string().max(50).optional(),
     })
     .optional(),


### PR DESCRIPTION
Reworks the "Join a Cycle" flow to be lighter and mobile-first.

**Softer questions** — dropped the "what problem excites you" ask and the skill-level tap. Now: optional "what draws you to this theme?" (timing's a fine answer, skippable) → learning goals → professional goals → hours → sign. `answers` JSONB keys + the Zod schema move to `theme_interest / learning_goals / professional_goals / hours` (no migration — nothing reads the old keys; no agreement-copy change → no version bump).

**Pitch moved off the flow** — the two dark "threshold" beats leave registration; tapping Register goes straight to questions → sign → confirmation. The public `/build-cycles` page already carries the whole pitch (the "three months" hero, the promise cards incl. open source, the dated anchor events), so nothing was lost. The sign step now restates the dates + open-source compactly (the "I'll be there" term names the five core events *with dates*).

**Mobile** — the confirmation's primary CTA moves to a pinned, safe-area-padded action bar (thumb zone); the flow already rides the account-creation shell (keyboard-aware `100dvh`, 16px inputs, focus-scroll). `/build-cycles` "13 weeks" → 12.

**Confirmation polish** — adversarial review caught a flex-centering scroll clip (fixed with `margin:auto`); content left-aligned to match the brand.

Verified: lint 0 errors · `next build` 45 routes · 21 tests. A 5-dimension adversarial review over the diff confirmed one issue (the scroll clip), now fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_