### PR TITLE
Docs: record milestone Learning Logs, flip Phase 1 to done

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -40,6 +40,8 @@ flowchart TD
 
 > `cycle_config.pod_limit` (migration `00043`, default 1) is the admin-editable ceiling on active pod memberships per participant per cycle — one pod by default. It replaces the old hardcoded 2-pod cap and is enforced in the pod register routes (participant + admin); projects stay at one-per-cycle, guaranteed by the `one_active_project_per_cycle` partial unique index.
 
+> `cycle_config.milestone_mid_week` / `milestone_final_week` (migration `00047`, default 6 / 12) are the admin-editable cycle weeks the mid/end-cycle milestone Learning Logs open on. They drive `learning_logs.kind` = `milestone_7` / `milestone_13` (opaque legacy IDs from the old 13-week model, surfaced in the UI as "Mid-cycle" / "End-cycle"); the API server-derives which `kind` to write from the current cycle week against these values, else `weekly`. `log_due_at` / `log_gate_paused` (migration `00040`) are the weekly-gate stamp + grace toggle.
+
 ```mermaid
 erDiagram
     cycles {
@@ -65,6 +67,10 @@ erDiagram
         smallint max_projects
         smallint project_min
         smallint project_max
+        smallint milestone_mid_week
+        smallint milestone_final_week
+        timestamp log_due_at
+        boolean log_gate_paused
         timestamp problem_statement_open
         timestamp problem_statement_close
         timestamp voting_open
@@ -523,7 +529,7 @@ erDiagram
 
 **RSVP hardening (migration `00039`):** `event_rsvps.ip_hash` (sha256, never the raw IP) backs the anonymous path's per-IP window cap in `POST /api/events/[event_id]/rsvp` (`lib/api/rate-limit.ts` — the backend doc §8 pre-launch blocker); `participant_id` records member identity on the one-tap path (NULL for anonymous), feeding the Poderator workshop-signups view.
 
-**Learning Log (migrations `00040`, `00041` — roadmap Phase 1):** `learning_logs` is the weekly practice ritual replacing `pulse_checks` for new cycles (pulse history stays, private, untouched). Three parts in one row: health check (`clarity`/`alignment` 1–5 + `is_blocked`/`blocker_context` — visible to the member, their Poderator, and admins; never shared), scaffolded reflection (`accomplished`/`exploring`/`next_focus`), and `share_publicly` — when true the API writes a `profile_updates` row carrying ONLY the concatenated paragraph (provenance via `learning_log_id`; the metrics never travel). `kind` carries the wk-7/13 milestone variants. No per-window unique — unlimited logs. The weekly gate is config-as-data: the Friday cron (`/api/cron/learning-log-window`) stamps `cycle_config.log_due_at`; an active enrollee with no log at/after the stamp is locked to the dashboard (`lib/learning-logs/gate.ts`); `log_gate_paused` is the grace toggle. RLS: self + cycle-staff SELECT, self INSERT, append-only; `profile_updates` is authenticated-SELECT (`visibility='labs'`), self-DELETE, service-role INSERT only. `participants.is_staff`/`is_test` (00041) are roster-visibility flags (hidden by default on Poderator rosters, excluded from health math) — never permissions.
+**Learning Log (migrations `00040`, `00041` — roadmap Phase 1):** `learning_logs` is the weekly practice ritual replacing `pulse_checks` for new cycles (pulse history stays, private, untouched). Three parts in one row: health check (`clarity`/`alignment` 1–5 + `is_blocked`/`blocker_context` — visible to the member, their Poderator, and admins; never shared), scaffolded reflection (`accomplished`/`exploring`/`next_focus`), and `share_publicly` — when true the API writes a `profile_updates` row carrying ONLY the concatenated paragraph (provenance via `learning_log_id`; the metrics never travel). `kind` carries the milestone variants (`milestone_7` / `milestone_13`, surfaced as Mid-cycle / End-cycle) — opened on the admin-configurable `cycle_config.milestone_mid_week` / `milestone_final_week` (migration `00047`, default weeks 6 / 12), server-derived at write time. No per-window unique — unlimited logs. The weekly gate is config-as-data: the Friday cron (`/api/cron/learning-log-window`) stamps `cycle_config.log_due_at`; an active enrollee with no log at/after the stamp is locked to the dashboard (`lib/learning-logs/gate.ts`); `log_gate_paused` is the grace toggle. RLS: self + cycle-staff SELECT, self INSERT, append-only; `profile_updates` is authenticated-SELECT (`visibility='labs'`), self-DELETE, service-role INSERT only. `participants.is_staff`/`is_test` (00041) are roster-visibility flags (hidden by default on Poderator rosters, excluded from health math) — never permissions.
 
 **Testing pathway (migration `00042`):** `testers` is the email-keyed tester grant (service-role only). Admin grants from `/admin/participants` (sets `participants.is_test` + the `testers` row); a tester self-resets via `POST /api/testing/reset` — every journey row AND the participants row deleted, so the next sign-in replays the full onboarding; the funnel re-applies `is_test` from the surviving email grant. The one sanctioned bulk-delete path in the app; proposals/statements that won (FK'd by projects/pods) survive a reset.
 

--- a/docs/audit/GAP_AUDIT.md
+++ b/docs/audit/GAP_AUDIT.md
@@ -48,7 +48,7 @@ before it").
 | Setup checklist (visible Start →, collapse to "All done ✓" strip) | missing | Dashboard has no onboarding checklist; the placeholder-name gate (`layout.tsx:49-56`) could front the profile row |
 | "Up next" todos (phase-aware, dismissible) | partial | Phase-window chips exist (`cycle-phase-indicator.tsx:358-379`) but nothing is dismissible; `nudge_dismissals` (`00023`) is the ready primitive |
 | "Your commitments" dated rows + anytime `.ics` | missing | No anchor-event commitment list, no `.ics` anywhere; Luma-synced `events` is the natural source |
-| Week rail | **diverged-better** | `CyclePhaseIndicator` (13-week rail, milestones, live progress, window chips) exceeds the prototype — keep |
+| Week rail | **diverged-better** | `CyclePhaseIndicator` (12-week rail, milestones, live progress, window chips) exceeds the prototype — keep |
 | No public composer; LL shares are the only update source | parity by absence | OLOS never had a composer; build `profile_updates` fed only by LL shares from day one |
 
 **Migration path (from the deep read):** keep `pulse_checks` + history untouched (authored

--- a/docs/audit/IMPROVEMENT_ROADMAP.md
+++ b/docs/audit/IMPROVEMENT_ROADMAP.md
@@ -8,9 +8,9 @@ crosswalk, Appendix A) + `docs/audit/DATA_ARCHITECTURE.md` (the DB blueprint ser
 Data Sensemaker and Project Ortelius canvases). Phases are ordered by dependency and member
 impact; each is shippable alone.
 
-> **Live status (2026-07-05, through PR #157):** Phase 0 done (revocation cron held), Phase
-> 0.5 done, Pod Squad batch done, Phase 1 ~90% (share-feed reader now landed via Phase 2;
-> only wk-7/13 milestone logs open), **Phase 2 done** (small profile tails deferred), Phases
+> **Live status (2026-07-05, through PR #161):** Phase 0 done (revocation cron held), Phase
+> 0.5 done, Pod Squad batch done, **Phase 1 done** (share-feed reader landed via Phase 2;
+> mid/end-cycle milestone logs landed via PR #161), **Phase 2 done** (small profile tails deferred), Phases
 > 3–7 not started (Phase 3 nav partially advanced — Directory added). Per-phase progress
 > detail lives in **`docs/audit/PROGRESS.md`** — update it as phases land; keep this file as
 > the plan.
@@ -61,7 +61,7 @@ TIMESTAMPTZ standard + documented soft-delete convention · `schema_version` int
 5. Restore the A-vs-B orientation card on the Poderator page (the memo re-asked the exact
    question the card answers; reverse the PRD's cut).
 
-## Phase 1 — The Learning Log pivot 🟡 ~70% (the deepest conceptual change)
+## Phase 1 — The Learning Log pivot ✅ done (the deepest conceptual change)
 
 Replaces pulse-check as the weekly practice ritual (proto CLAUDE.md: "replaces the Practice
 Journal, and the Pulse before it"). Migration path in GAP_AUDIT A3: pulse history stays
@@ -204,8 +204,8 @@ compound:
 
 ## Poderator throughline 🟡 (lands piecewise)
 
-Phase 1 → health-band + blocked-tier repoint. Phase 4 → journey spine + teams drill-down
-(formation context), milestone-logs card. Phase 5 → member-drawer mentor flag. Plus, any
+Phase 1 → health-band + blocked-tier repoint + milestone-logs card (PR #161). Phase 4 →
+journey spine + teams drill-down (formation context). Phase 5 → member-drawer mentor flag. Plus, any
 phase: `process_signals` (§6b — table + composer + prefills; the owner's core shepherd
 mechanic, independent of everything else), pod-scoped feedback inbox (`feedback` table
 already exists), shepherd voice pass on page copy.
@@ -216,7 +216,7 @@ already exists), shepherd voice pass on page copy.
 |---|---|
 | OAuth read-only email in the funnel | Already ratified (Stage B precedent) |
 | LLM project/pod naming (Claude) | The real version of the prototype's deterministic fake — prototype says so itself |
-| 13-week `CyclePhaseIndicator` rail | Exceeds the prototype's week rail |
+| 12-week `CyclePhaseIndicator` rail | Exceeds the prototype's week rail |
 | Withdraw-to-switch on project registration | Prototype is join-once; withdraw is kinder |
 | Post-save confirmation card (vs silent reset) | Clearer feedback |
 | `nudge_key` re-firing dismissals; persisted roster filters | Stronger than session-dismiss |

--- a/docs/audit/PROGRESS.md
+++ b/docs/audit/PROGRESS.md
@@ -17,7 +17,7 @@ Legend: ✅ done · 🟡 partial · ⬜ not started · ⏳ deferred (deliberate)
 | **Phase 0** — hygiene + safety | ✅ (1 item ⏳) | Shipped; only the revocation-cron re-registration is deliberately held |
 | **Phase 0.5** — schema hardening | ✅ | Migrations 00037–00039 applied + verified on dev |
 | **Pod Squad batch** | ✅ | All 5 memo items shipped |
-| **Phase 1** — Learning Log pivot | 🟡 ~90% | Log + gate + Poderator repoint + dashboard done; share-feed reader now landed (Phase 2); only wk-7/13 milestones open |
+| **Phase 1** — Learning Log pivot | ✅ | Log + gate + Poderator repoint + dashboard done; share-feed reader landed (Phase 2); mid/end-cycle milestone logs landed (PR #161) |
 | **Testing pathway** (extra) | ✅ | 00042 — not in the roadmap; admin-granted tester accounts + self-reset |
 | **One-pod/one-project + 12-week model** (extra) | ✅ | PRs #152–#156: `pod_limit` (00043), 12-week rail (wk0 Kickoff→wk12 Showcase), lean mobile registration, brand left-align sweep |
 | **Phase 2** — Directory + Me | ✅ | PR #157 — `/directory`, `/u/[handle]`, updates feed, standalone nominations, migration 00044. Profile cred-band + locked badges + links deferred |
@@ -26,7 +26,7 @@ Legend: ✅ done · 🟡 partial · ⬜ not started · ⏳ deferred (deliberate)
 | **Phase 5** — Trust + mentors | ⬜ | Not started |
 | **Phase 6** — Data Sensemaker | ⬜ | Not started |
 | **Phase 7** — Living Atlas (Ortelius) | ⬜ | Not started |
-| **Poderator throughline** | 🟡 | Health-band + blocked tier + orientation card done; process_signals, journey spine, milestone card open |
+| **Poderator throughline** | 🟡 | Health-band + blocked tier + orientation card + milestone card done; process_signals, journey spine open |
 
 ---
 
@@ -56,6 +56,15 @@ left the nav, Home carries the log-due pip); Poderator health repoint (`lib/mode
 — clarity/alignment averages, blocked-first list in the member's own words, logged/waiting
 compliance strip).
 
