### PR TITLE
Milestone Learning Logs: mid/end-cycle evaluations (finish Phase 1)

### DIFF
--- a/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
@@ -16,6 +16,8 @@ type Config = {
   max_projects: number;
   project_min: number;
   project_max: number;
+  milestone_mid_week: number;
+  milestone_final_week: number;
   phase_2_start: string | null;
   phase_3_start: string | null;
   problem_statement_open: string | null;
@@ -240,6 +242,15 @@ const PARAM_GROUPS = [
       { label: "Project max members", name: "project_max" },
     ],
   },
+  {
+    // Milestone review weeks (0–12), inside the practice — the mid/end-cycle
+    // Learning Log evaluations open on these cycle weeks (migration 00047).
+    heading: "Milestone Reviews",
+    fields: [
+      { label: "Mid-cycle review week", name: "milestone_mid_week", max: 12 },
+      { label: "End-cycle review week", name: "milestone_final_week", max: 12 },
+    ],
+  },
 ] as const;
 
 type ParamKey = typeof PARAM_GROUPS[number]["fields"][number]["name"];
@@ -308,6 +319,7 @@ export function CycleParamsForm({
                     id={field.name}
                     type="number"
                     min={0}
+                    max={"max" in field ? field.max : undefined}
                     {...register(field.name as ParamKey)}
                     className="w-20 rounded-card border border-ink/10 bg-white px-2 py-1 text-right text-base tabular-nums text-ink transition-colors duration-150 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal"
                   />

--- a/app/(dashboard)/cycles/cycle-phase-indicator.tsx
+++ b/app/(dashboard)/cycles/cycle-phase-indicator.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { getCycleWeek } from "@/lib/cycle/week";
 
 type CycleConfig = {
   phase_2_start: string | null;
@@ -77,16 +78,6 @@ function daysUntil(from: Date, to: Date): number {
   return Math.max(0, Math.ceil((to.getTime() - from.getTime()) / 86_400_000));
 }
 
-function getCurrentWeek(now: Date, start: Date, end: Date): number {
-  if (now < start) return -1; // not started — Week 0 (kickoff) hasn't begun
-  if (now > end) return 13; // past the Showcase (Week 12)
-  const totalMs = end.getTime() - start.getTime();
-  const elapsed = now.getTime() - start.getTime();
-  // 13 weekly markers, numbered 0–12
-  const week = Math.floor((elapsed / totalMs) * 13);
-  return Math.min(week, 12);
-}
-
 function getActiveWindows(
   config: CycleConfig,
   now: Date
@@ -137,7 +128,7 @@ export default function CyclePhaseIndicator({
   const startDate = new Date(cycle.start_date);
   const endDate = new Date(cycle.end_date);
 
-  const currentWeek = getCurrentWeek(now, startDate, endDate);
+  const currentWeek = getCycleWeek(now, startDate, endDate);
   const daysLeft = daysUntil(now, endDate);
   const cycleActive = now >= startDate && now <= endDate;
   const cycleComplete = now > endDate;

--- a/app/(dashboard)/dashboard/learning-log-card.tsx
+++ b/app/(dashboard)/dashboard/learning-log-card.tsx
@@ -72,18 +72,37 @@ function ScaleRow({
   );
 }
 
+export interface MilestoneContext {
+  kind: string;
+  /** "Mid-cycle review" / "End-cycle review". */
+  label: string;
+  /** Seed values from the member's most recent log (review, don't re-ask). */
+  prefill: {
+    clarity: number;
+    alignment: number;
+    accomplished: string;
+    exploring: string;
+    next_focus: string;
+  } | null;
+}
+
 export default function LearningLogCard({
   gateActive,
+  milestone = null,
 }: {
   gateActive: boolean;
+  /** When set, this week is a milestone evaluation — same flow, evaluation
+      framing, prefilled from the member's own logs (never a grade). */
+  milestone?: MilestoneContext | null;
 }) {
-  const [clarity, setClarity] = useState(3);
-  const [alignment, setAlignment] = useState(3);
+  const pf = milestone?.prefill ?? null;
+  const [clarity, setClarity] = useState(pf?.clarity ?? 3);
+  const [alignment, setAlignment] = useState(pf?.alignment ?? 3);
   const [blocked, setBlocked] = useState(false);
   const [blockerContext, setBlockerContext] = useState("");
-  const [accomplished, setAccomplished] = useState("");
-  const [exploring, setExploring] = useState("");
-  const [nextFocus, setNextFocus] = useState("");
+  const [accomplished, setAccomplished] = useState(pf?.accomplished ?? "");
+  const [exploring, setExploring] = useState(pf?.exploring ?? "");
+  const [nextFocus, setNextFocus] = useState(pf?.next_focus ?? "");
   const [share, setShare] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -129,6 +148,22 @@ export default function LearningLogCard({
   ]
     .filter(Boolean)
     .join(" ");
+
+  // Milestone weeks reframe the same three prompts as an evaluation.
+  const isFinal = milestone?.kind === "milestone_13";
+  const promptLabels: [string, string, string] = milestone
+    ? [
+        "Looking back over the cycle, what have you built or figured out?",
+        "Where are you now — what are you still working through?",
+        isFinal
+          ? "What are you taking with you from this cycle?"
+          : "What’s your focus for the rest of the cycle?",
+      ]
+    : [
+        "This week, I figured out…",
+        "I’m currently exploring…",
+        "Next week, my focus is…",
+      ];
 
   async function save() {
     setBusy(true);
@@ -185,8 +220,10 @@ export default function LearningLogCard({
     >
       <div className="flex items-baseline justify-between">
         <div>
-          <p className="lbl">Weekly ritual</p>
-          <h2 className="t-h3 text-ink">Learning Log</h2>
+          <p className="lbl">{milestone ? "Milestone" : "Weekly ritual"}</p>
+          <h2 className="t-h3 text-ink">
+            {milestone ? milestone.label : "Learning Log"}
+          </h2>
         </div>
         {count > 0 && (
           <span className="text-sm text-meta">
@@ -194,6 +231,14 @@ export default function LearningLogCard({
           </span>
         )}
       </div>
+
+      {milestone && (
+        <p className="mt-2 text-sm text-charcoal">
+          An evaluation inside the practice — the same Learning Log, prefilled
+          from your own logs so you review your record instead of a blank page.
+          Never a grade.
+        </p>
+      )}
 
       {justSaved && (
         <div
@@ -249,9 +294,9 @@ export default function LearningLogCard({
       <div className="mt-6 space-y-4">
         {(
           [
-            ["This week, I figured out…", accomplished, setAccomplished],
-            ["I’m currently exploring…", exploring, setExploring],
-            ["Next week, my focus is…", nextFocus, setNextFocus],
+            [promptLabels[0], accomplished, setAccomplished],
+            [promptLabels[1], exploring, setExploring],
+            [promptLabels[2], nextFocus, setNextFocus],
           ] as const
         ).map(([label, value, setter]) => (
           <div key={label}>
@@ -298,7 +343,7 @@ export default function LearningLogCard({
         disabled={busy}
         className="btn btn-teal mt-5"
       >
-        {busy ? "Saving…" : "Save log"}
+        {busy ? "Saving…" : milestone ? "Save review" : "Save log"}
       </button>
 
       {recent.length > 0 && (

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -5,7 +5,13 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { StatusBadge, EmptyState } from "@/app/components/ui";
 import CyclePhaseIndicator from "../cycles/cycle-phase-indicator";
 import PodJoinSection from "./pod-join-section";
-import LearningLogCard from "./learning-log-card";
+import LearningLogCard, { type MilestoneContext } from "./learning-log-card";
+import { getCycleWeek } from "@/lib/cycle/week";
+import {
+  milestoneKindForWeek,
+  milestoneLabel,
+  type MilestoneWeeks,
+} from "@/lib/cycle/milestones";
 import SetupChecklist, { type ChecklistItem } from "./setup-checklist";
 import CycleCommitments from "./cycle-commitments";
 import UpNext, { type TodoCard } from "./up-next";
@@ -54,7 +60,7 @@ export default async function DashboardPage() {
         serviceClient
           .from("cycle_config")
           .select(
-            "phase_2_start, phase_3_start, problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close, pod_limit"
+            "phase_2_start, phase_3_start, problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close, pod_limit, milestone_mid_week, milestone_final_week"
           )
           .eq("cycle_id", activeCycle.id)
           .single(),
@@ -124,6 +130,43 @@ export default async function DashboardPage() {
 
   // The weekly Learning Log gate (fixed window — lib/learning-logs/gate.ts).
   const logGate = await learningLogGate(participant.id);
+
+  // Milestone weeks reframe the weekly log as an evaluation, prefilled from the
+  // member's own record. Weeks are admin-configurable (cycle_config, 00047).
+  let milestoneCtx: MilestoneContext | null = null;
+  if (activeCycle && activeCycleConfig && enrollment?.status === "active") {
+    const week = getCycleWeek(
+      new Date(),
+      new Date(activeCycle.start_date),
+      new Date(activeCycle.end_date)
+    );
+    const kind = milestoneKindForWeek(
+      week,
+      activeCycleConfig as unknown as MilestoneWeeks
+    );
+    if (kind) {
+      const { data: last } = await serviceClient
+        .from("learning_logs")
+        .select("clarity, alignment, accomplished, exploring, next_focus")
+        .eq("participant_id", participant.id)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      milestoneCtx = {
+        kind,
+        label: milestoneLabel(kind),
+        prefill: last
+          ? {
+              clarity: last.clarity ?? 3,
+              alignment: last.alignment ?? 3,
+              accomplished: last.accomplished ?? "",
+              exploring: last.exploring ?? "",
+              next_focus: last.next_focus ?? "",
+            }
+          : null,
+      };
+    }
+  }
 
   let state: DashboardState = "no_cycle";
   if (activeCycle) {
@@ -345,7 +388,7 @@ export default async function DashboardPage() {
                   </p>
                 </div>
               )}
-              <LearningLogCard gateActive={logGate.active} />
+              <LearningLogCard gateActive={logGate.active} milestone={milestoneCtx} />
             </section>
           )}
 

--- a/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
@@ -16,6 +16,7 @@ import { getPodsForUser } from "@/lib/moderator/pods-list";
 import { getUiState } from "@/lib/moderator/ui-state";
 import { PodContentTabs } from "./pod-content-tabs";
 import PodSquadSections from "./pod-squad-sections";
+import PodMilestoneLogs from "./pod-milestone-logs";
 
 export const dynamic = "force-dynamic";
 
@@ -126,6 +127,8 @@ export default async function ModeratorPodPage({
           sign-ups, feedback inbox — the memo batch + Phase 1 repoint. */}
       <PodSquadSections cycleId={detail.cycle_id} members={detail.members} />
 
+      {/* Milestone Logs: wk-mid/final evaluation status per member. */}
+      <PodMilestoneLogs cycleId={detail.cycle_id} members={detail.members} />
 
       <PodContentTabs
         members={detail.members}

--- a/app/(dashboard)/moderator/pods/[pod_id]/pod-milestone-logs.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/pod-milestone-logs.tsx
@@ -1,0 +1,90 @@
+import { createServiceClient } from "@/lib/supabase/server";
+import { getMilestoneStatus } from "@/lib/moderator/milestone-status";
+import type { RosterRow } from "@/lib/moderator/pod-detail";
+
+/* Milestone Logs — the wk-mid/final evaluations, inside the practice (Phase 1).
+   Same Learning Log flow with evaluation prompts, prefilled from the member's
+   own logs; here the Poderator sees per-member submitted/open status ONLY,
+   never a grade (prototype renderEvaluations() + backend §6). A milestone that
+   hasn't reached its configured week reads "opens later". */
+
+export default async function PodMilestoneLogs({
+  cycleId,
+  members,
+}: {
+  cycleId: number;
+  members: RosterRow[];
+}) {
+  const supabase = createServiceClient();
+  const realMembers = members.filter((m) => !m.is_staff_or_test);
+  const nameById = new Map(
+    realMembers.map((m) => [m.participant_id, m.display_name])
+  );
+  const initialsById = new Map(
+    realMembers.map((m) => [m.participant_id, m.initials])
+  );
+
+  const status = await getMilestoneStatus(supabase, cycleId, realMembers);
+
+  return (
+    <section className="mb-6 rounded-card border border-ink/10 bg-white p-5 shadow-card">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="t-h3 text-ink">Milestone Logs</h2>
+        <span className="text-xs text-meta">Evaluations, inside the practice</span>
+      </div>
+      <p className="mt-1 text-sm text-meta">
+        Same Learning Log flow, prefilled from each member&apos;s own logs — an
+        evaluation, never a grade. Status only.
+      </p>
+
+      {status.total === 0 ? (
+        <p className="mt-3 text-sm text-meta">No members to evaluate yet.</p>
+      ) : (
+        <div className="mt-4 space-y-5">
+          {status.rows.map((row) => (
+            <div key={row.kind}>
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <p className="lbl">
+                  {row.label} review{" "}
+                  <span className="font-normal text-meta-soft">· week {row.week}</span>
+                </p>
+                {row.opened ? (
+                  <span className="text-xs text-meta">
+                    {row.submitted_ids.length} / {status.total} submitted
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center rounded-sm bg-ink/[0.04] px-2 py-0.5 text-xs font-medium text-meta">
+                    Opens later
+                  </span>
+                )}
+              </div>
+
+              {row.opened && (
+                <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                  {row.submitted_ids.map((id) => (
+                    <span
+                      key={id}
+                      title={`${nameById.get(id) ?? "Member"} — submitted`}
+                      className="flex h-8 w-8 items-center justify-center rounded-full bg-teal-deep text-xs font-bold text-white"
+                    >
+                      {initialsById.get(id) ?? "?"}
+                    </span>
+                  ))}
+                  {row.waiting_ids.map((id) => (
+                    <span
+                      key={id}
+                      title={`${nameById.get(id) ?? "Member"} — open`}
+                      className="flex h-8 w-8 items-center justify-center rounded-full border border-ink/15 bg-paper text-xs font-bold text-meta"
+                    >
+                      {initialsById.get(id) ?? "?"}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/api/learning-logs/route.ts
+++ b/app/api/learning-logs/route.ts
@@ -10,6 +10,11 @@ import {
   sharedParagraph,
 } from "@/lib/validations/learning-logs";
 import { learningLogGate } from "@/lib/learning-logs/gate";
+import { getCycleWeek } from "@/lib/cycle/week";
+import {
+  milestoneKindForWeek,
+  type MilestoneKind,
+} from "@/lib/cycle/milestones";
 
 // The Learning Log (roadmap Phase 1; backend doc §6). One POST saves the
 // three-part ritual; when share_publicly is set and the reflection has
@@ -17,10 +22,11 @@ import { learningLogGate } from "@/lib/learning-logs/gate";
 // profile_updates with learning_log_id provenance — the only write path
 // into the member-updates feed (no composer, owner decision).
 //
-// cycle_id and kind are derived server-side: the active enrollment decides
-// the cycle (NULL = standalone reflection); kind is 'weekly' until the
-// milestone cron exists. Saving instantly clears the weekly gate — the
-// response says so ("You're back in ✓" is the client's beat to play).
+// cycle_id and kind are derived server-side (never trusted from the client):
+// the active enrollment decides the cycle (NULL = standalone reflection); kind
+// is the milestone variant when the current cycle week matches an admin-set
+// milestone week (cycle_config.milestone_mid_week/final_week), else 'weekly'.
+// Any log clears the weekly gate — the response says so ("You're back in ✓").
 
 export const POST = withAuth(
   async (request: NextRequest, auth: AuthenticatedRequest) => {
@@ -49,10 +55,11 @@ export const POST = withAuth(
     const service = createServiceClient();
     const { data: activeCycle } = await service
       .from("cycles")
-      .select("id")
+      .select("id, start_date, end_date")
       .eq("status", "active")
       .maybeSingle();
     let cycleId: number | null = null;
+    let kind: "weekly" | MilestoneKind = "weekly";
     if (activeCycle) {
       const { data: enrollment } = await service
         .from("cycle_enrollments")
@@ -61,7 +68,24 @@ export const POST = withAuth(
         .eq("cycle_id", activeCycle.id)
         .eq("status", "active")
         .maybeSingle();
-      if (enrollment) cycleId = activeCycle.id;
+      if (enrollment) {
+        cycleId = activeCycle.id;
+        // Milestone weeks are admin-configurable (cycle_config, 00047); if the
+        // current cycle week is one of them, this log is that evaluation.
+        const { data: cfg } = await service
+          .from("cycle_config")
+          .select("milestone_mid_week, milestone_final_week")
+          .eq("cycle_id", activeCycle.id)
+          .maybeSingle();
+        if (cfg && activeCycle.start_date && activeCycle.end_date) {
+          const week = getCycleWeek(
+            new Date(),
+            new Date(activeCycle.start_date),
+            new Date(activeCycle.end_date)
+          );
+          kind = milestoneKindForWeek(week, cfg) ?? "weekly";
+        }
+      }
     }
 
     const { data: log, error } = await auth.supabase
@@ -69,7 +93,7 @@ export const POST = withAuth(
       .insert({
         participant_id: participantId,
         cycle_id: cycleId,
-        kind: "weekly",
+        kind,
         clarity: body.clarity,
         alignment: body.alignment,
         is_blocked: body.is_blocked,

--- a/lib/cycle/milestones.ts
+++ b/lib/cycle/milestones.ts
@@ -1,0 +1,65 @@
+/**
+ * The two milestone Learning-Log evaluations (Phase 1): a mid-cycle and a final
+ * review. They are Learning Log variants (learning_logs.kind), NOT a separate
+ * system — same flow, evaluation framing, prefilled from the member's own logs,
+ * never grades (prototype renderEvaluations() + backend §6).
+ *
+ * The weeks they open on are admin-configurable per cycle (cycle_config,
+ * migration 00047); the `kind` values stay as opaque legacy IDs
+ * (`milestone_7`/`milestone_13` from the old 13-week model) and are surfaced as
+ * "Mid-cycle" / "End-cycle" in the UI.
+ */
+
+export type MilestoneKind = "milestone_7" | "milestone_13";
+
+/** The two admin-configurable milestone weeks from cycle_config. */
+export interface MilestoneWeeks {
+  milestone_mid_week: number; // default 6
+  milestone_final_week: number; // default 12
+}
+
+export interface MilestoneDef {
+  kind: MilestoneKind;
+  weekOf: (w: MilestoneWeeks) => number;
+  /** Full card/header label. */
+  label: string;
+  /** Short chip/status label. */
+  short: string;
+}
+
+export const MILESTONES: MilestoneDef[] = [
+  {
+    kind: "milestone_7",
+    weekOf: (w) => w.milestone_mid_week,
+    label: "Mid-cycle review",
+    short: "Mid-cycle",
+  },
+  {
+    kind: "milestone_13",
+    weekOf: (w) => w.milestone_final_week,
+    label: "End-cycle review",
+    short: "End-cycle",
+  },
+];
+
+/**
+ * Which milestone (if any) opens on this exact cycle week. First match wins if
+ * an admin misconfigures both to the same week.
+ */
+export function milestoneKindForWeek(
+  week: number,
+  weeks: MilestoneWeeks
+): MilestoneKind | null {
+  for (const m of MILESTONES) {
+    if (m.weekOf(weeks) === week) return m.kind;
+  }
+  return null;
+}
+
+export function milestoneDef(kind: MilestoneKind): MilestoneDef {
+  return MILESTONES.find((m) => m.kind === kind) ?? MILESTONES[0];
+}
+
+export function milestoneLabel(kind: MilestoneKind): string {
+  return milestoneDef(kind).label;
+}

--- a/lib/cycle/week.test.ts
+++ b/lib/cycle/week.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { getCycleWeek } from "./week";
+import { milestoneKindForWeek, MILESTONES } from "./milestones";
+
+const start = new Date("2026-01-05T00:00:00Z");
+// 13 weekly markers over the span → pick an end exactly 13 weeks out so week
+// boundaries land cleanly.
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const end = new Date(start.getTime() + 13 * WEEK_MS);
+
+describe("getCycleWeek", () => {
+  it("is -1 before the cycle starts", () => {
+    expect(getCycleWeek(new Date(start.getTime() - 1), start, end)).toBe(-1);
+  });
+
+  it("is 0 at the start (Kickoff week)", () => {
+    expect(getCycleWeek(start, start, end)).toBe(0);
+  });
+
+  it("advances one marker per elapsed 1/13 of the span", () => {
+    expect(getCycleWeek(new Date(start.getTime() + 6 * WEEK_MS), start, end)).toBe(6);
+    expect(getCycleWeek(new Date(start.getTime() + 11.5 * WEEK_MS), start, end)).toBe(11);
+  });
+
+  it("clamps to 12 at/near the end (Showcase week)", () => {
+    expect(getCycleWeek(new Date(end.getTime() - 1), start, end)).toBe(12);
+  });
+
+  it("is 13 past the end", () => {
+    expect(getCycleWeek(new Date(end.getTime() + 1), start, end)).toBe(13);
+  });
+
+  it("handles a zero-length span without dividing by zero", () => {
+    expect(getCycleWeek(start, start, start)).toBe(0);
+  });
+});
+
+describe("milestoneKindForWeek", () => {
+  const weeks = { milestone_mid_week: 6, milestone_final_week: 12 };
+
+  it("returns the mid milestone on its configured week", () => {
+    expect(milestoneKindForWeek(6, weeks)).toBe("milestone_7");
+  });
+
+  it("returns the final milestone on its configured week", () => {
+    expect(milestoneKindForWeek(12, weeks)).toBe("milestone_13");
+  });
+
+  it("returns null on a non-milestone week", () => {
+    expect(milestoneKindForWeek(5, weeks)).toBeNull();
+    expect(milestoneKindForWeek(0, weeks)).toBeNull();
+  });
+
+  it("respects reconfigured weeks", () => {
+    expect(
+      milestoneKindForWeek(4, { milestone_mid_week: 4, milestone_final_week: 10 })
+    ).toBe("milestone_7");
+    expect(
+      milestoneKindForWeek(10, { milestone_mid_week: 4, milestone_final_week: 10 })
+    ).toBe("milestone_13");
+  });
+
+  it("MILESTONES covers both kinds", () => {
+    expect(MILESTONES.map((m) => m.kind)).toEqual(["milestone_7", "milestone_13"]);
+  });
+});

--- a/lib/cycle/week.ts
+++ b/lib/cycle/week.ts
@@ -1,0 +1,20 @@
+/**
+ * Cycle-week math — the single source (server + client). Weeks are numbered
+ * 0–12 on the wk0-Kickoff → wk12-Showcase calendar (owner: 12-week model).
+ *
+ * Extracted from app/(dashboard)/cycles/cycle-phase-indicator.tsx so the API,
+ * the dashboard, and the Poderator surface all derive "what week is it?" the
+ * same way. Keep the formula identical to the phase-indicator rail.
+ *
+ * Returns -1 before the cycle starts and 13 after it ends; otherwise 0–12.
+ */
+export function getCycleWeek(now: Date, start: Date, end: Date): number {
+  if (now < start) return -1; // not started — Week 0 (kickoff) hasn't begun
+  if (now > end) return 13; // past the Showcase (Week 12)
+  const totalMs = end.getTime() - start.getTime();
+  if (totalMs <= 0) return 0;
+  const elapsed = now.getTime() - start.getTime();
+  // 13 weekly markers, numbered 0–12
+  const week = Math.floor((elapsed / totalMs) * 13);
+  return Math.min(week, 12);
+}

--- a/lib/moderator/milestone-status.ts
+++ b/lib/moderator/milestone-status.ts
@@ -1,0 +1,92 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getCycleWeek } from "@/lib/cycle/week";
+import {
+  MILESTONES,
+  type MilestoneKind,
+  type MilestoneWeeks,
+} from "@/lib/cycle/milestones";
+
+/* Milestone-log status for one pod (Phase 1 — the wk-mid/final evaluations,
+   inside the practice). Status ONLY — submitted vs open per member — never a
+   grade (shepherd rule). A milestone "opens" once the cycle reaches its
+   admin-configured week; before that it reads "opens later". staff/test +
+   inactive members are outside the count, like log-health. */
+
+interface MemberInput {
+  participant_id: number;
+  is_inactive: boolean;
+  is_staff_or_test: boolean;
+}
+
+export interface MilestoneRow {
+  kind: MilestoneKind;
+  /** Short label — "Mid-cycle" / "End-cycle". */
+  label: string;
+  /** The configured cycle week it opens on. */
+  week: number;
+  /** currentWeek >= week — the evaluation is live. */
+  opened: boolean;
+  submitted_ids: number[];
+  waiting_ids: number[];
+}
+
+export interface MilestoneStatus {
+  rows: MilestoneRow[];
+  total: number;
+  /** Null when the cycle has no dates configured. */
+  currentWeek: number | null;
+}
+
+export async function getMilestoneStatus(
+  supabase: SupabaseClient,
+  cycleId: number,
+  members: MemberInput[]
+): Promise<MilestoneStatus> {
+  const real = members.filter((m) => !m.is_inactive && !m.is_staff_or_test);
+  const ids = real.map((m) => m.participant_id);
+
+  const [{ data: cycle }, { data: cfg }] = await Promise.all([
+    supabase.from("cycles").select("start_date, end_date").eq("id", cycleId).maybeSingle(),
+    supabase
+      .from("cycle_config")
+      .select("milestone_mid_week, milestone_final_week")
+      .eq("cycle_id", cycleId)
+      .maybeSingle(),
+  ]);
+
+  const weeks: MilestoneWeeks = {
+    milestone_mid_week: cfg?.milestone_mid_week ?? 6,
+    milestone_final_week: cfg?.milestone_final_week ?? 12,
+  };
+  const currentWeek =
+    cycle?.start_date && cycle?.end_date
+      ? getCycleWeek(new Date(), new Date(cycle.start_date), new Date(cycle.end_date))
+      : null;
+
+  const { data: logs } =
+    ids.length > 0
+      ? await supabase
+          .from("learning_logs")
+          .select("participant_id, kind")
+          .eq("cycle_id", cycleId)
+          .in("participant_id", ids)
+          .in("kind", MILESTONES.map((m) => m.kind))
+      : { data: [] as { participant_id: number; kind: string }[] };
+
+  const rows: MilestoneRow[] = MILESTONES.map((m) => {
+    const week = m.weekOf(weeks);
+    const submitted = new Set(
+      (logs ?? []).filter((l) => l.kind === m.kind).map((l) => l.participant_id)
+    );
+    return {
+      kind: m.kind,
+      label: m.short,
+      week,
+      opened: currentWeek !== null && currentWeek >= week,
+      submitted_ids: ids.filter((id) => submitted.has(id)),
+      waiting_ids: ids.filter((id) => !submitted.has(id)),
+    };
+  });
+
+  return { rows, total: ids.length, currentWeek };
+}

--- a/lib/validations/cycles.ts
+++ b/lib/validations/cycles.ts
@@ -18,6 +18,9 @@ export const updateCycleConfigSchema = z.object({
   project_vote_threshold: z.number().int().min(0).optional(),
   max_projects: z.number().int().min(1).optional(),
   project_max: z.number().int().min(1).optional(),
+  // Milestone evaluation weeks (0–12; migration 00047). Admin-configurable.
+  milestone_mid_week: z.number().int().min(0).max(12).optional(),
+  milestone_final_week: z.number().int().min(0).max(12).optional(),
   problem_statement_open: z.string().nullable().optional(),
   problem_statement_close: z.string().nullable().optional(),
   voting_open: z.string().nullable().optional(),

--- a/supabase/migrations/00047_milestone_weeks.sql
+++ b/supabase/migrations/00047_milestone_weeks.sql
@@ -1,0 +1,35 @@
+-- 00047_milestone_weeks.sql
+-- The wk-mid/final milestone Learning-Log evaluations fire on admin-configurable
+-- weeks, not hardcoded constants (owner: "everything configurable in the admin
+-- panel"; finishes Phase 1 — the milestone_7/milestone_13 log kinds from 00040).
+-- The two weeks default to 6 (mid-cycle) and 12 (final/Showcase) on the
+-- wk0-Kickoff → wk12-Showcase calendar. Legacy note: the kind labels say 7/13
+-- from the old 13-week model; the weeks are what actually drive timing, hence
+-- config here. Read by app/api/learning-logs (which kind to write) + the member
+-- card + the Poderator milestone card.
+--
+-- Idempotent + re-runnable. Existing rows inherit the DEFAULTs.
+--
+-- DOWN:
+--   ALTER TABLE cycle_config DROP CONSTRAINT IF EXISTS cycle_config_milestone_weeks_range;
+--   ALTER TABLE cycle_config DROP COLUMN IF EXISTS milestone_mid_week, DROP COLUMN IF EXISTS milestone_final_week;
+
+ALTER TABLE cycle_config
+  ADD COLUMN IF NOT EXISTS milestone_mid_week   SMALLINT NOT NULL DEFAULT 6,
+  ADD COLUMN IF NOT EXISTS milestone_final_week SMALLINT NOT NULL DEFAULT 12;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'cycle_config_milestone_weeks_range'
+  ) THEN
+    ALTER TABLE cycle_config
+      ADD CONSTRAINT cycle_config_milestone_weeks_range
+      CHECK (milestone_mid_week BETWEEN 0 AND 12 AND milestone_final_week BETWEEN 0 AND 12);
+  END IF;
+END $$;
+
+COMMENT ON COLUMN cycle_config.milestone_mid_week IS
+  'Cycle week (0-12) the mid-cycle milestone evaluation (learning_logs.kind=milestone_7) opens. Admin-editable; default 6.';
+COMMENT ON COLUMN cycle_config.milestone_final_week IS
+  'Cycle week (0-12) the final milestone evaluation (learning_logs.kind=milestone_13) opens. Admin-editable; default 12.';


### PR DESCRIPTION
## What & why

Finishes Phase 1 of the Learning Log pivot: the **mid/end-cycle milestone evaluations**. The DB was already built for this (`learning_logs.kind` had `'weekly'|'milestone_7'|'milestone_13'` since migration `00040`), but nothing wrote milestone rows and there was no prefill UI or Poderator card.

Design intent (prototype `renderEvaluations()` + backend doc §6): a milestone log is the **same Learning Log flow with evaluation framing, prefilled from the member's own prior logs** — a review of your record, not a blank form. It rides the existing weekly gate/cron (any log clears the window), and it is **never a grade** — the Poderator sees per-member **submitted/open status only** (shepherd rule).

## Admin-configurable weeks (owner principle)

Per *"everything configurable in the admin panel,"* the two milestone weeks are **`cycle_config` values, not hardcoded constants** — defaulting to **week 6 (mid)** and **week 12 (final)** on the wk0-Kickoff → wk12-Showcase calendar. The `milestone_7`/`milestone_13` enum values stay as opaque IDs, surfaced in the UI as **"Mid-cycle" / "End-cycle"** (no enum rename).

## Changes

- **`supabase/migrations/00047_milestone_weeks.sql`** — adds `cycle_config.milestone_mid_week` / `milestone_final_week` (`SMALLINT NOT NULL DEFAULT 6/12`, `0–12` CHECK). Idempotent, has a `-- DOWN:` block. **Applied to dev.**
- **`lib/cycle/week.ts`** — `getCycleWeek(now, start, end)` extracted from `cycle-phase-indicator.tsx` (dedupe) + `week.test.ts`.
- **`lib/cycle/milestones.ts`** — `MILESTONES` + `milestoneKindForWeek(week, config)`.
- **`app/api/learning-logs/route.ts`** — **server-derives** the kind from the active cycle's dates + the config weeks; if the current week matches a milestone week it writes that kind, else `'weekly'`. Never trusts a client-sent kind. Gate behaviour unchanged.
- **`app/(dashboard)/dashboard/learning-log-card.tsx` + `page.tsx`** — milestone-mode card: reframed prompts, sliders + reflections **prefilled from the member's latest log**; the page derives the milestone context.
- **`app/(dashboard)/moderator/pods/[pod_id]/pod-milestone-logs.tsx` + `lib/moderator/milestone-status.ts`** — a "Milestone Logs" card: submitted/open avatar strip per milestone, "opens later" before its configured week. Status only.
- **`app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx` + `lib/validations/cycles.ts`** — the two milestone-week inputs (0–12) in the admin cycle-config editor + Zod bounds.

## Verification

- `npx tsc --noEmit` clean · `npm run lint` 0 errors · `npx vitest run` **39 passed** · `npx next build` green.
- Confirmed both new columns are live on dev with defaults 6/12.

## Out of scope (flagged, not built)

- Doc drift (architecture-brief/personas still say "13-week") — separate cleanup.
- No LLM summarization of milestone content (OLOS runs no in-app LLM — design rule).
- A broader sweep of other still-hardcoded cycle constants (team caps `projectMin/Max`, gate day) into `cycle_config` + admin editor — good follow-up, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_