### PR TITLE
Record the three Ortelius v1 decisions (consent, mapping, buyers)

### DIFF
--- a/docs/ORTELIUS_NORTHSTAR.md
+++ b/docs/ORTELIUS_NORTHSTAR.md
@@ -258,6 +258,15 @@ The MVP is not a competitor to the ceiling — it is the ceiling with `sys_to = 
 
 ## 12. Load-bearing open questions (owner decisions)
 
+**Decided (owner, 2026-07-05):**
+- **Consent (#1/#2) → broad, bundled at submission.** The survey consent is reframed so a submission is used "as part of projects leveraging AI **hosted by The Labs**." This bundles training-eligibility into participation consent (training-eligible ≈ all consented submissions, incl. anonymous) rather than a separate low-uptake opt-in — which is what gives the flywheel fuel. Trade-off: broader than the unbundled/revocable model, so it leans on the **"hosted by The Labs"** scope — a frontier-lab *partner* (see below) receives the eval/benchmark + derived artifacts, **never raw participant data to train the partner's models** — and it **still requires attorney review** before it ships. Draft wording: *"…used by The Upskilling Labs in the development of public projects — including projects that leverage AI hosted by The Upskilling Labs — and shared with program participants…"*.
+- **Response→card (#5) → every response is a node; curation is a *temporal overlay*.** Nothing is dropped at intake. The swipe/second signal-vs-noise judgments accrete as bitemporal events, and the **trajectory** (what was signal vs. noise, and how it flipped over time) is itself the training data. This confirms the **bitemporal event-stream-as-label-store** as core, not optional; "noise" is retained (filtered from the active view, never deleted).
+- **Lead buyers (#6) → a frontier AI lab + local/state political leaders & philanthropists.** Not Palantir-as-source-system, not fed procurement. So v1 optimizes for (a) the **research artifact** (the reasoning benchmark + clean corpus + the human-in-the-loop flywheel) and (b) the **civic insight / sector-atlas surface + participatory legitimacy** — over audit/marking/FedRAMP hardening (which drops down the priority list).
+
+**Still gated before the model flywheel ships:** attorney review of the reframed consent, and the #11 governance framework. The v1 **floor** (survey intake + BYO-LLM extraction + the canvas) is gate-free and buildable now.
+
+Original framing of the questions, for context:
+
 1. **Consent economics — the make-or-break number.** Project the **C2 opt-in rate** after all correct exclusions (unbundled, revocable, anonymous-excluded). If the training-eligible fraction is tiny, the flywheel has no fuel and the "AI-native" premise must be re-scoped to *the small-clean-corpus + eval* story. Decide before building the training path.
 2. **The C2 promise wording** — ratify the three-"nevers" + one-"can" string; attorney-bless the retrospective-withdrawal *ceiling* language.
 3. **Standpoint: coverage flag vs. governed weight** — confirm the default is **equal weight** and standpoint feeds **diversity**, not credibility (the recommended, review-surviving choice), or ratify an appealable weighted parameter with a fairness audit.

--- a/docs/SENSEMAKING_FLOW.md
+++ b/docs/SENSEMAKING_FLOW.md
@@ -73,7 +73,7 @@ kind of actant is speaking).
 | Survey field | Column | Notes |
 |---|---|---|
 | survey identity + intro copy | `field_surveys(title, problem_domain, about, share_slug, status, allow_anonymous)` | the public "about" already promises an **open-source insights repository** = Ortelius, to the public |
-| **Consent to Participation** * | `consent_participation` BOOL + `consent_version` | required; gates submission; keep the exact wording (legal basis for sharing with participants) |
+| **Consent to Participation** * | `consent_participation` BOOL + `consent_version` | required; gates submission. **Reframed (owner 2026-07):** explicitly covers use in projects that **leverage AI hosted by The Labs** — this bundling (not a separate opt-in) is what makes contributions training-eligible; attorney review pending. See `ORTELIUS_NORTHSTAR.md` §12. |
 | **What are you observing…** * | `observation` TEXT NOT NULL | the core evidence body; the source every `extract` derives from. No title — atomization happens at the extract layer |
 | **What is your experience?** | `standpoint` TEXT[] | multi-select, structured (work-in-field / affected / tried-to-fix / research / pay-attention / other) — feeds evidence weighting |
 | **How much does this matter?** (1–5) | `salience` SMALLINT NULL | intensity |
@@ -90,8 +90,18 @@ the Ortelius `source_url`-has-no-producer gap — uploaded sources are its produ
 
 **Two-tier consent + anonymity stay intact.** Participation consent is required
 and gates submission; contact consent is optional and separate. Anonymous by
-default. (The retention/scrub policy for `participant_id IS NULL` submissions is a
-prerequisite before `allow_anonymous` ships — Ortelius gap #7.)
+default. The participation consent is **reframed (owner 2026-07)** to cover use in
+projects that leverage AI hosted by The Labs — so a consented submission (incl.
+anonymous) is training-eligible; a frontier-lab partner gets the eval/benchmark +
+derived artifacts, never raw data (`ORTELIUS_NORTHSTAR.md` §12; attorney review
+pending). (The retention/scrub policy for `participant_id IS NULL` submissions is
+a prerequisite before `allow_anonymous` ships — Ortelius gap #7.)
+
+**Every response is a node; curation is a temporal overlay (owner 2026-07).** No
+raw response is dropped at intake — it enters the graph, and the swipe/second
+signal-vs-noise judgments accrete as **bitemporal events**. The *trajectory*
+(what flipped between signal and noise, and when) is itself training data, so
+"noise" is filtered from the active pool, never deleted.
 
 ---
 


### PR DESCRIPTION
## What

Docs only. Records the three owner decisions (2026-07-05) that unblock the Ortelius v1 floor, in `ORTELIUS_NORTHSTAR.md` §12 and `SENSEMAKING_FLOW.md` §3.

- **Consent → broad + bundled at submission.** The survey consent is reframed to cover use in projects that leverage AI **"hosted by The Labs"**, making contributions training-eligible without a separate low-uptake opt-in. A frontier-lab *partner* gets the eval/benchmark + derived artifacts — **never raw participant data to train the partner's models**. Still requires attorney review before shipping.
- **Response→card → every response is a node; curation is a temporal overlay.** Nothing is dropped at intake; the signal/noise judgments accrete as bitemporal events, and the *trajectory* (what flipped, and when) is itself the training data. Confirms the bitemporal event-stream-as-label-store as core.
- **Lead buyers → a frontier AI lab + local/state political leaders & philanthropists** (not Palantir-as-source, not fed procurement). v1 optimizes for the research artifact + the civic insight/atlas surface + participatory legitimacy over audit/marking/FedRAMP hardening.

## Still gated

The model flywheel waits on attorney-reviewed consent + the #11 governance framework. The v1 **floor** (survey intake + BYO-LLM extraction + the canvas) is gate-free and buildable now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_