### PR TITLE
Show the member's photo in the site-wide chrome avatar

### DIFF
--- a/app/(dashboard)/dashboard/dashboard-hero.tsx
+++ b/app/(dashboard)/dashboard/dashboard-hero.tsx
@@ -14,12 +14,14 @@ export interface HeroStat {
 
 export default function DashboardHero({
   initials,
+  avatarUrl,
   eyebrow,
   greeting,
   lede,
   stats,
 }: {
   initials: string;
+  avatarUrl?: string | null;
   eyebrow: string;
   greeting: string;
   lede: string;
@@ -39,9 +41,20 @@ export default function DashboardHero({
       />
       <div className="app-cover-inner px-6 sm:px-10">
         <div className="flex flex-wrap items-center gap-5 sm:gap-7">
-          <div className="avatar-lg" aria-hidden>
-            {initials}
-          </div>
+          {avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={avatarUrl}
+              alt=""
+              aria-hidden
+              referrerPolicy="no-referrer"
+              className="avatar-lg object-cover"
+            />
+          ) : (
+            <div className="avatar-lg" aria-hidden>
+              {initials}
+            </div>
+          )}
           <div className="min-w-[220px] flex-1">
             <div className="lbl lbl-teal mb-2">{eyebrow}</div>
             <h1 className="t-h1">{greeting}</h1>

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -32,7 +32,7 @@ export default async function DashboardPage() {
   const serviceClient = createServiceClient();
 
   const [{ data: participant }, { data: cycles }] = await Promise.all([
-    serviceClient.from("participants").select("id, preferred_name, first_name, last_name").eq("auth_user_id", user.id).maybeSingle(),
+    serviceClient.from("participants").select("id, preferred_name, first_name, last_name, profile_image_url").eq("auth_user_id", user.id).maybeSingle(),
     serviceClient.from("cycles").select("id, name, slug, start_date, end_date, status").order("start_date", { ascending: false }),
   ]);
 
@@ -108,6 +108,12 @@ export default async function DashboardPage() {
     (participant.first_name?.[0] ?? "") + (participant.last_name?.[0] ?? "")
   ).toUpperCase() || "?";
 
+  const avatarUrl =
+    participant.profile_image_url ||
+    (user.user_metadata?.avatar_url as string | undefined) ||
+    (user.user_metadata?.picture as string | undefined) ||
+    null;
+
   // Determine enrollment state for active cycle
   type DashboardState =
     | "no_cycle"
@@ -138,6 +144,7 @@ export default async function DashboardPage() {
       <div>
         <DashboardHero
           initials={initials}
+          avatarUrl={avatarUrl}
           eyebrow="Member portal"
           greeting={`Welcome, ${displayName}`}
           lede="You're almost in. Join the current Build Cycle to get started."
@@ -176,6 +183,7 @@ export default async function DashboardPage() {
       <div>
         <DashboardHero
           initials={initials}
+          avatarUrl={avatarUrl}
           eyebrow="Member portal"
           greeting={`Welcome, ${displayName}`}
           lede="Here's your home base at The Labs. The next Build Cycle will show up right here."

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -27,7 +27,7 @@ export default async function DashboardLayout({
   const serviceClient = createServiceClient();
   const { data: participant } = await serviceClient
     .from("participants")
-    .select("id, preferred_name, first_name, last_name, is_test")
+    .select("id, preferred_name, first_name, last_name, is_test, profile_image_url")
     .eq("auth_user_id", user.id)
     .maybeSingle();
 
@@ -113,11 +113,20 @@ export default async function DashboardLayout({
     ? `${participant.first_name[0]}${participant.last_name[0]}`
     : (user.email?.[0] ?? "?").toUpperCase();
 
+  // The site-wide avatar: the member's photo (uploaded or Google), falling back
+  // to the OAuth picture, then to initials in the chrome components.
+  const avatarUrl =
+    participant?.profile_image_url ||
+    (user.user_metadata?.avatar_url as string | undefined) ||
+    (user.user_metadata?.picture as string | undefined) ||
+    null;
+
   return (
     <div className="flex min-h-screen flex-col">
       <OrbDefs />
       <AppNav
         initials={initials}
+        avatarUrl={avatarUrl}
         displayName={displayName}
         isAdmin={adminUser}
         isModerator={moderatorUser}
@@ -127,7 +136,7 @@ export default async function DashboardLayout({
         isTest={!!participant?.is_test}
       />
       <main className="app-main container w-full flex-1 py-8">{children}</main>
-      <TabBar initials={initials} hasEnrollment={hasEnrollment} />
+      <TabBar initials={initials} avatarUrl={avatarUrl} hasEnrollment={hasEnrollment} />
       <FeedbackWidget />
     </div>
   );

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -11,12 +11,12 @@ export default async function PublicLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { signedIn, initials } = await publicSession();
+  const { signedIn, initials, avatarUrl } = await publicSession();
 
   return (
     <div className={`flex min-h-screen flex-col${signedIn ? "" : " has-upsell"}`}>
       <OrbDefs />
-      <PublicNav signedIn={signedIn} initials={initials} />
+      <PublicNav signedIn={signedIn} initials={initials} avatarUrl={avatarUrl} />
       <div className="flex-1">{children}</div>
       <PgFoot />
       {!signedIn && <UpsellBand />}

--- a/app/components/chrome/app-nav.tsx
+++ b/app/components/chrome/app-nav.tsx
@@ -20,6 +20,8 @@ import { createClient } from "@/lib/supabase/client";
 
 export interface AppNavProps {
   initials: string;
+  /** The member's profile photo (uploaded or Google); initials when null. */
+  avatarUrl: string | null;
   displayName: string;
   isAdmin: boolean;
   isModerator: boolean;
@@ -34,6 +36,7 @@ export interface AppNavProps {
 
 export default function AppNav({
   initials,
+  avatarUrl,
   displayName,
   isAdmin,
   isModerator,
@@ -114,6 +117,7 @@ export default function AppNav({
         )}
         <AvatarMenu
           initials={initials}
+          avatarUrl={avatarUrl}
           displayName={displayName}
           isAdmin={isAdmin}
           isModerator={isModerator}
@@ -132,6 +136,7 @@ function isActive(pathname: string, prefix: string) {
 
 function AvatarMenu({
   initials,
+  avatarUrl,
   displayName,
   isAdmin,
   isModerator,
@@ -140,6 +145,7 @@ function AvatarMenu({
   isTest,
 }: {
   initials: string;
+  avatarUrl: string | null;
   displayName: string;
   isAdmin: boolean;
   isModerator: boolean;
@@ -257,8 +263,19 @@ function AvatarMenu({
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((o) => !o)}
+        style={avatarUrl ? { padding: 0, overflow: "hidden" } : undefined}
       >
-        {initials}
+        {avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={avatarUrl}
+            alt=""
+            referrerPolicy="no-referrer"
+            className="block h-full w-full rounded-full object-cover"
+          />
+        ) : (
+          initials
+        )}
       </button>
       {open && (
         <div id="avatar-menu" role="menu" aria-label="Account menu">

--- a/app/components/chrome/public-nav.tsx
+++ b/app/components/chrome/public-nav.tsx
@@ -26,10 +26,12 @@ const DESTS = [
 export default function PublicNav({
   signedIn,
   initials,
+  avatarUrl = null,
   overHero = false,
 }: {
   signedIn: boolean;
   initials: string | null;
+  avatarUrl?: string | null;
   overHero?: boolean;
 }) {
   const pathname = usePathname() || "";
@@ -62,8 +64,18 @@ export default function PublicNav({
             <Link className="nav-link pn-login" href="/dashboard">
               Home
             </Link>
-            <Link className="pg-avatar" href="/profile" aria-label="Your profile">
-              {initials || "U"}
+            <Link className="pg-avatar" href="/profile" aria-label="Your profile" style={avatarUrl ? { padding: 0, overflow: "hidden" } : undefined}>
+              {avatarUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={avatarUrl}
+                  alt=""
+                  referrerPolicy="no-referrer"
+                  className="block h-full w-full rounded-full object-cover"
+                />
+              ) : (
+                initials || "U"
+              )}
             </Link>
           </span>
         ) : (

--- a/app/components/chrome/tab-bar.tsx
+++ b/app/components/chrome/tab-bar.tsx
@@ -32,9 +32,11 @@ const DIRECTORY_SVG = (
 
 export default function TabBar({
   initials,
+  avatarUrl,
   hasEnrollment,
 }: {
   initials: string;
+  avatarUrl: string | null;
   hasEnrollment: boolean;
 }) {
   const pathname = usePathname() || "";
@@ -65,7 +67,18 @@ export default function TabBar({
         <span>Directory</span>
       </Link>
       <Link className={`tab${active("/profile")}`} id="tab-me" href="/profile">
-        <span className="tab-avatar">{initials}</span>
+        {avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={avatarUrl}
+            alt=""
+            referrerPolicy="no-referrer"
+            className="tab-avatar object-cover"
+            style={{ padding: 0 }}
+          />
+        ) : (
+          <span className="tab-avatar">{initials}</span>
+        )}
         <span>Me</span>
       </Link>
     </nav>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,7 @@ export const dynamic = "force-dynamic";
    labs) rendered from the content tables, ending in the open-source footer.
    The stories row and the survey CTA arrive with their stages. */
 export default async function LandingPage() {
-  const [{ signedIn, initials }, events, resources, metros] =
+  const [{ signedIn, initials, avatarUrl }, events, resources, metros] =
     await Promise.all([publicSession(), getEvents(), getResources(), getMetros()]);
 
   // The cycle banner's CTA: signed-in members go straight to the ceremony.
@@ -53,7 +53,7 @@ export default async function LandingPage() {
   return (
     <div className="flex min-h-screen flex-col">
       <OrbDefs />
-      <PublicNav signedIn={signedIn} initials={initials} overHero />
+      <PublicNav signedIn={signedIn} initials={initials} avatarUrl={avatarUrl} overHero />
 
       {/* ── Hero ── */}
       <div className="hero-band s-cover grain on-dark">

--- a/lib/auth/public-session.ts
+++ b/lib/auth/public-session.ts
@@ -10,6 +10,7 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 export interface PublicSession {
   signedIn: boolean;
   initials: string | null;
+  avatarUrl: string | null;
   email: string | null;
   fullName: string | null;
 }
@@ -17,6 +18,7 @@ export interface PublicSession {
 const SIGNED_OUT: PublicSession = {
   signedIn: false,
   initials: null,
+  avatarUrl: null,
   email: null,
   fullName: null,
 };
@@ -32,7 +34,7 @@ export async function publicSession(): Promise<PublicSession> {
     const serviceClient = createServiceClient();
     const { data: participant } = await serviceClient
       .from("participants")
-      .select("first_name, last_name")
+      .select("first_name, last_name, profile_image_url")
       .eq("auth_user_id", user.id)
       .maybeSingle();
 
@@ -42,9 +44,15 @@ export async function publicSession(): Promise<PublicSession> {
     const fullName = participant
       ? `${participant.first_name} ${participant.last_name}`.trim()
       : null;
+    const avatarUrl =
+      participant?.profile_image_url ||
+      (user.user_metadata?.avatar_url as string | undefined) ||
+      (user.user_metadata?.picture as string | undefined) ||
+      null;
     return {
       signedIn: true,
       initials,
+      avatarUrl,
       email: user.email?.toLowerCase() ?? null,
       fullName,
     };


### PR DESCRIPTION
The chrome avatar — the little circle a member sees on every page — rendered **initials only**, ignoring `profile_image_url`. Now it shows their photo (uploaded or Google) everywhere it appears, falling back to initials.

Wiring only — no new data or migration (`profile_image_url` already exists and is populated).

**Render sites** (each: photo `<img>` or initials):
- `app-nav.tsx` — `.appbar-avatar` (top bar, every app page + persona pages)
- `tab-bar.tsx` — `.tab-avatar` (mobile "Me" tab)
- `dashboard-hero.tsx` — `.avatar-lg` (dashboard greeting cover)
- `public-nav.tsx` — `.pg-avatar` (public pages, signed-in)

**Data sources** — resolve an `avatarUrl` (`profile_image_url` → OAuth `avatar_url`/`picture` → null) and pass it down:
- `(dashboard)/layout.tsx` → AppNav + TabBar
- `dashboard/page.tsx` → DashboardHero
- `lib/auth/public-session.ts` → `(public)/layout.tsx` + landing `app/page.tsx` → PublicNav

The `<img>` uses `object-cover` + `referrerPolicy="no-referrer"` (Google `lh3.googleusercontent.com` can 403 hotlinks otherwise). Updates are live: the editor already calls `router.refresh()`, which re-renders these server layouts; uploads are cache-busted with `?v=`.

_Out of scope:_ other members' avatars in the moderator roster / pulse feeds still show initials (a separate enhancement); directory + updates feed already render member photos.

## Verification
- `npm run lint` → 0 errors (8 pre-existing warnings)
- `npx tsc --noEmit` → clean
- `npx next build` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_