### PR TITLE
Enforce one active cycle at a time (fix the two-active bug at the source)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -42,6 +42,8 @@ flowchart TD
 
 > `cycle_config.milestone_mid_week` / `milestone_final_week` (migration `00047`, default 6 / 12) are the admin-editable cycle weeks the mid/end-cycle milestone Learning Logs open on. They drive `learning_logs.kind` = `milestone_7` / `milestone_13` (opaque legacy IDs from the old 13-week model, surfaced in the UI as "Mid-cycle" / "End-cycle"); the API server-derives which `kind` to write from the current cycle week against these values, else `weekly`. `log_due_at` / `log_gate_paused` (migration `00040`) are the weekly-gate stamp + grace toggle.
 
+> **At most one `active` cycle at a time** — the `one_active_cycle` partial unique index (migration `00048`) enforces the house invariant every `.eq('status','active').maybeSingle()` read assumes (home, funnel, learning-log gate). The two cycle-activation paths (`/api/cycles/[id]/status`, `/api/cycles/[id]/advance-phase`) return a clear 409 instead of a raw unique-violation. Forward-compatible groundwork for `docs/SECTOR_MODEL.md` Phase A (which adds a sibling ≤1-`upcoming` index; until then a not-yet-started next cohort sits in `draft`).
+
 ```mermaid
 erDiagram
     cycles {

--- a/app/api/cycles/[cycle_id]/advance-phase/route.ts
+++ b/app/api/cycles/[cycle_id]/advance-phase/route.ts
@@ -112,12 +112,20 @@ export const POST = withAdminAuth(
       );
     }
 
-    // Ensure cycle is active
-    await serviceClient
+    // Ensure cycle is active. A no-op when already active; when promoting a
+    // draft, the ≤1-active invariant (migration 00048) can reject it — surface
+    // that as a clear 409 rather than an unhandled 500.
+    const { error: activateError } = await serviceClient
       .from("cycles")
       .update({ status: "active" })
       .eq("id", cycleId)
       .eq("status", "draft");
+    if (activateError) {
+      return NextResponse.json(
+        { error: "Another cycle is already active. Close it before advancing this draft cycle." },
+        { status: 409 }
+      );
+    }
 
     return NextResponse.json({
       previous_phase: currentActivePhase,

--- a/app/api/cycles/[cycle_id]/status/route.ts
+++ b/app/api/cycles/[cycle_id]/status/route.ts
@@ -45,6 +45,22 @@ export const PATCH = withAdminAuth(
       );
     }
 
+    // At most one active cycle at a time (migration 00048). Reject a second
+    // activation with a clear message instead of a raw unique-violation.
+    if (status === "active") {
+      const { count } = await auth.supabase
+        .from("cycles")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "active")
+        .neq("id", cycleId);
+      if ((count ?? 0) > 0) {
+        return NextResponse.json(
+          { error: "Another cycle is already active. Close it before activating this one." },
+          { status: 409 }
+        );
+      }
+    }
+
     const { data, error } = await auth.supabase
       .from("cycles")
       .update({ status })

--- a/supabase/migrations/00048_single_active_cycle.sql
+++ b/supabase/migrations/00048_single_active_cycle.sql
@@ -1,0 +1,42 @@
+-- 00048_single_active_cycle.sql
+-- Enforce the house invariant: at most ONE cycle is 'active' at a time.
+-- Nothing enforced this, so two cycles drifted to 'active' on dev — which 406s
+-- every `.eq('status','active').maybeSingle()` read (the home page, the signup
+-- funnel, the learning-log gate + POST) and made the dashboard pick the future
+-- cohort over the running one (it orders by latest start_date).
+--
+-- Forward-compatible groundwork for SECTOR_MODEL.md Phase A, which keeps this
+-- invariant and adds a sibling ≤1-'upcoming' index. The 'upcoming' state is not
+-- built yet; today a not-yet-started next cohort sits in 'draft'. When Phase A
+-- lands `cycles.mode`, this index may be scoped to `mode='open'` (closed B2B
+-- cycles may run in parallel) — a documented future refinement, not a rewrite.
+--
+-- Two parts, idempotent + re-runnable:
+--   (1) reconcile any existing >1 active to a single one — keep the cycle that
+--       best represents "now" (in its date window; else already-started latest;
+--       else latest start_date), demote the rest to 'draft' (reversible; never
+--       terminates a cohort). No-op where the invariant already holds.
+--   (2) a partial unique index so it cannot recur, whatever the code path (the
+--       status route AND advance-phase both activate cycles).
+--
+-- DOWN:
+--   DROP INDEX IF EXISTS one_active_cycle;
+
+-- (1) Reconcile: keep one active cycle, demote the others to draft.
+WITH keep AS (
+  SELECT id FROM cycles WHERE status = 'active'
+  ORDER BY
+    (start_date <= now() AND (end_date IS NULL OR end_date >= now())) DESC,
+    (start_date <= now()) DESC,
+    start_date DESC
+  LIMIT 1
+)
+UPDATE cycles c SET status = 'draft'
+ WHERE c.status = 'active'
+   AND c.id NOT IN (SELECT id FROM keep);
+
+-- (2) At most one active cycle, ever. All qualifying rows share status='active',
+-- so a unique index over that partial set admits exactly one.
+CREATE UNIQUE INDEX IF NOT EXISTS one_active_cycle
+  ON cycles ((status))
+  WHERE status = 'active';


### PR DESCRIPTION
## What & why

Two cycles had drifted to `status='active'` on dev. Because ~10 reads resolve "the cycle" with `.eq('status','active').maybeSingle()`, a second active cycle **406s the home page, the signup funnel, and the learning-log gate + POST**, and makes the dashboard pick the *future* cohort over the running one (it orders by latest `start_date`). The earlier data patch (demoting the stray cycle) was a stopgap; **this is the guardrail so it can't recur.**

## Changes

- **`supabase/migrations/00048_single_active_cycle.sql`** — (1) reconcile any `>1` active to a single one (keep the cycle best representing "now" — in-window, else latest-started; demote the rest to `draft`, which is reversible and never terminates a cohort), and (2) a `one_active_cycle` **partial unique index** so it can't recur *whatever the code path* (both the status route and advance-phase activate cycles). **Applied to dev.**
- **Both activation routes guarded** — `/api/cycles/[id]/status` and `/api/cycles/[id]/advance-phase` return a clear **409** ("Another cycle is already active. Close it first.") instead of a raw unique-violation / unhandled 500.
- **`SCHEMA.md`** — documents the invariant.

## Forward-compatible with the sector model

This is Phase-A groundwork for `docs/SECTOR_MODEL.md`: the target model keeps the ≤1-`active` invariant and adds a sibling ≤1-`upcoming` index. The `upcoming` state isn't built yet, so a not-yet-started next cohort sits in `draft` today (which is exactly what the reconcile does).

## Verification

- `npx tsc --noEmit` clean · `npm run lint` 0 errors · `npx next build` green.
- On dev after applying: exactly **one active cycle**, index present, and a direct attempt to activate a second cycle is **rejected with `23505`** (the route guards turn that into a 409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_