+**Phase 1 milestones (PR #161):** the mid/end-cycle evaluations — `learning_logs.kind`'s
+`milestone_7`/`milestone_13` variants finally get a write path and UI. Migration `00047` adds
+`cycle_config.milestone_mid_week`/`milestone_final_week` (admin-configurable, default weeks 6/12);
+the API server-derives the `kind` from the current cycle week (never trusts the client); the
+dashboard card flips to milestone mode, prefilled from the member's own prior logs (review your
+record, not a blank form); the Poderator pod page gains a `pod-milestone-logs` card showing
+per-member submitted/open status only — never a grade. Shared helpers `lib/cycle/week.ts` +
+`lib/cycle/milestones.ts`; `lib/moderator/milestone-status.ts`. Closes the Phase 1 pivot.
+
 **Testing pathway (PR #147–#151):** `testers` (`00042`), self-reset endpoint, admin toggle
 (now in the permissions panel), reset-in-avatar-menu, sign-out→home. Not a roadmap item —
 built on request to make the onboarding loop testable pre-kickoff.
@@ -64,9 +73,11 @@ built on request to make the onboarding loop testable pre-kickoff.
 
 ## Open within partially-done work
 
-**Phase 1 remainder (the ~10%):**
-- **Milestone logs (wk-7/13):** the `kind` enum exists in `learning_logs`, but there's
-  **no prefill UI** and no Poderator milestone card. (Roadmap Phase 1; memo "evaluations in OLOS".)
+**Phase 1 remainder — ✅ none.** Both former open items are now closed:
+- ~~**Milestone logs (wk-7/13):** no prefill UI, no Poderator milestone card~~ — **CLOSED by PR #161.**
+  Migration `00047` (admin-configurable mid/end weeks, default 6/12), the API server-derives `kind`,
+  the member card's milestone mode (prefilled from the member's own prior logs), and the Poderator
+  `pod-milestone-logs` status card all landed. (Roadmap Phase 1; memo "evaluations in OLOS".)
 - ~~**The share has no reader**~~ — **CLOSED by Phase 2 (PR #157).** `learning_logs.share_publicly`
   writes a `profile_updates` row, and the Phase-2 `updates-feed` now reads it — as the community
   "All" feed on `/directory`, member-scoped on `/u/[handle]`, and "Your shares" on `/profile`.
@@ -79,9 +90,9 @@ engaged dashboard now renders greeting → checklist → phase rail → Learning
 commitments → Up next → pods → past cycles.
 
 **Poderator throughline remainder:** `process_signals` (table + composer — the owner's core
-"shepherd, not manager" R&D mechanic) is **absent**; the frame-journey spine, teams drill-down,
-and milestone-logs card are absent. Shepherd voice: partial (orientation card added; page
-copy pass pending).
+"shepherd, not manager" R&D mechanic) is **absent**; the frame-journey spine and teams drill-down
+are absent (the milestone-logs card landed in PR #161). Shepherd voice: partial (orientation card
+added; page copy pass pending).
 
 ---
 
