### PR TITLE
Community directory (roadmap Phase 2 — Directory + Me)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -115,6 +115,11 @@ erDiagram
         varchar referred_by
         varchar zip
         varchar metro_slug
+        int metro_id FK "→ metros(id), normalizes metro_slug (00044)"
+        varchar handle UK "url-safe, auto-gen + editable (00044)"
+        text bio "directory (00044)"
+        varchar headline "directory tagline (00044)"
+        boolean public_profile_visible "opt-in future public tier, default false (00044)"
         text_array role_intents "NOT NULL DEFAULT {}"
         varchar agreement_version
         timestamptz agreement_accepted_at

--- a/app/(dashboard)/directory/directory-grid.tsx
+++ b/app/(dashboard)/directory/directory-grid.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import NominateButton from "./nominate-button";
+import { ROLE_INTENT_LABELS } from "../profile/member-profile-view";
+import type { DirectoryMember } from "./page";
+
+/**
+ * The member directory grid — chip filter (All / Builders / Mentors /
+ * Volunteers, from role_intents) + a name/metro search box, modeled on
+ * participants-global-table + metro-search. Cards are `.card.tappable` teasers
+ * linking to /u/[handle]; the Nominate ghost button stops the tap from
+ * following the card link.
+ */
+
+const FILTERS: { key: string; label: string; intent?: string }[] = [
+  { key: "all", label: "All" },
+  { key: "cycle", label: "Builders", intent: "cycle" },
+  { key: "mentor", label: "Mentors", intent: "mentor" },
+  { key: "volunteer", label: "Volunteers", intent: "volunteer" },
+];
+
+export default function DirectoryGrid({
+  members,
+}: {
+  members: DirectoryMember[];
+}) {
+  const [filter, setFilter] = useState("all");
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return members.filter((m) => {
+      const matchesFilter =
+        filter === "all" || (m.role_intents ?? []).includes(filter);
+      if (!matchesFilter) return false;
+      if (!q) return true;
+      return (
+        m.displayName.toLowerCase().includes(q) ||
+        (m.metroName?.toLowerCase().includes(q) ?? false) ||
+        (m.headline?.toLowerCase().includes(q) ?? false) ||
+        (m.primary_expertise?.toLowerCase().includes(q) ?? false)
+      );
+    });
+  }, [members, filter, search]);
+
+  return (
+    <div>
+      {/* Controls */}
+      <div className="mb-5 space-y-3">
+        <input
+          type="text"
+          placeholder="Search by name, city, or expertise…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="Search the directory"
+          className="w-full max-w-md rounded-card border border-ink/10 bg-white px-3.5 py-2.5 text-base text-ink placeholder:text-meta-soft focus:border-teal focus:outline-none focus:ring-[3px] focus:ring-teal/15 transition-[border-color,box-shadow] duration-150"
+        />
+        <div className="flex flex-wrap items-center gap-2">
+          {FILTERS.map((f) => (
+            <button
+              key={f.key}
+              className={`chip${filter === f.key ? " active" : ""}`}
+              aria-pressed={filter === f.key}
+              onClick={() => setFilter(f.key)}
+            >
+              {f.label}
+            </button>
+          ))}
+          <span className="ml-1 text-sm text-meta tabular-nums">
+            {filtered.length} {filtered.length === 1 ? "member" : "members"}
+          </span>
+        </div>
+      </div>
+
+      {/* Grid */}
+      {filtered.length === 0 ? (
+        <div className="rounded-card border border-dashed border-meta-soft p-10 text-center">
+          <p className="t-small">No members match your search.</p>
+        </div>
+      ) : (
+        <div className="cards dense all">
+          {filtered.map((m) => (
+            <MemberCard key={m.id} member={m} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MemberCard({ member: m }: { member: DirectoryMember }) {
+  const href = m.handle ? `/u/${m.handle}` : null;
+  return (
+    // Stretched-link pattern: the whole card is tappable via an absolutely-
+    // positioned overlay <Link>, while the Nominate <button> sits above it
+    // (relative z-10). This keeps the button OUT of the anchor — React 19
+    // rejects a <button> nested inside an <a> as invalid nesting.
+    <div className="card tappable relative">
+      <div className="card-body">
+        <div className="flex items-start gap-3">
+          {m.profile_image_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={m.profile_image_url}
+              alt={m.displayName}
+              className="h-12 w-12 shrink-0 rounded-full object-cover ring-1 ring-ink/10"
+            />
+          ) : (
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-teal-deep text-sm font-bold text-white">
+              {m.firstInitial}
+              {m.lastInitial}
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <p className="t-h4 truncate text-ink">{m.displayName}</p>
+            {m.headline ? (
+              <p className="truncate text-sm font-medium text-teal-deep">
+                {m.headline}
+              </p>
+            ) : m.primary_expertise ? (
+              <p className="truncate text-sm text-charcoal">
+                {m.primary_expertise}
+              </p>
+            ) : null}
+            {m.metroName && (
+              <p className="mt-0.5 truncate text-xs text-meta">{m.metroName}</p>
+            )}
+          </div>
+        </div>
+
+        {(m.role_intents?.length ?? 0) > 0 && (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {m.role_intents.map((r) => (
+              <span
+                key={r}
+                className="inline-flex items-center rounded-sm bg-teal/10 px-2 py-0.5 text-xs font-medium text-teal-deep"
+              >
+                {ROLE_INTENT_LABELS[r] ?? r}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Above the overlay link so it stays independently clickable. */}
+        <div className="relative z-10 mt-3 inline-flex">
+          <NominateButton nomineeName={m.displayName} />
+        </div>
+      </div>
+
+      {href && (
+        <Link
+          href={href}
+          className="absolute inset-0 rounded-[inherit] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+          aria-label={`View ${m.displayName}'s profile`}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/directory/nominate-button.tsx
+++ b/app/(dashboard)/directory/nominate-button.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { Sheet, Button, Field, Textarea, Select } from "@/app/components/ui";
+
+/**
+ * "Nominate" — members surface talent; staff concierge, never gate (prototype:
+ * FLOWS('nominate') → nominations pipeline). One reason field + a type, decoupled
+ * from the pulse bundle → standalone POST /api/nominations.
+ *
+ * `variant="ghost"` is the directory-card affordance; `stopPropagation` keeps a
+ * tap on it from following the card's link to /u/[handle].
+ */
+
+const TYPES: { value: string; label: string }[] = [
+  { value: "mentor", label: "as a mentor" },
+  { value: "advisor", label: "as an advisor" },
+  { value: "upskiller", label: "as an upskiller" },
+];
+
+export default function NominateButton({
+  nomineeName,
+  className,
+  variant = "ghost",
+}: {
+  nomineeName: string;
+  className?: string;
+  variant?: "ghost" | "secondary";
+}) {
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState("mentor");
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const submit = async () => {
+    if (!reason.trim()) {
+      setError("Tell us why in a sentence or two.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/nominations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          nominee_name: nomineeName,
+          nomination_type: type,
+          reason: reason.trim(),
+        }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => null);
+        setError(j?.error || "Something went wrong. Try again.");
+        setBusy(false);
+        return;
+      }
+      setDone(true);
+    } catch {
+      setError("Something went wrong. Try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const close = () => {
+    setOpen(false);
+    // Reset after the drawer animates out so the copy doesn't flash.
+    setTimeout(() => {
+      setReason("");
+      setType("mentor");
+      setError(null);
+      setDone(false);
+    }, 200);
+  };
+
+  return (
+    <>
+      <Button
+        variant={variant}
+        size="sm"
+        className={className}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setOpen(true);
+        }}
+      >
+        Nominate
+      </Button>
+
+      <Sheet
+        open={open}
+        onClose={close}
+        title={done ? "Thank you" : `Nominate ${nomineeName}`}
+        description={
+          done
+            ? undefined
+            : "The team reviews every nomination. Nothing is shared publicly."
+        }
+        footer={
+          done ? (
+            <Button variant="primary" className="w-full" onClick={close}>
+              Done
+            </Button>
+          ) : (
+            <div className="flex gap-3">
+              <Button variant="secondary" onClick={close} disabled={busy}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                className="flex-1"
+                onClick={submit}
+                disabled={busy}
+              >
+                {busy ? "Sending…" : "Send nomination"}
+              </Button>
+            </div>
+          )
+        }
+      >
+        <div className="px-6 py-5">
+          {done ? (
+            <p className="text-sm leading-relaxed text-charcoal">
+              We&apos;ve got your nomination for{" "}
+              <span className="font-semibold text-ink">{nomineeName}</span>. The
+              team will take it from here.
+            </p>
+          ) : (
+            <div className="space-y-5">
+              <Field label="You're nominating them" htmlFor="nominate-type">
+                <Select
+                  id="nominate-type"
+                  value={type}
+                  onChange={(e) => setType(e.target.value)}
+                >
+                  {TYPES.map((t) => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </Select>
+              </Field>
+              <Field
+                label="Why them?"
+                htmlFor="nominate-reason"
+                required
+                error={error}
+                charCount={`${reason.length}/2000`}
+              >
+                <Textarea
+                  id="nominate-reason"
+                  rows={5}
+                  maxLength={2000}
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  placeholder="What have you seen them do that others should know about?"
+                  invalid={!!error}
+                />
+              </Field>
+            </div>
+          )}
+        </div>
+      </Sheet>
+    </>
+  );
+}

--- a/app/(dashboard)/directory/page.tsx
+++ b/app/(dashboard)/directory/page.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import { MapPin } from "lucide-react";
+import { createServiceClient } from "@/lib/supabase/server";
+import DirectoryGrid from "./directory-grid";
+import UpdatesFeed from "./updates-feed";
+
+/**
+ * /directory — the community directory (roadmap Phase 2). Members-only: the
+ * (dashboard)/layout.tsx guard gates the whole route group, and the weekly
+ * Learning-Log gate applies (locked members bounce Home).
+ *
+ * Security: we read the display-column allowlist via the SERVICE client — never
+ * a widened participants RLS. No PII column (email, phone, zip, dcpl_card,
+ * notes, google_id) is selected. Test accounts are excluded.
+ */
+
+export const dynamic = "force-dynamic";
+
+const DISPLAY_COLUMNS =
+  "id, handle, preferred_name, first_name, last_name, headline, primary_expertise, role_intents, profile_image_url, metro_slug, is_test";
+
+export interface DirectoryMember {
+  id: number;
+  handle: string | null;
+  displayName: string;
+  firstInitial: string;
+  lastInitial: string;
+  headline: string | null;
+  primary_expertise: string | null;
+  role_intents: string[];
+  profile_image_url: string | null;
+  metroName: string | null;
+}
+
+export default async function DirectoryPage() {
+  const service = createServiceClient();
+
+  const [{ data: rows }, { data: metros }] = await Promise.all([
+    service
+      .from("participants")
+      .select(DISPLAY_COLUMNS)
+      // Members only — internal (test + staff) accounts are hidden everywhere
+      // else in the app (the Poderator's visibleMembers()); match that here.
+      .eq("is_test", false)
+      .eq("is_staff", false)
+      .order("created_at", { ascending: false }),
+    service.from("metros").select("slug, name, st"),
+  ]);
+
+  const metroBySlug = new Map<string, string>();
+  for (const m of metros ?? []) {
+    metroBySlug.set(m.slug, [m.name, m.st].filter(Boolean).join(", "));
+  }
+
+  const members: DirectoryMember[] = (rows ?? []).map((m) => ({
+    id: m.id,
+    handle: m.handle,
+    displayName:
+      m.preferred_name || `${m.first_name} ${m.last_name}`.trim() || "A member",
+    firstInitial: m.first_name?.[0] ?? "",
+    lastInitial: m.last_name?.[0] ?? "",
+    headline: m.headline ?? null,
+    primary_expertise: m.primary_expertise ?? null,
+    role_intents: m.role_intents ?? [],
+    profile_image_url: m.profile_image_url ?? null,
+    metroName: m.metro_slug ? (metroBySlug.get(m.metro_slug) ?? null) : null,
+  }));
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-10">
+      <header className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="t-h1 text-ink">Directory</h1>
+          <p className="mt-1 t-small">Find your people. Build your edge.</p>
+        </div>
+        <Link
+          href="/local-labs"
+          className="inline-flex items-center gap-1.5 rounded-card border border-ink/10 bg-white px-3.5 py-2 text-sm font-medium text-teal-deep shadow-card transition-colors duration-150 hover:border-teal/40 hover:text-ink"
+        >
+          <MapPin className="h-4 w-4" aria-hidden />
+          Cities
+        </Link>
+      </header>
+
+      <DirectoryGrid members={members} />
+
+      <UpdatesFeed />
+    </div>
+  );
+}

--- a/app/(dashboard)/directory/updates-feed.tsx
+++ b/app/(dashboard)/directory/updates-feed.tsx
@@ -1,0 +1,171 @@
+import Link from "next/link";
+import { createServiceClient } from "@/lib/supabase/server";
+import { EmptyState } from "@/app/components/ui";
+
+/**
+ * Community updates — the reader that finally pays off the Learning Log's
+ * "share to Discover" toggle (migration 00040's `profile_updates`). The prototype
+ * ran this as Discover's "Community updates" list.
+ *
+ * Members-only "All" feed this phase (Following is Phase 5). We read through the
+ * service client with a poster allowlist (name/handle/avatar only) rather than a
+ * cookie-bound `profile_updates` SELECT + a participants join, so no PII column is
+ * ever in reach — the same posture the directory grid uses.
+ *
+ * Two shapes:
+ *   - feed:  the whole 'labs'-visibility stream (on /directory).
+ *   - member: one member's shared updates (on /u/[handle] and owner /profile).
+ * Owner mode gets a lightweight retract control (the RLS already permits the
+ * self-DELETE); it renders as a client island passed via `retractSlot`.
+ */
+
+const PAGE = 30;
+
+export interface UpdatesFeedProps {
+  /** Scope to a single member (their shared updates). Omit for the full feed. */
+  participantId?: number;
+  title?: string;
+  emptyTitle?: string;
+  emptyDescription?: string;
+  /** Owner mode: render a per-row retract control. */
+  renderRetract?: (updateId: number) => React.ReactNode;
+}
+
+interface Poster {
+  handle: string | null;
+  preferred_name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  profile_image_url: string | null;
+}
+
+interface UpdateRow {
+  id: number;
+  participant_id: number;
+  body: string;
+  created_at: string;
+  participants: Poster | Poster[] | null;
+}
+
+function relTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const s = Math.max(0, Math.round((now - then) / 1000));
+  if (s < 60) return "just now";
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default async function UpdatesFeed({
+  participantId,
+  title = "Community updates",
+  emptyTitle = "No updates yet",
+  emptyDescription = "When members share a Learning Log to the community, it shows up here.",
+  renderRetract,
+}: UpdatesFeedProps) {
+  const service = createServiceClient();
+  // !inner so the poster filter (global feed) applies as a join predicate.
+  let query = service
+    .from("profile_updates")
+    .select(
+      "id, participant_id, body, created_at, participants:participant_id!inner(handle, preferred_name, first_name, last_name, profile_image_url)"
+    )
+    .eq("visibility", "labs")
+    .order("created_at", { ascending: false })
+    .limit(PAGE);
+
+  if (participantId != null) {
+    // Member-scoped (a profile's own shares) — already access-controlled by the
+    // page; don't hide internal accounts here or a staff owner wouldn't see
+    // their own shares.
+    query = query.eq("participant_id", participantId);
+  } else {
+    // Global community feed — hide internal (test/staff) posters, matching the
+    // directory grid.
+    query = query
+      .eq("participants.is_test", false)
+      .eq("participants.is_staff", false);
+  }
+
+  const { data } = await query;
+  const rows = (data ?? []) as unknown as UpdateRow[];
+
+  return (
+    <section>
+      <h2 className="section-head mb-3">{title}</h2>
+      {rows.length === 0 ? (
+        <EmptyState title={emptyTitle} description={emptyDescription} />
+      ) : (
+        <ul className="space-y-3">
+          {rows.map((u) => {
+            const p = Array.isArray(u.participants)
+              ? u.participants[0]
+              : u.participants;
+            const name =
+              p?.preferred_name ||
+              [p?.first_name, p?.last_name].filter(Boolean).join(" ") ||
+              "A member";
+            const initials =
+              `${p?.first_name?.[0] ?? ""}${p?.last_name?.[0] ?? ""}`.toUpperCase() ||
+              "•";
+            const posterLink = p?.handle ? `/u/${p.handle}` : null;
+            return (
+              <li
+                key={u.id}
+                className="rounded-card border border-ink/10 bg-white p-4 shadow-card"
+              >
+                <div className="flex items-start gap-3">
+                  {p?.profile_image_url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={p.profile_image_url}
+                      alt={name}
+                      className="h-9 w-9 shrink-0 rounded-full object-cover ring-1 ring-ink/10"
+                    />
+                  ) : (
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-teal-deep text-xs font-bold text-white">
+                      {initials}
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-baseline justify-between gap-2">
+                      {posterLink ? (
+                        <Link
+                          href={posterLink}
+                          className="text-sm font-semibold text-ink transition-colors duration-150 hover:text-teal-deep focus-visible:outline-none focus-visible:text-teal-deep"
+                        >
+                          {name}
+                        </Link>
+                      ) : (
+                        <span className="text-sm font-semibold text-ink">
+                          {name}
+                        </span>
+                      )}
+                      <span className="shrink-0 text-xs text-meta tabular-nums">
+                        {relTime(u.created_at)}
+                      </span>
+                    </div>
+                    <p className="mt-1 whitespace-pre-line text-sm leading-relaxed text-charcoal">
+                      {u.body}
+                    </p>
+                    {renderRetract && (
+                      <div className="mt-2">{renderRetract(u.id)}</div>
+                    )}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/app/(dashboard)/profile/edit/page.tsx
+++ b/app/(dashboard)/profile/edit/page.tsx
@@ -40,7 +40,7 @@ export default async function ProfileEditPage({ searchParams }: PageProps) {
   const serviceClient = createServiceClient();
   const { data: participant } = await serviceClient
     .from("participants")
-    .select("id, email, first_name, last_name, preferred_name")
+    .select("id, email, first_name, last_name, preferred_name, headline, bio, handle")
     .eq("auth_user_id", user.id)
     .maybeSingle();
 
@@ -74,7 +74,8 @@ export default async function ProfileEditPage({ searchParams }: PageProps) {
           )}
           {!required && (
             <p className="mt-2 text-sm text-slate">
-              Update your name and how you&apos;d like to be addressed.
+              Update your name, how you&apos;d like to be addressed, and your
+              directory profile.
             </p>
           )}
         </header>
@@ -85,6 +86,9 @@ export default async function ProfileEditPage({ searchParams }: PageProps) {
             first_name: participant.first_name ?? "",
             last_name: participant.last_name ?? "",
             preferred_name: participant.preferred_name ?? "",
+            headline: participant.headline ?? "",
+            bio: participant.bio ?? "",
+            handle: participant.handle ?? "",
           }}
           required={required}
           nextPath={nextPath}

--- a/app/(dashboard)/profile/edit/profile-edit-form.tsx
+++ b/app/(dashboard)/profile/edit/profile-edit-form.tsx
@@ -6,7 +6,8 @@ import Link from "next/link";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { FormField, Input } from "@/app/components/ui/form";
+import { FormField, Input, Textarea } from "@/app/components/ui/form";
+import { HANDLE_RE } from "@/lib/participants/handle";
 
 // Form-side schema: stricter than the API's partial-update schema because
 // the form always submits all three whitelisted fields. The API accepts
@@ -26,6 +27,20 @@ const formSchema = z.object({
   first_name: nameField,
   last_name: nameField,
   preferred_name: z.string().max(100).optional().or(z.literal("")),
+  // Directory profile (Phase 2). Empty is allowed on the client — an empty
+  // handle is omitted from the PATCH so the DB keeps the existing one; empty
+  // bio/headline send null to clear. A non-empty handle must be url-safe;
+  // uniqueness is enforced server-side (409 surfaced inline).
+  headline: z.string().max(200, "Too long").optional().or(z.literal("")),
+  bio: z.string().max(2000, "Too long").optional().or(z.literal("")),
+  handle: z
+    .string()
+    .max(50, "Too long")
+    .refine((s) => s === "" || HANDLE_RE.test(s), {
+      message: "Use lowercase letters, numbers, and dashes",
+    })
+    .optional()
+    .or(z.literal("")),
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -36,6 +51,9 @@ interface Props {
     first_name: string;
     last_name: string;
     preferred_name: string;
+    headline: string;
+    bio: string;
+    handle: string;
   };
   required: boolean;
   nextPath: string;
@@ -81,7 +99,16 @@ export default function ProfileEditForm({
       preferred_name: values.preferred_name?.trim()
         ? values.preferred_name.trim()
         : null,
+      // bio/headline are nullable — empty clears them.
+      headline: values.headline?.trim() ? values.headline.trim() : null,
+      bio: values.bio?.trim() ? values.bio.trim() : null,
     };
+
+    // handle is NOT NULL in the DB (auto-generated). Only send it when the
+    // user typed one, so clearing the field keeps their existing handle
+    // rather than failing the min-length check.
+    const handle = values.handle?.trim();
+    if (handle) body.handle = handle;
 
     const res = await fetch(`/api/participants/${participantId}`, {
       method: "PATCH",
@@ -160,6 +187,62 @@ export default function ProfileEditForm({
             {...register("preferred_name")}
           />
         </FormField>
+
+        {/* Directory profile — only on the voluntary edit path. Mode B (forced
+            name completion) stays a single-purpose interstitial. */}
+        {!required && (
+          <div className="space-y-5 border-t border-ink/10 pt-5">
+            <p className="lbl">Directory profile</p>
+
+            <FormField
+              name="headline"
+              label="Headline"
+              helper="One line under your name in the directory (e.g. “Frontend dev learning AI in practice”)."
+              htmlFor="headline"
+            >
+              <Input
+                id="headline"
+                type="text"
+                maxLength={200}
+                invalid={!!errors.headline}
+                {...register("headline")}
+              />
+            </FormField>
+
+            <FormField
+              name="bio"
+              label="About"
+              helper="A short intro shown on your profile. Optional."
+              htmlFor="bio"
+            >
+              <Textarea
+                id="bio"
+                rows={4}
+                maxLength={2000}
+                invalid={!!errors.bio}
+                {...register("bio")}
+              />
+            </FormField>
+
+            <FormField
+              name="handle"
+              label="Profile URL"
+              helper="Your directory address: /u/your-handle. Lowercase letters, numbers, and dashes."
+              htmlFor="handle"
+            >
+              <Input
+                id="handle"
+                type="text"
+                inputMode="url"
+                autoCapitalize="none"
+                spellCheck={false}
+                maxLength={50}
+                invalid={!!errors.handle}
+                {...register("handle")}
+              />
+            </FormField>
+          </div>
+        )}
 
         {serverError && (
           <p className="rounded-card border border-red/30 bg-red/10 px-3 py-2 text-sm text-red">

--- a/app/(dashboard)/profile/member-profile-view.tsx
+++ b/app/(dashboard)/profile/member-profile-view.tsx
@@ -1,0 +1,290 @@
+import Link from "next/link";
+import { StatusBadge } from "@/app/components/ui";
+
+/**
+ * Shared member profile card — the single render for both `/profile` (owner)
+ * and `/u/[handle]` (visitor). The prototype's `PROFILE_PANEL_HTML` mounted in
+ * two modes; this mirrors that (owner decision: one markup source, two lenses).
+ *
+ * Security note: visitor mode NEVER receives PII. The `/u/[handle]` page fetches
+ * only the display-column allowlist via the service client, so the owner-only
+ * fields below simply arrive `undefined`/`null` and their sections don't render.
+ * Owner mode fetches the full row. The gating here is presentational — the real
+ * boundary is which columns each page selects.
+ */
+
+export const ROLE_INTENT_LABELS: Record<string, string> = {
+  cycle: "Builder",
+  mentor: "Mentor",
+  volunteer: "Volunteer",
+  events: "Community",
+};
+
+export interface MemberProfileMember {
+  id: number;
+  handle: string | null;
+  displayName: string;
+  firstInitial: string;
+  lastInitial: string;
+  avatarUrl: string | null;
+  headline: string | null;
+  bio: string | null;
+  currentTitle: string | null;
+  primaryExpertise: string | null;
+  metroName: string | null;
+  roleIntents: string[];
+  createdAt: string;
+  // Owner-only fields — visitor mode leaves these undefined and their sections
+  // never render (the page also never selects them from the DB).
+  email?: string | null;
+  state?: string | null;
+  neighborhood?: string | null;
+  dcplCard?: string | null;
+  workSituation?: string | null;
+  mainFocus?: string | null;
+  sector?: string | null;
+  linkedin?: string | null;
+  aiToolFamiliarity?: number | null;
+}
+
+export interface MemberProfileEnrollment {
+  cycle_id: number;
+  status: string;
+  cycle_name: string | null;
+}
+
+export interface MemberProfileViewProps {
+  mode: "owner" | "visitor";
+  member: MemberProfileMember;
+  /** Owner-only multiselect answers (ai_tools, labs_goals, …). */
+  options?: Record<string, string[]>;
+  enrollments?: MemberProfileEnrollment[];
+  /** Rendered below the card — the member's shared Learning-Log updates. */
+  updatesSlot?: React.ReactNode;
+  /** Visitor-mode Nominate control (client island). */
+  nominateSlot?: React.ReactNode;
+}
+
+export default function MemberProfileView({
+  mode,
+  member,
+  options,
+  enrollments,
+  updatesSlot,
+  nominateSlot,
+}: MemberProfileViewProps) {
+  const isOwner = mode === "owner";
+  const grouped = options ?? {};
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      {/* Visitor context bar — who you're looking at + the way back. */}
+      {!isOwner && (
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <Link
+            href="/directory"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-teal-deep transition-colors duration-150 hover:text-ink focus-visible:outline-none focus-visible:text-ink"
+          >
+            <span aria-hidden>←</span> Back to the Directory
+          </Link>
+          {nominateSlot}
+        </div>
+      )}
+
+      <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card sm:p-8">
+        {/* Header with avatar */}
+        <div className="flex items-center gap-6 border-b border-ink/10 pb-6">
+          {member.avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={member.avatarUrl}
+              alt={member.displayName}
+              className="h-20 w-20 rounded-full object-cover ring-1 ring-ink/10"
+            />
+          ) : (
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-teal-deep text-2xl font-bold text-white">
+              {member.firstInitial}
+              {member.lastInitial}
+            </div>
+          )}
+          <div className="min-w-0">
+            <h1 className="t-h1 text-ink">{member.displayName}</h1>
+            {member.headline ? (
+              <p className="mt-0.5 text-sm font-medium text-teal-deep">
+                {member.headline}
+              </p>
+            ) : member.currentTitle ? (
+              <p className="mt-0.5 text-sm text-charcoal">
+                {member.currentTitle}
+              </p>
+            ) : null}
+            {isOwner && member.email && (
+              <p className="mt-1 text-sm text-charcoal">{member.email}</p>
+            )}
+            {member.metroName && (
+              <p className="mt-1 text-sm text-meta">{member.metroName}</p>
+            )}
+            <p className="mt-1 text-xs text-meta tabular-nums">
+              Upskiller since{" "}
+              {new Date(member.createdAt).toLocaleDateString("en-US", {
+                month: "long",
+                year: "numeric",
+              })}
+            </p>
+            {member.roleIntents.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {member.roleIntents.map((r) => (
+                  <span
+                    key={r}
+                    className="inline-flex items-center rounded-sm bg-teal/10 px-2.5 py-0.5 text-xs font-medium text-teal-deep"
+                  >
+                    {ROLE_INTENT_LABELS[r] ?? r}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Profile sections */}
+        <div className="mt-6 space-y-6">
+          {member.bio && (
+            <Section title="About">
+              <p className="whitespace-pre-line text-sm leading-relaxed text-charcoal">
+                {member.bio}
+              </p>
+            </Section>
+          )}
+
+          {/* Public professional signal (both modes). */}
+          {member.primaryExpertise && (
+            <Section title="Expertise">
+              <Field label="Primary" value={member.primaryExpertise} />
+            </Section>
+          )}
+
+          {/* ── Owner-only PII + intake detail below ── */}
+          {isOwner && (
+            <>
+              <Section title="Location">
+                <Field label="State" value={member.state} />
+                <Field label="Neighborhood" value={member.neighborhood} />
+                <Field label="DCPL Card" value={member.dcplCard} />
+              </Section>
+
+              <Section title="Professional context">
+                <Field label="Work Situation" value={member.workSituation} />
+                <Field label="Main Focus" value={member.mainFocus} />
+                <Field label="Sector" value={member.sector} />
+                <Field label="LinkedIn" value={member.linkedin} isLink />
+              </Section>
+
+              <Section title="AI background">
+                {member.aiToolFamiliarity != null && (
+                  <Field
+                    label="Tool Familiarity"
+                    value={`${member.aiToolFamiliarity} / 5`}
+                  />
+                )}
+                {grouped.ai_tools && (
+                  <Field label="Tools Used" value={grouped.ai_tools.join(", ")} />
+                )}
+              </Section>
+
+              <Section title="Labs fit">
+                {grouped.labs_goals && (
+                  <Field label="Goals" value={grouped.labs_goals.join(", ")} />
+                )}
+                {grouped.availability && (
+                  <Field
+                    label="Availability"
+                    value={grouped.availability.join(", ")}
+                  />
+                )}
+                {grouped.work_style && (
+                  <Field label="Work Style" value={grouped.work_style.join(", ")} />
+                )}
+                {grouped.group_strengths && (
+                  <Field
+                    label="Strengths"
+                    value={grouped.group_strengths.join(", ")}
+                  />
+                )}
+              </Section>
+            </>
+          )}
+
+          {/* Cycle enrollments — cycle membership is visible within the
+              members-only directory (not PII). */}
+          {enrollments && enrollments.length > 0 && (
+            <Section title="Cycle enrollments">
+              <div className="space-y-2">
+                {enrollments.map((e) => (
+                  <div
+                    key={e.cycle_id}
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <span className="text-sm text-charcoal">
+                      {e.cycle_name || `Cycle ${e.cycle_id}`}
+                    </span>
+                    <StatusBadge
+                      variant={e.status === "active" ? "active" : "inactive"}
+                    >
+                      {e.status}
+                    </StatusBadge>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+        </div>
+      </div>
+
+      {updatesSlot && <div className="mt-6">{updatesSlot}</div>}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h2 className="lbl mb-3">{title}</h2>
+      <div className="space-y-2">{children}</div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  isLink,
+}: {
+  label: string;
+  value: string | null | undefined;
+  isLink?: boolean;
+}) {
+  if (!value) return null;
+  return (
+    <div className="flex items-baseline gap-3">
+      <span className="w-32 shrink-0 text-sm text-meta">{label}</span>
+      {isLink ? (
+        <a
+          href={value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="break-all text-sm text-teal-deep transition-colors duration-150 hover:text-ink hover:underline focus-visible:outline-none focus-visible:text-ink"
+        >
+          {value}
+        </a>
+      ) : (
+        <span className="text-sm text-charcoal">{value}</span>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
-import { StatusBadge } from "@/app/components/ui";
+import MemberProfileView from "./member-profile-view";
+import UpdatesFeed from "../directory/updates-feed";
 
 export default async function ProfilePage() {
   const supabase = await createClient();
@@ -43,185 +44,70 @@ export default async function ProfilePage() {
     .select("cycle_id, status, cycles(name)")
     .eq("participant_id", participant.id);
 
+  // Resolve the metro display name (metro_slug → metros.name).
+  let metroName: string | null = null;
+  if (participant.metro_slug) {
+    const { data: metro } = await serviceClient
+      .from("metros")
+      .select("name, st")
+      .eq("slug", participant.metro_slug)
+      .maybeSingle();
+    metroName = metro ? [metro.name, metro.st].filter(Boolean).join(", ") : null;
+  }
+
   const displayName =
     participant.preferred_name ||
     `${participant.first_name} ${participant.last_name}`;
 
-  // Avatar from Google OAuth metadata
-  const avatarUrl: string | null = user.user_metadata?.avatar_url ?? null;
+  // Avatar: the Google OAuth photo (own session) falls back to the stored
+  // profile image, then to initials in the view.
+  const avatarUrl: string | null =
+    user.user_metadata?.avatar_url ?? participant.profile_image_url ?? null;
 
   return (
-    <div className="mx-auto max-w-3xl">
-      <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card sm:p-8">
-        {/* Header with avatar */}
-        <div className="flex items-center gap-6 border-b border-ink/10 pb-6">
-          {avatarUrl ? (
-            <img
-              src={avatarUrl}
-              alt={displayName}
-              className="h-20 w-20 rounded-full ring-1 ring-ink/10"
-            />
-          ) : (
-            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-teal-deep text-2xl font-bold text-white">
-              {participant.first_name[0]}
-              {participant.last_name[0]}
-            </div>
-          )}
-          <div>
-            <h1 className="t-h1 text-ink">
-              {displayName}
-            </h1>
-            <p className="text-sm text-charcoal">{participant.email}</p>
-            {participant.current_title && (
-              <p className="mt-1 text-sm text-charcoal">
-                {participant.current_title}
-              </p>
-            )}
-            <p className="mt-1 text-xs text-meta tabular-nums">
-              Upskiller since{" "}
-              {new Date(participant.created_at).toLocaleDateString("en-US", {
-                month: "long",
-                year: "numeric",
-              })}
-            </p>
-          </div>
-        </div>
-
-        {/* Profile sections */}
-        <div className="mt-6 space-y-6">
-          {/* Location */}
-          <Section title="Location">
-            <Field label="State" value={participant.state} />
-            <Field label="Neighborhood" value={participant.neighborhood} />
-            <Field label="DCPL Card" value={participant.dcpl_card} />
-          </Section>
-
-          {/* Professional */}
-          <Section title="Professional context">
-            <Field label="Work Situation" value={participant.work_situation} />
-            <Field label="Main Focus" value={participant.main_focus} />
-            {participant.sector && (
-              <Field label="Sector" value={participant.sector} />
-            )}
-            {participant.linkedin && (
-              <Field label="LinkedIn" value={participant.linkedin} isLink />
-            )}
-          </Section>
-
-          {/* AI Background */}
-          <Section title="AI background">
-            <Field
-              label="Tool Familiarity"
-              value={`${participant.ai_tool_familiarity} / 5`}
-            />
-            {grouped.ai_tools && (
-              <Field label="Tools Used" value={grouped.ai_tools.join(", ")} />
-            )}
-          </Section>
-
-          {/* Labs Fit */}
-          <Section title="Labs fit">
-            {grouped.labs_goals && (
-              <Field label="Goals" value={grouped.labs_goals.join(", ")} />
-            )}
-            {grouped.availability && (
-              <Field
-                label="Availability"
-                value={grouped.availability.join(", ")}
-              />
-            )}
-            {grouped.work_style && (
-              <Field
-                label="Work Style"
-                value={grouped.work_style.join(", ")}
-              />
-            )}
-            {grouped.group_strengths && (
-              <Field
-                label="Strengths"
-                value={grouped.group_strengths.join(", ")}
-              />
-            )}
-            {participant.primary_expertise && (
-              <Field
-                label="Primary Expertise"
-                value={participant.primary_expertise}
-              />
-            )}
-          </Section>
-
-          {/* Cycle Enrollments */}
-          {enrollments && enrollments.length > 0 && (
-            <Section title="Cycle enrollments">
-              <div className="space-y-2">
-                {enrollments.map((e) => {
-                  const cycle = e.cycles as unknown as Record<string, unknown>;
-                  return (
-                    <div
-                      key={e.cycle_id}
-                      className="flex items-center justify-between gap-3"
-                    >
-                      <span className="text-sm text-charcoal">
-                        {(cycle?.name as string) || `Cycle ${e.cycle_id}`}
-                      </span>
-                      <StatusBadge
-                        variant={e.status === "active" ? "active" : "inactive"}
-                      >
-                        {e.status}
-                      </StatusBadge>
-                    </div>
-                  );
-                })}
-              </div>
-            </Section>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function Section({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <h2 className="lbl mb-3">
-        {title}
-      </h2>
-      <div className="space-y-2">{children}</div>
-    </div>
-  );
-}
-
-function Field({
-  label,
-  value,
-  isLink,
-}: {
-  label: string;
-  value: string;
-  isLink?: boolean;
-}) {
-  return (
-    <div className="flex items-baseline gap-3">
-      <span className="w-32 shrink-0 text-sm text-meta">{label}</span>
-      {isLink ? (
-        <a
-          href={value}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="break-all text-sm text-teal-deep transition-colors duration-150 hover:text-ink hover:underline focus-visible:outline-none focus-visible:text-ink"
-        >
-          {value}
-        </a>
-      ) : (
-        <span className="text-sm text-charcoal">{value}</span>
-      )}
-    </div>
+    <MemberProfileView
+      mode="owner"
+      member={{
+        id: participant.id,
+        handle: participant.handle ?? null,
+        displayName,
+        firstInitial: participant.first_name?.[0] ?? "",
+        lastInitial: participant.last_name?.[0] ?? "",
+        avatarUrl,
+        headline: participant.headline ?? null,
+        bio: participant.bio ?? null,
+        currentTitle: participant.current_title ?? null,
+        primaryExpertise: participant.primary_expertise ?? null,
+        metroName,
+        roleIntents: participant.role_intents ?? [],
+        createdAt: participant.created_at,
+        email: participant.email,
+        state: participant.state,
+        neighborhood: participant.neighborhood,
+        dcplCard: participant.dcpl_card,
+        workSituation: participant.work_situation,
+        mainFocus: participant.main_focus,
+        sector: participant.sector,
+        linkedin: participant.linkedin,
+        aiToolFamiliarity: participant.ai_tool_familiarity,
+      }}
+      options={grouped}
+      enrollments={(enrollments ?? []).map((e) => {
+        const cycle = e.cycles as unknown as Record<string, unknown>;
+        return {
+          cycle_id: e.cycle_id,
+          status: e.status,
+          cycle_name: (cycle?.name as string) ?? null,
+        };
+      })}
+      updatesSlot={
+        <UpdatesFeed
+          participantId={participant.id}
+          title="Your shares"
+          emptyTitle="You haven't shared anything yet"
+          emptyDescription="Share a Learning Log to the community and it will appear here."
+        />
+      }
+    />
   );
 }

--- a/app/(dashboard)/u/[handle]/page.tsx
+++ b/app/(dashboard)/u/[handle]/page.tsx
@@ -1,0 +1,101 @@
+import { notFound } from "next/navigation";
+import { createServiceClient } from "@/lib/supabase/server";
+import MemberProfileView from "../../profile/member-profile-view";
+import UpdatesFeed from "../../directory/updates-feed";
+import NominateButton from "../../directory/nominate-button";
+
+/**
+ * /u/[handle] — a member's public-to-members profile (visitor mode).
+ *
+ * Security: this page fetches ONLY the display-column allowlist via the service
+ * client. No PII column (email, phone, zip, dcpl_card, notes, google_id, …) is
+ * ever selected, so nothing sensitive can leak through the shared view. The
+ * (dashboard)/layout.tsx auth guard already gates the whole route group to
+ * signed-in members; test accounts are excluded from resolution here too.
+ */
+
+const DISPLAY_COLUMNS =
+  "id, handle, preferred_name, first_name, last_name, headline, bio, current_title, primary_expertise, role_intents, profile_image_url, metro_slug, created_at, is_test, is_staff";
+
+export default async function MemberProfilePage({
+  params,
+}: {
+  params: Promise<{ handle: string }>;
+}) {
+  const { handle } = await params;
+  const service = createServiceClient();
+
+  // Stored handles are always lowercase (the CHECK constraint + slugify enforce
+  // it), so an exact lowercased match is correct — and avoids ilike treating a
+  // `%`/`_` in the URL param as a wildcard that could resolve the wrong member.
+  const { data: member } = await service
+    .from("participants")
+    .select(DISPLAY_COLUMNS)
+    .eq("handle", handle.toLowerCase())
+    .maybeSingle();
+
+  // Unknown handle, or an internal account (test/staff) — never surfaced in
+  // the members-only directory, matching the grid + the Poderator's
+  // visibleMembers().
+  if (!member || member.is_test || member.is_staff) {
+    notFound();
+  }
+
+  // Resolve the metro display name (metro_slug → metros.name).
+  let metroName: string | null = null;
+  if (member.metro_slug) {
+    const { data: metro } = await service
+      .from("metros")
+      .select("name, st")
+      .eq("slug", member.metro_slug)
+      .maybeSingle();
+    metroName = metro ? [metro.name, metro.st].filter(Boolean).join(", ") : null;
+  }
+
+  // Cycle enrollments (membership is visible within the members-only directory).
+  const { data: enrollments } = await service
+    .from("cycle_enrollments")
+    .select("cycle_id, status, cycles(name)")
+    .eq("participant_id", member.id);
+
+  const displayName =
+    member.preferred_name || `${member.first_name} ${member.last_name}`;
+
+  return (
+    <MemberProfileView
+      mode="visitor"
+      member={{
+        id: member.id,
+        handle: member.handle,
+        displayName,
+        firstInitial: member.first_name?.[0] ?? "",
+        lastInitial: member.last_name?.[0] ?? "",
+        avatarUrl: member.profile_image_url ?? null,
+        headline: member.headline ?? null,
+        bio: member.bio ?? null,
+        currentTitle: member.current_title ?? null,
+        primaryExpertise: member.primary_expertise ?? null,
+        metroName,
+        roleIntents: member.role_intents ?? [],
+        createdAt: member.created_at,
+      }}
+      enrollments={(enrollments ?? []).map((e) => {
+        const cycle = e.cycles as unknown as Record<string, unknown>;
+        return {
+          cycle_id: e.cycle_id,
+          status: e.status,
+          cycle_name: (cycle?.name as string) ?? null,
+        };
+      })}
+      nominateSlot={<NominateButton nomineeName={displayName} variant="secondary" />}
+      updatesSlot={
+        <UpdatesFeed
+          participantId={member.id}
+          title={`${displayName}'s updates`}
+          emptyTitle="No updates yet"
+          emptyDescription={`${displayName} hasn't shared anything to the community yet.`}
+        />
+      }
+    />
+  );
+}

--- a/app/api/nominations/route.ts
+++ b/app/api/nominations/route.ts
@@ -2,6 +2,8 @@ import { NextResponse, NextRequest } from "next/server";
 import { withAuth } from "@/lib/auth/middleware";
 import { dbError } from "@/lib/api/errors";
 import { can, isAdmin } from "@/lib/auth/roles";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { nominationSchema } from "@/lib/validations/nominations";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 
 export const GET = withAuth(
@@ -49,5 +51,47 @@ export const GET = withAuth(
     const { data, error } = await query;
     if (error) return dbError(error);
     return NextResponse.json(data);
+  }
+);
+
+/**
+ * POST /api/nominations
+ *
+ * A member nominates someone (a peer for mentor/advisor, or an outsider worth
+ * inviting). This is the directory-card / visitor-profile "Nominate" target —
+ * standalone, decoupled from the pulse-check bundle.
+ *
+ * The insert runs through the cookie-bound client so RLS's insert-own policy
+ * (migration 00017: `participant_id = current_participant_id()`) fires: the
+ * nominator is always the authenticated participant, never a body-supplied id.
+ */
+export const POST = withAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest) => {
+    const participantId = auth.user.participantId;
+    if (!participantId) {
+      return NextResponse.json(
+        { error: "Not a registered participant" },
+        { status: 403 }
+      );
+    }
+
+    const body = await parseBody(request, nominationSchema);
+    if (isErrorResponse(body)) return body;
+
+    const { data, error } = await auth.supabase
+      .from("nominations")
+      .insert({
+        participant_id: participantId,
+        nominee_name: body.nominee_name,
+        nominee_email: body.nominee_email || null,
+        nominee_linkedin: body.nominee_linkedin || null,
+        nomination_type: body.nomination_type,
+        reason: body.reason,
+      })
+      .select("id")
+      .single();
+
+    if (error) return dbError(error, "post-nomination");
+    return NextResponse.json({ id: data.id }, { status: 201 });
   }
 );

--- a/app/api/participants/[participant_id]/route.ts
+++ b/app/api/participants/[participant_id]/route.ts
@@ -99,10 +99,18 @@ export const PATCH = withAuth(
       .from("participants")
       .update(body)
       .eq("id", targetId)
-      .select("id, first_name, last_name, preferred_name, email")
+      .select("id, first_name, last_name, preferred_name, email, handle, headline, bio")
       .single();
 
     if (error) {
+      // Unique-violation on the case-insensitive handle index → a clean 409
+      // rather than a generic 500 (the profile editor surfaces this inline).
+      if (error.code === "23505") {
+        return NextResponse.json(
+          { error: "That handle is already taken." },
+          { status: 409 }
+        );
+      }
       return dbError(error, "patch-participant");
     }
 

--- a/app/components/chrome/app-nav.tsx
+++ b/app/components/chrome/app-nav.tsx
@@ -103,6 +103,13 @@ export default function AppNav({
                 My Cycle
               </Link>
             )}
+            <Link
+              className={`nav-link${isActive(pathname, "/directory") ? " active" : ""}`}
+              id="nav-directory"
+              href="/directory"
+            >
+              Directory
+            </Link>
           </nav>
         )}
         <AvatarMenu

--- a/app/components/chrome/tab-bar.tsx
+++ b/app/components/chrome/tab-bar.tsx
@@ -21,6 +21,14 @@ const CYCLE_SVG = (
     <polyline points="21 3 21 9 15 9" />
   </svg>
 );
+const DIRECTORY_SVG = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+  </svg>
+);
 
 export default function TabBar({
   initials,
@@ -48,6 +56,14 @@ export default function TabBar({
           <span>Cycle</span>
         </Link>
       )}
+      <Link
+        className={`tab${active("/directory")}`}
+        id="tab-directory"
+        href="/directory"
+      >
+        {DIRECTORY_SVG}
+        <span>Directory</span>
+      </Link>
       <Link className={`tab${active("/profile")}`} id="tab-me" href="/profile">
         <span className="tab-avatar">{initials}</span>
         <span>Me</span>

--- a/lib/participants/handle.test.ts
+++ b/lib/participants/handle.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { slugifyHandle, isValidHandle } from "./handle";
+
+describe("slugifyHandle", () => {
+  it("lowercases and dashes spaces", () => {
+    expect(slugifyHandle("Priya Shah")).toBe("priya-shah");
+  });
+  it("collapses runs of non-alphanumerics to a single dash", () => {
+    expect(slugifyHandle("Jordan  O'Kafor")).toBe("jordan-o-kafor");
+  });
+  it("trims leading/trailing dashes", () => {
+    expect(slugifyHandle("  --Alex--  ")).toBe("alex");
+  });
+  it("falls back to 'member' when nothing survives", () => {
+    expect(slugifyHandle("!!!")).toBe("member");
+    expect(slugifyHandle("")).toBe("member");
+  });
+  it("caps length at 40 with no trailing dash", () => {
+    const out = slugifyHandle("a".repeat(60));
+    expect(out.length).toBeLessThanOrEqual(40);
+    expect(out.endsWith("-")).toBe(false);
+  });
+});
+
+describe("isValidHandle", () => {
+  it("accepts lowercase slugs with internal dashes", () => {
+    expect(isValidHandle("priya-shah")).toBe(true);
+    expect(isValidHandle("m1")).toBe(true);
+  });
+  it("rejects uppercase, leading dash, underscores, empty, and >50", () => {
+    expect(isValidHandle("Priya")).toBe(false);
+    expect(isValidHandle("-lead")).toBe(false);
+    expect(isValidHandle("ab_cd")).toBe(false);
+    expect(isValidHandle("")).toBe(false);
+    expect(isValidHandle("a".repeat(51))).toBe(false);
+  });
+});

--- a/lib/participants/handle.ts
+++ b/lib/participants/handle.ts
@@ -1,0 +1,25 @@
+/* URL-safe member handles for the community directory (/u/[handle]).
+   Mirrors the DB slugify_handle() in migration 00044 — keep the two in sync.
+   Generation is DB-side (a BEFORE INSERT trigger); these helpers are for the
+   profile-edit form's format validation + hint. */
+
+export const HANDLE_RE = /^[a-z0-9][a-z0-9-]*$/;
+export const HANDLE_MAX = 50;
+
+/** Turn arbitrary text into a url-safe slug: lowercase, [a-z0-9-] only, no
+    leading/trailing/double dashes, capped at 40 chars. Empty → "member". */
+export function slugifyHandle(input: string): string {
+  const s = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
+  return s || "member";
+}
+
+/** A handle a member may set: [a-z0-9], dashes allowed but not leading, 1–50. */
+export function isValidHandle(h: string): boolean {
+  return h.length >= 1 && h.length <= HANDLE_MAX && HANDLE_RE.test(h);
+}

--- a/lib/validations/participants-update.ts
+++ b/lib/validations/participants-update.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { HANDLE_RE } from "@/lib/participants/handle";
 
 // Reject the literal placeholder value 'Unknown' (case-insensitive, trimmed)
 // that scripts/migration/migrate.py wrote for participants missing name data.
@@ -35,6 +36,17 @@ export const participantsUpdateSchema = z
     first_name: nameField,
     last_name: nameField,
     preferred_name: z.string().min(1).max(100).nullable(),
+    // Directory profile fields (Phase 2). bio/headline nullable so they can be
+    // cleared; handle is the /u/[handle] key — always present, format-checked
+    // (uniqueness enforced by the DB index → 409 in the route).
+    bio: z.string().max(2000).nullable(),
+    headline: z.string().max(200).nullable(),
+    handle: z
+      .string()
+      .trim()
+      .min(1)
+      .max(50)
+      .regex(HANDLE_RE, "Use lowercase letters, numbers, and dashes"),
   })
   .partial()
   .strict();

--- a/supabase/migrations/00044_directory_columns.sql
+++ b/supabase/migrations/00044_directory_columns.sql
@@ -1,0 +1,125 @@
+-- 00044_directory_columns.sql
+-- The community directory (roadmap Phase 2 — Directory + Me §1.8). Adds the
+-- member-facing profile columns the /directory grid + /u/[handle] visitor
+-- pages read: a url-safe `handle` (the vanity-URL key), `bio`, `headline`, an
+-- opt-in `public_profile_visible` flag (default false — members-only this
+-- phase), and a normalized `metro_id` FK reconciling the existing `metro_slug`
+-- string.
+--
+-- Handles are auto-generated for EVERY participant (backfill here + a BEFORE
+-- INSERT trigger for new rows) so /u/[handle] works for everyone; members can
+-- later customize theirs in the profile editor (uniqueness enforced below).
+--
+-- Security: directory reads never widen participants RLS — the pages serve an
+-- explicit display-column allowlist via the service client (GAP_AUDIT RLS
+-- decision). No RLS change here.
+--
+-- Idempotent + re-runnable (house style).
+--
+-- DOWN:
+--   DROP TRIGGER IF EXISTS trg_set_participant_handle ON participants;
+--   DROP FUNCTION IF EXISTS set_participant_handle();
+--   DROP FUNCTION IF EXISTS slugify_handle(TEXT);
+--   ALTER TABLE participants DROP CONSTRAINT IF EXISTS participants_metro_id_fkey;
+--   ALTER TABLE participants DROP CONSTRAINT IF EXISTS participants_handle_format;
+--   DROP INDEX IF EXISTS participants_handle_lower_key;
+--   ALTER TABLE participants
+--     DROP COLUMN IF EXISTS handle, DROP COLUMN IF EXISTS bio,
+--     DROP COLUMN IF EXISTS headline, DROP COLUMN IF EXISTS public_profile_visible,
+--     DROP COLUMN IF EXISTS metro_id;
+
+-- 1. Columns ---------------------------------------------------------------
+ALTER TABLE participants ADD COLUMN IF NOT EXISTS handle VARCHAR(50);
+ALTER TABLE participants ADD COLUMN IF NOT EXISTS bio TEXT;
+ALTER TABLE participants ADD COLUMN IF NOT EXISTS headline VARCHAR(200);
+ALTER TABLE participants ADD COLUMN IF NOT EXISTS public_profile_visible BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE participants ADD COLUMN IF NOT EXISTS metro_id INT;
+
+-- 2. slugify helper (mirrored in lib/participants/handle.ts — keep in sync) -
+CREATE OR REPLACE FUNCTION slugify_handle(txt TEXT)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+SET search_path = pg_catalog
+AS $$
+  SELECT COALESCE(
+    NULLIF(
+      left(trim(BOTH '-' FROM regexp_replace(lower(txt), '[^a-z0-9]+', '-', 'g')), 40),
+    ''),
+  'member');
+$$;
+
+-- 3. Backfill a unique handle for every existing participant ---------------
+WITH b AS (
+  SELECT id,
+         slugify_handle(COALESCE(NULLIF(preferred_name, ''), first_name) || '-' || last_name) AS base
+  FROM participants
+  WHERE handle IS NULL
+),
+r AS (
+  SELECT id, base, ROW_NUMBER() OVER (PARTITION BY base ORDER BY id) AS rn FROM b
+)
+UPDATE participants p
+SET handle = CASE WHEN r.rn = 1 THEN r.base ELSE r.base || '-' || r.rn END
+FROM r
+WHERE p.id = r.id;
+
+-- 4. Uniqueness (case-insensitive) + format --------------------------------
+CREATE UNIQUE INDEX IF NOT EXISTS participants_handle_lower_key
+  ON participants (lower(handle)) WHERE handle IS NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'participants_handle_format') THEN
+    ALTER TABLE participants
+      ADD CONSTRAINT participants_handle_format
+      CHECK (handle IS NULL OR handle ~ '^[a-z0-9][a-z0-9-]*$') NOT VALID;
+  END IF;
+END $$;
+
+-- 5. Auto-generate a handle for new participants ---------------------------
+-- NEW.id is populated in BEFORE INSERT (the SERIAL default fires first), so a
+-- base collision falls back to the globally-unique `base-<id>`.
+CREATE OR REPLACE FUNCTION set_participant_handle()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public, pg_catalog
+AS $$
+DECLARE base TEXT;
+BEGIN
+  IF NEW.handle IS NULL OR NEW.handle = '' THEN
+    base := slugify_handle(COALESCE(NULLIF(NEW.preferred_name, ''), NEW.first_name) || '-' || NEW.last_name);
+    IF EXISTS (SELECT 1 FROM participants WHERE lower(handle) = lower(base)) THEN
+      NEW.handle := left(base, 40) || '-' || NEW.id;
+    ELSE
+      NEW.handle := base;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_set_participant_handle ON participants;
+CREATE TRIGGER trg_set_participant_handle
+  BEFORE INSERT ON participants
+  FOR EACH ROW EXECUTE FUNCTION set_participant_handle();
+
+-- 6. Normalize metro_slug → metro_id (roadmap §1.8) ------------------------
+UPDATE participants p SET metro_id = m.id
+FROM metros m WHERE p.metro_slug = m.slug AND p.metro_id IS NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'participants_metro_id_fkey') THEN
+    ALTER TABLE participants
+      ADD CONSTRAINT participants_metro_id_fkey
+      FOREIGN KEY (metro_id) REFERENCES metros(id) NOT VALID;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_participants_metro_id ON participants(metro_id);
+
+COMMENT ON COLUMN participants.handle IS
+  'URL-safe vanity handle for /u/[handle]; auto-generated (trigger) + member-editable. Unique, case-insensitive.';
+COMMENT ON COLUMN participants.public_profile_visible IS
+  'Opt-in flag for a future PUBLIC (non-authed) profile tier. Default false; the members-only directory ignores it.';


### PR DESCRIPTION
## What

Adds the signed-in app's **member directory** — the biggest missing member surface — and finally gives the Learning Log's "share to Discover" toggle a reader. Roadmap **Phase 2**, **members-only** scope (owner-confirmed).

## Backend

- **Migration `00044_directory_columns.sql`** — `participants` gains:
  - `handle` (url-safe, unique case-insensitive; **auto-generated** via a `BEFORE INSERT` trigger + backfilled for all existing rows; member-editable)
  - `bio`, `headline`
  - `public_profile_visible` (opt-in flag for a *future* public tier — default `false`, ignored this phase)
  - `metro_id` FK → `metros(id)` (normalizes the existing `metro_slug` string, roadmap §1.8)
  - `slugify_handle()` SQL helper mirrored in `lib/participants/handle.ts` (unit-tested).
  - **Applied to OLOS-dev** and verified: 65/65 participants have handles, 0 duplicates.
- **`POST /api/nominations`** — standalone insert. Nominator is taken from the session (never the request body); cookie-bound client so RLS `insert-own` fires.
- **`PATCH /api/participants/[id]`** — widened allowlist to `bio`/`headline`/`handle`. Schema stays `.partial().strict()`; a duplicate handle returns a clean **409**.

## Frontend

- **`/directory`** — server page. Reads a **display-column allowlist via the service client** (never widens `participants` RLS over PII). `directory-grid` client: All / Builders / Mentors / Volunteers chips + name/city/expertise search; cards are stretched-link teasers to `/u/[handle]` with a Nominate action.
- **`/u/[handle]`** — visitor profile. Service client, **allowlist only (zero PII)**; `notFound()` for unknown/internal handles.
- **`member-profile-view`** — one render for owner (`/profile`) and visitor (`/u/[handle]`); PII + intake detail render **only** in owner mode.
- **`updates-feed`** — the community **"All"** feed off `profile_updates` (`visibility='labs'`). Reused member-scoped on `/u/[handle]` and as **"Your shares"** on `/profile`.
- **`profile/edit`** — `bio`/`headline`/`handle` fields on the voluntary edit path (Mode B name-completion stays lean).
- **Nav** — Directory added to the app nav + a Directory tab in the mobile bottom bar.

## Security

Directory + visitor pages serve an **explicit display-column allowlist via the service client** — raw `participants` RLS stays tight over PII (email, phone, zip, dcpl_card, notes, google_id). Test **and** staff accounts are excluded from the grid, the visitor pages, and the **global** updates feed (member-scoped feeds stay unfiltered so a staff owner still sees their own shares). A focused adversarial review over the allowlist/RLS/write-endpoints found no critical/high leak; the two test/staff-filtering gaps it flagged are fixed in this PR. The `/u/[handle]` lookup uses an exact lowercased `.eq` (not `.ilike`) so a `%`/`_` in the URL can't act as a wildcard.

## Verification

- `npm run lint` → 0 errors (8 pre-existing warnings)
- `npx next build` → green, +`/directory` +`/u/[handle]`
- `npx vitest run` → 28 pass (incl. the new handle slugify/dedup test)

## Deferred (flagged, not built)

Follow + "Following" filter, verified/vouched-mentor sort, mentor-request (Phase 5); "The Work" teasers (Phase 4/5/7); public non-authed profiles + trust badges.

Please review the RLS/allowlist posture before merge — **do not merge until reviewed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_