### PR TITLE
Left-align content site-wide (brand rule)

### DIFF
--- a/app/(auth)/login/login-card.tsx
+++ b/app/(auth)/login/login-card.tsx
@@ -132,7 +132,7 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
   );
 
   const finePrint = (
-    <p className="t-small" style={{ textAlign: "center" }}>
+    <p className="t-small">
       We only access your name and email. Already a member? Same door — Google
       signs you in either way.
     </p>

--- a/app/(dashboard)/admin/explore/entity-table.tsx
+++ b/app/(dashboard)/admin/explore/entity-table.tsx
@@ -88,7 +88,7 @@ export function EntityTable({
               <tr>
                 <td
                   colSpan={config.columns.length}
-                  className="px-4 py-8 text-center text-sm text-meta"
+                  className="px-4 py-8 text-sm text-meta"
                 >
                   No rows.
                 </td>

--- a/app/(dashboard)/admin/explore/env-banner.tsx
+++ b/app/(dashboard)/admin/explore/env-banner.tsx
@@ -23,7 +23,7 @@ export function EnvBanner() {
     return (
       <div
         role="status"
-        className="mb-6 flex items-center justify-center gap-2 rounded-card border border-red/60 bg-red/10 px-4 py-2 text-xs font-bold uppercase tracking-wider text-red shadow-card"
+        className="mb-6 flex items-center gap-2 rounded-card border border-red/60 bg-red/10 px-4 py-2 text-xs font-bold uppercase tracking-wider text-red shadow-card"
       >
         <span aria-hidden>⚠</span>
         PROD — live participant data — {ref}
@@ -34,7 +34,7 @@ export function EnvBanner() {
   return (
     <div
       role="status"
-      className="mb-6 flex items-center justify-center gap-2 rounded-card border border-teal/40 bg-teal/10 px-4 py-2 text-xs font-bold uppercase tracking-wider text-teal-deep"
+      className="mb-6 flex items-center gap-2 rounded-card border border-teal/40 bg-teal/10 px-4 py-2 text-xs font-bold uppercase tracking-wider text-teal-deep"
     >
       <span aria-hidden className="text-teal">●</span>
       DEV — {ref}

--- a/app/(dashboard)/admin/invitations/invitations-table.tsx
+++ b/app/(dashboard)/admin/invitations/invitations-table.tsx
@@ -346,7 +346,7 @@ export default function InvitationsTable({
             })}
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-4 py-8 text-center text-sm text-meta">
+                <td colSpan={6} className="px-4 py-8 text-sm text-meta">
                   No invitations match your filter.
                 </td>
               </tr>

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -143,7 +143,7 @@ export default async function AdminPage() {
               <tr>
                 <td
                   colSpan={5}
-                  className="px-4 py-8 text-center text-sm text-meta"
+                  className="px-4 py-8 text-sm text-meta"
                 >
                   No cycles yet. Create one to get started.
                 </td>

--- a/app/(dashboard)/admin/participants/participants-global-table.tsx
+++ b/app/(dashboard)/admin/participants/participants-global-table.tsx
@@ -197,7 +197,7 @@ export default function ParticipantsGlobalTable({
               <tr>
                 <td
                   colSpan={7}
-                  className="px-4 py-8 text-center text-sm text-meta"
+                  className="px-4 py-8 text-sm text-meta"
                 >
                   No participants match your search.
                 </td>

--- a/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
@@ -82,7 +82,7 @@ export default async function ProposePage({
       {isOpen ? (
         <ProposeForm cycleId={cycleId} participantName={participantName} />
       ) : (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
             Problem statement submission is not currently open.
           </p>

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -171,11 +171,11 @@ export default function ProposeForm({
 
   if (submitted) {
     return (
-      <div className="rounded-card border border-teal/30 bg-teal/10 p-8 text-center">
+      <div className="rounded-card border border-teal/30 bg-teal/10 p-8">
         <h2 className="t-h3 text-ink">
           Proposal submitted
         </h2>
-        <p className="mx-auto mt-3 max-w-lg text-sm leading-relaxed text-charcoal">
+        <p className="mt-3 max-w-lg text-sm leading-relaxed text-charcoal">
           Your proposal enters the Open Cycle queue. At the start of each cycle,
           active participants vote during Phase 1 to build a shortlist. If your
           proposal makes the shortlist, it opens for registration. Research pods

--- a/app/(dashboard)/cycles/[cycle_id]/register-pods/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-pods/page.tsx
@@ -88,7 +88,7 @@ export default async function RegisterPodsPage({
           </div>
         </>
       ) : (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
             Pod registration is not currently open.
           </p>

--- a/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
@@ -138,7 +138,7 @@ export default function PodRegistration({
 
   if (pods.length === 0) {
     return (
-      <div className="rounded-card border border-dashed border-meta-soft bg-white p-12 text-center">
+      <div className="rounded-card border border-dashed border-meta-soft bg-white p-12">
         <p className="text-sm text-meta">
           No pods available for registration yet.
         </p>

--- a/app/(dashboard)/cycles/[cycle_id]/register-projects/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-projects/page.tsx
@@ -135,7 +135,7 @@ export default async function RegisterProjectsPage({
       </div>
 
       {!isOpen ? (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
             Project registration is not currently open.
           </p>
@@ -151,7 +151,7 @@ export default async function RegisterProjectsPage({
             )}
         </div>
       ) : !enrollmentActive ? (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
             You are not an active participant in this cycle.
           </p>

--- a/app/(dashboard)/cycles/[cycle_id]/register-projects/project-registration.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-projects/project-registration.tsx
@@ -99,7 +99,7 @@ export default function ProjectRegistration({
 
   if (projects.length === 0) {
     return (
-      <div className="rounded-card border border-dashed border-meta-soft bg-white p-12 text-center">
+      <div className="rounded-card border border-dashed border-meta-soft bg-white p-12">
         <p className="text-sm text-meta">
           No projects available for registration yet.
         </p>

--- a/app/(dashboard)/cycles/[cycle_id]/solution-vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solution-vote/page.tsx
@@ -95,7 +95,7 @@ export default async function SolutionVotePage({
       </div>
 
       {!isOpen ? (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">Project voting is not currently open.</p>
           {openAt && now < openAt && (
             <p className="mt-2 text-sm text-meta tabular-nums">
@@ -110,7 +110,7 @@ export default async function SolutionVotePage({
           )}
         </div>
       ) : myPods.length === 0 ? (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
             You are not a member of any pods in this cycle.
           </p>

--- a/app/(dashboard)/cycles/[cycle_id]/solution-vote/solution-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solution-vote/solution-ballot.tsx
@@ -220,7 +220,7 @@ export default function SolutionBallot({
           Loading projects...
         </div>
       ) : proposals.length === 0 ? (
-        <div className="rounded-card border border-dashed border-meta-soft bg-white p-12 text-center">
+        <div className="rounded-card border border-dashed border-meta-soft bg-white p-12">
           <p className="text-sm text-meta">
             No projects have been submitted in this pod.
           </p>

--- a/app/(dashboard)/cycles/[cycle_id]/solutions/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solutions/page.tsx
@@ -105,7 +105,7 @@ export default async function SolutionsPage({
       </div>
 
       {!tabVisible ? (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
             Project submission is not currently open.
           </p>
@@ -122,7 +122,7 @@ export default async function SolutionsPage({
           )}
         </div>
       ) : myPods.length === 0 ? (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
             You are not a member of any pods in this cycle.
           </p>

--- a/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
@@ -61,7 +61,7 @@ export default async function VotePage({
           nonSubmitterBudget={config?.non_submitter_votes ?? 0}
         />
       ) : (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">Voting is not currently open.</p>
           {config?.voting_open && now < new Date(config.voting_open) && (
             <p className="mt-2 text-sm text-meta tabular-nums">

--- a/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
@@ -136,7 +136,7 @@ export default function VoteBallot({
 
   if (statements.length === 0) {
     return (
-      <div className="rounded-card border border-dashed border-meta-soft bg-white p-12 text-center">
+      <div className="rounded-card border border-dashed border-meta-soft bg-white p-12">
         <p className="text-sm text-meta">
           No problem statements have been submitted yet.
         </p>

--- a/app/(dashboard)/moderator/cycles/[cycle_id]/vote-progress/page.tsx
+++ b/app/(dashboard)/moderator/cycles/[cycle_id]/vote-progress/page.tsx
@@ -167,7 +167,7 @@ export default async function ModeratorVoteProgressPage({
       </div>
 
       {podData.length === 0 ? (
-        <div className="rounded-card border border-ink/10 bg-white p-6 text-center shadow-card">
+        <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
             No pods to display for this cycle.
             {!isAdmin(userRoles) && " You are not assigned to any pods here."}
@@ -193,7 +193,7 @@ export default async function ModeratorVoteProgressPage({
                 </header>
 
                 {pod.proposals.length === 0 ? (
-                  <p className="rounded-card border border-dashed border-meta-soft p-6 text-center text-sm text-meta">
+                  <p className="rounded-card border border-dashed border-meta-soft p-6 text-sm text-meta">
                     No projects submitted in this pod.
                   </p>
                 ) : (

--- a/app/(dashboard)/moderator/pods/[pod_id]/recent-pulses-feed.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/recent-pulses-feed.tsx
@@ -99,7 +99,7 @@ export function RecentPulsesFeed({ podId }: { podId: number }) {
 
   if (payload.pulses.length === 0) {
     return (
-      <div className="rounded-card border border-ink/10 bg-white p-6 text-center text-sm text-meta">
+      <div className="rounded-card border border-ink/10 bg-white p-6 text-sm text-meta">
         No submitted pulses in this pod yet.
       </div>
     );

--- a/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
@@ -310,7 +310,7 @@ export function RosterTable({
             {visible.length === 0 && (
               <tr className="border-t border-ink/10">
                 <td
-                  className="px-4 py-6 text-center text-meta"
+                  className="px-4 py-6 text-meta"
                   colSpan={5}
                 >
                   No members match the current filter.

--- a/app/(dashboard)/pulse-check/page.tsx
+++ b/app/(dashboard)/pulse-check/page.tsx
@@ -32,7 +32,7 @@ export default async function PulseCheckPage() {
 
   if (!participantId) {
     return (
-      <div className="mx-auto max-w-2xl py-10 text-center text-sm text-slate">
+      <div className="mx-auto max-w-2xl py-10 text-sm text-slate">
         {copy.page.notRegistered}
       </div>
     );

--- a/app/(dashboard)/pulse-check/pulse-check-form.tsx
+++ b/app/(dashboard)/pulse-check/pulse-check-form.tsx
@@ -867,8 +867,8 @@ function ConfirmationView({
   onSubmitAnother: () => void;
 }) {
   return (
-    <div className="rounded-card border border-teal/30 bg-white p-8 text-center shadow-card">
-      <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-teal/10 text-teal-deep">
+    <div className="rounded-card border border-teal/30 bg-white p-8 shadow-card">
+      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-teal/10 text-teal-deep">
         <svg
           className="h-6 w-6"
           fill="none"
@@ -891,7 +891,7 @@ function ConfirmationView({
         {copy.confirmation.body}
         {nominationCount > 0 && copy.confirmation.nominationThanks(nominationCount)}
       </p>
-      <div className="mt-6 flex flex-col items-center gap-3">
+      <div className="mt-6 flex flex-col items-start gap-3">
         <Link
           href="/cycles"
           className="btn btn-teal w-full max-w-xs sm:w-auto"

--- a/app/(public)/events/[slug]/rsvp.tsx
+++ b/app/(public)/events/[slug]/rsvp.tsx
@@ -219,7 +219,7 @@ export default function RsvpButton({
               </p>
             </div>
           ) : (
-            <div style={{ textAlign: "center", padding: "12px 0" }}>
+            <div style={{ padding: "12px 0" }}>
               <h3 className="t-h3" style={{ marginBottom: 8 }}>
                 Spot saved ✓
               </h3>

--- a/app/(public)/library/page.tsx
+++ b/app/(public)/library/page.tsx
@@ -46,7 +46,7 @@ export default async function LibraryPage() {
               ))}
             </div>
           ) : (
-            <div className="lcard" style={{ padding: 48, textAlign: "center" }}>
+            <div className="lcard" style={{ padding: 48 }}>
               <div className="t-h3">Coming Soon</div>
             </div>
           )}

--- a/app/components/feedback/feedback-widget.tsx
+++ b/app/components/feedback/feedback-widget.tsx
@@ -190,7 +190,7 @@ export default function FeedbackWidget() {
             </div>
 
             {done ? (
-              <div className="flex flex-col items-center gap-3 px-5 py-10 text-center">
+              <div className="flex flex-col gap-3 px-5 py-10">
                 <span className="flex h-12 w-12 items-center justify-center rounded-full bg-teal/10 text-teal-deep">
                   <Check className="h-6 w-6" aria-hidden />
                 </span>

--- a/app/components/ui/empty-state.tsx
+++ b/app/components/ui/empty-state.tsx
@@ -16,7 +16,7 @@ export function EmptyState({
 }) {
   return (
     <div
-      className={`flex flex-col items-center justify-center rounded-card border border-dashed border-meta-soft p-12 text-center ${className ?? ""}`}
+      className={`flex flex-col justify-center rounded-card border border-dashed border-meta-soft p-12 ${className ?? ""}`}
     >
       {Icon && <Icon className="mb-4 h-12 w-12 text-meta-soft" aria-hidden />}
       <h3 className="t-h4 mb-2">{title}</h3>

--- a/app/globals.css
+++ b/app/globals.css
@@ -328,7 +328,7 @@ dialog::backdrop {
   .flow-help { margin-bottom: 32px; max-width: 36ch; }
   .flow-scroll { padding-bottom: 32px; }
   .flow-emaillarge { font-size: 22px; font-weight: 600; letter-spacing: -0.02em; color: var(--ink); padding: 18px 20px; border: 1px solid var(--rule); border-radius: var(--r); background: var(--white); }
-  .flow-skip { text-align: center; }
+  .flow-skip { text-align: left; }
   .choice-list { display: flex; flex-direction: column; gap: 8px; }
   .choice { display: flex; align-items: center; gap: 16px; padding: 18px 20px; border: 1px solid var(--rule); border-radius: var(--r); background: var(--white); cursor: pointer; transition: border-color 0.15s, box-shadow 0.15s, transform 0.08s; }
   .choice:active { transform: scale(0.99); }
@@ -691,7 +691,7 @@ button:focus-visible {
   .metro-search input::placeholder { color: var(--meta-soft); }
 
   /* ── signed-out upsell band ── */
-  .upsell { position: fixed; bottom: 0; left: 0; right: 0; z-index: 50; background: var(--ink); color: var(--od1); padding: 12px var(--pad); display: flex; align-items: center; justify-content: center; gap: 16px; flex-wrap: wrap; box-shadow: 0 -8px 30px rgba(0, 20, 27, 0.25); }
+  .upsell { position: fixed; bottom: 0; left: 0; right: 0; z-index: 50; background: var(--ink); color: var(--od1); padding: 12px var(--pad); display: flex; align-items: center; gap: 16px; flex-wrap: wrap; box-shadow: 0 -8px 30px rgba(0, 20, 27, 0.25); }
   .upsell p { font-size: 14px; font-weight: 600; color: #fff; }
   .upsell .t-small { color: var(--od2); }
   .has-upsell { padding-bottom: 76px; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -175,7 +175,7 @@ export default async function LandingPage() {
               ))}
             </div>
           ) : (
-            <div className="lcard" style={{ padding: 48, textAlign: "center" }}>
+            <div className="lcard" style={{ padding: 48 }}>
               <div className="t-h3">Coming Soon</div>
             </div>
           )}


### PR DESCRIPTION
The whole site expresses the Labs brand, and the brand is **left-aligned always** — centered content reads off-brand.

Swept all five areas and left-aligned genuine content-text centering (**37 edits across 28 files**):
- Empty-state cards + table "no results" cells (admin tables, rosters, ballots, registration lists)
- Status "not open / not a member" cards across the formation flow
- Success/confirmation screens: RSVP "Spot saved ✓", propose "Proposal submitted", pulse-check + feedback confirmations
- Login fine-print, the flow **Skip** link, the shared `EmptyState` component, the `.upsell` + env banners

**Deliberately left untouched** (structural — not content; flagged for your call): the cycle phase-timeline week labels (they align to the rail pips), stat-cell numbers, the 404/error page card layouts, modal/dialog viewport positioning, spinners, and icon / vertical (`align-items`) centering.

Method: a fan-out sweep (one agent per area) that classified every centering signal and applied only the clear content fixes, each area then checked by an adversarial verify pass that restores any over-strip — all came back clean.

Verified: lint 0 errors · `next build` 45 routes · 21 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_