@@ -146,12 +157,11 @@ telemetry, **#13** Ortelius pilot scope, **#14** embeddings model.
 
 ## Recommended next moves
 
-1. **Finish Phase 1** (wk-7/13 milestone logs + the Poderator milestone card) — the last ~10%,
-   small and high member-value; closes the Learning Log pivot cleanly.
+1. **`process_signals`** (table + composer) — with Phase 1 closed (PR #161), this is the owner's
+   core "shepherd, not manager" R&D mechanic and the main remaining gap in the Poderator throughline.
 2. **Phase 2 tails** (cheap): profile cred band from `cycle_agreements`, locked-badge shells,
    external links in the profile editor — round out "Me" now that the directory is live.
 3. **Phase 3 (Learning destination + editorial)** — the natural next surface: authed `/learning`
    (route-shell over existing teasers) + `saved_items`/hearts completes the nav to the full five
    (only the **Learning** tab remains), then `/stories` + landing editorial.
-4. **`process_signals`** whenever — independent of everything, the owner's core shepherd mechanic.
-5. Get **owner decisions #1, #4–6** answered before Phase 4; **#11** before any Phase 6 build.
+4. Get **owner decisions #1, #4–6** answered before Phase 4; **#11** before any Phase 6 build.


### PR DESCRIPTION
## What & why

Documentation hygiene following **PR #161** (the milestone Learning Logs feature). That PR shipped the code + migration `00047` but not the docs that ride alongside it — this closes that gap: it records the two new `cycle_config` columns in the schema and marks **Phase 1 as complete** across the audit docs (they still said milestone logs were open / ~90% / "milestone card absent").

**Docs only — no code, no schema, no migration.**

## Changes

- **`SCHEMA.md`** — added `milestone_mid_week` / `milestone_final_week` to the `cycle_config` ERD, plus a `pod_limit`-style prose note explaining they're the admin-set weeks the mid/end-cycle milestone logs open on (driving `learning_logs.kind` = `milestone_7`/`milestone_13`, server-derived). Also filled a **pre-existing gap in the same ERD block**: the `log_due_at` / `log_gate_paused` gate columns from migration `00040` were never recorded. Clarified the Learning Log section's `kind`-variant wording.
- **`docs/audit/PROGRESS.md`** — Phase 1 scorecard row → ✅; both "Phase 1 remainder" bullets now closed; Poderator row drops "milestone card open"; added a "Phase 1 milestones (PR #161)" done-detail paragraph; repointed the top "next move" from *Finish Phase 1* to `process_signals` (the real remaining Poderator gap).
- **`docs/audit/IMPROVEMENT_ROADMAP.md`** — flipped the inconsistent `~90%`/`~70%` Phase-1 markers to **done** (through PR #161), un-futured the milestone-logs card in the Poderator throughline, and corrected the deviation-ledger rail entry `13-week` → `12-week`.
- **`docs/audit/GAP_AUDIT.md`** — `CyclePhaseIndicator` "13-week rail" → "12-week rail".

## Scope note

Per owner decision (tight scope), this fixes the `13-week` cycle-model drift **only** in the two audit lines already being edited. The broader `13-week` *duration* wording in `DESIGN_SYSTEM.md` / `personas.md` / `OLOS-architecture-brief.md` is left for a separate pass.

## Verification

- `npm run lint` 0 errors · `npx next build` green (docs-only, unaffected).
- `git grep` confirms: both new columns appear in SCHEMA.md; no stale Phase-1 "open / ~90% / ~70%" hits remain in `docs/audit/`; no `13-week` left in `docs/audit/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_