### PR TITLE
Basics: branded 404 / error / loading states + surface content read errors

### DIFF
--- a/app/(dashboard)/not-found.tsx
+++ b/app/(dashboard)/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+// 404 for the signed-in app (a cycle / pod / project / member that moved or
+// never existed) — renders inside the app shell, keeping the nav + tab bar.
+export default function DashboardNotFound() {
+  return (
+    <section className="mx-auto flex min-h-[50vh] max-w-md flex-col items-center justify-center px-4 py-16 text-center">
+      <p className="lbl lbl-teal mb-1.5">404</p>
+      <h1 className="t-h2 mb-2 text-ink">We couldn&apos;t find that</h1>
+      <p className="t-small mb-6 text-meta">
+        This cycle, pod, project, or member may have moved or no longer exists.
+      </p>
+      <Link href="/dashboard" className="btn btn-teal">
+        Back to your dashboard
+      </Link>
+    </section>
+  );
+}

--- a/app/(public)/error.tsx
+++ b/app/(public)/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Error boundary for the public content pages — keeps the public chrome (the
+// root error.tsx renders chrome-less). Logs, and offers a retry.
+export default function PublicError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[PublicError]", error);
+  }, [error]);
+
+  return (
+    <section className="mx-auto flex min-h-[50vh] max-w-md flex-col items-center justify-center px-4 py-16 text-center">
+      <h1 className="t-h3 mb-2 text-ink">Something went wrong</h1>
+      <p className="t-small mb-6 text-meta">
+        This page hit a snag. Give it another try.
+      </p>
+      <button onClick={reset} className="btn btn-teal">
+        Try again
+      </button>
+    </section>
+  );
+}

--- a/app/(public)/loading.tsx
+++ b/app/(public)/loading.tsx
@@ -1,0 +1,13 @@
+// Loading skeleton for the DB-backed public content pages (force-dynamic), so a
+// slow read shows a branded spinner instead of a blank frame.
+export default function PublicLoading() {
+  return (
+    <div className="flex flex-1 items-center justify-center py-24" aria-busy="true">
+      <span
+        role="status"
+        aria-label="Loading"
+        className="h-8 w-8 animate-spin rounded-full border-2 border-ink/10 border-t-teal"
+      />
+    </div>
+  );
+}

--- a/app/(public)/not-found.tsx
+++ b/app/(public)/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+// 404 for the public content pages (events / library / cities) — renders inside
+// the public layout, so it keeps the dark nav, footer, and upsell band.
+export default function PublicNotFound() {
+  return (
+    <section className="mx-auto flex min-h-[50vh] max-w-md flex-col items-center justify-center px-4 py-16 text-center">
+      <p className="lbl lbl-teal mb-1.5">404</p>
+      <h1 className="t-h2 mb-2 text-ink">We couldn&apos;t find that page</h1>
+      <p className="t-small mb-6 text-meta">
+        The link may be broken, or the event, resource, or city may have moved.
+      </p>
+      <div className="flex flex-wrap justify-center gap-3">
+        <Link href="/" className="btn btn-teal">
+          Back home
+        </Link>
+        <Link href="/events" className="btn btn-ghost">
+          Browse events
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+// Root 404 — catches unmatched URLs and any notFound() not caught by a closer
+// route-group not-found. Renders inside the root layout (fonts + globals) with
+// no nav, so it's self-contained and centered.
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="card w-full max-w-md p-8 text-center shadow-card">
+        <p className="lbl lbl-teal mb-1.5">404</p>
+        <h1 className="t-h2 mb-2 text-ink">We couldn&apos;t find that page</h1>
+        <p className="t-small mb-6 text-meta">
+          The link may be broken, or the page may have moved.
+        </p>
+        <Link href="/" className="btn btn-teal">
+          Back to The Labs
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/lib/content/queries.ts
+++ b/lib/content/queries.ts
@@ -58,11 +58,12 @@ export interface MetroRow {
 
 export async function getEvents(): Promise<EventRow[]> {
   const supabase = createServiceClient();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("events")
     .select("*")
     .eq("status", "published")
     .order("start_at", { ascending: true });
+  if (error) console.error("[content] getEvents:", error.message);
   return (data as EventRow[]) ?? [];
 }
 
@@ -79,11 +80,12 @@ export async function getEvent(slug: string): Promise<EventRow | null> {
 
 export async function getResources(): Promise<ResourceRow[]> {
   const supabase = createServiceClient();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("resources")
     .select("*")
     .eq("status", "published")
     .order("id", { ascending: true });
+  if (error) console.error("[content] getResources:", error.message);
   return (data as ResourceRow[]) ?? [];
 }
 
@@ -118,7 +120,8 @@ async function withWaiting(rows: Record<string, unknown>[]): Promise<MetroRow[]>
 /** Active lab first, then waitlists by list size (the prototype's sort). */
 export async function getMetros(): Promise<MetroRow[]> {
   const supabase = createServiceClient();
-  const { data } = await supabase.from("metros").select("*");
+  const { data, error } = await supabase.from("metros").select("*");
+  if (error) console.error("[content] getMetros:", error.message);
   const rows = await withWaiting((data as Record<string, unknown>[]) ?? []);
   return rows.sort((a, b) =>
     a.status === "active" ? -1 : b.status === "active" ? 1 : b.waiting - a.waiting


### PR DESCRIPTION
## What & why

First pass of the "get the basics solid" work. Fixes the **most pervasive wall in the app**: 26 `notFound()` call sites had **no `not-found.tsx`**, so any expired / typo'd / shared-stale link rendered Next's bare, chrome-less 404 — the most common first-time-user misstep dumped them out of the branded experience entirely.

## Changes

- **`app/not-found.tsx`** — root branded 404 (unmatched URLs + fallback).
- **`app/(public)/not-found.tsx`** — 404 inside the public chrome (nav / footer / upsell band) for `/events`, `/library`, `/local-labs` detail misses.
- **`app/(dashboard)/not-found.tsx`** — 404 inside the app shell (a cycle / pod / project / member that moved or never existed).
- **`app/(public)/error.tsx`** — error boundary for the public pages (previously errors bubbled to the root `error.tsx`, which renders chrome-less); logs + retry.
- **`app/(public)/loading.tsx`** — branded spinner for the DB-backed (`force-dynamic`) public pages.
- **`lib/content/queries.ts`** — `getEvents` / `getResources` / `getMetros` now `console.error` the Supabase error before the `?? []` fallback, so a drifted/failed read is diagnosable instead of silently rendering "Coming Soon" (same fix already applied to the directory reads).

## Verification

- `npx tsc --noEmit` clean · `npm run lint` 0 errors · `npx next build` green.

Part of a sequence: this is ①a. Next up — ①b (landing banner → live from DB, retire the stale pulse-check messaging, returning-member redirect), then the Learning library, the theupskillinglabs.org content port, Upskiller Stories, and a copy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_