### PR TITLE
Profile: add an "Edit profile" entry point

### DIFF
--- a/app/(dashboard)/profile/member-profile-view.tsx
+++ b/app/(dashboard)/profile/member-profile-view.tsx
@@ -87,6 +87,15 @@ export default function MemberProfileView({
         </div>
       )}
 
+      {/* Owner action bar — the way into the editor (this is your own profile). */}
+      {isOwner && (
+        <div className="mb-4 flex justify-end">
+          <Link href="/profile/edit" className="btn btn-teal px-4 py-2 text-sm">
+            Edit profile
+          </Link>
+        </div>
+      )}
+
       <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card sm:p-8">
         {/* Header with avatar */}
         <div className="flex items-center gap-6 border-b border-ink/10 pb-6">

--- a/app/components/chrome/app-nav.tsx
+++ b/app/components/chrome/app-nav.tsx
@@ -276,6 +276,14 @@ function AvatarMenu({
           >
             Profile
           </Link>
+          <Link
+            className="menu-item"
+            role="menuitem"
+            href="/profile/edit"
+            onClick={() => setOpen(false)}
+          >
+            Edit profile
+          </Link>
           {canViewAs && (
             <>
               <div className="menu-rule" />


### PR DESCRIPTION
The profile editor (`/profile/edit`, now covering the whole profile) had **no user-facing way in** — the only paths there were the forced Mode-B name-completion redirect and a hardcoded-`done` "Edit" row buried in the (collapsed) dashboard setup checklist. Someone viewing their own profile found no way to start editing.

Adds two links to the existing route:
- **Owner profile page** (`member-profile-view.tsx`) — an "Edit profile" button above the card, **owner mode only** (never on `/u/[handle]` visitor profiles).
- **Avatar menu** (`app-nav.tsx`) — an "Edit profile" item right under Profile, reachable from any app page.

No new routes, APIs, or data.

## Verification
- `npm run lint` → 0 errors (8 pre-existing warnings)
- `npx next build` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_