### PR TITLE
Basics: landing banner live from DB + retire stale pulse-check CTAs

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Activity, ArrowRight, ChevronLeft } from "lucide-react";
+import { BookOpen, ArrowRight, ChevronLeft } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
 import { StatCard, StatusBadge } from "@/app/components/ui";
@@ -150,30 +150,30 @@ export default async function CycleDetailPage({
         </div>
       )}
 
-      {/* Pulse Check — always-on requirement */}
+      {/* Learning Log — the weekly practice, framed calmly (it replaced the pulse check) */}
       {cycle.status === "active" && (
         <div className="mb-8">
           <Link
-            href="/pulse-check"
-            className="group flex items-center justify-between gap-3 rounded-card border border-ink/10 border-l-4 border-l-red bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+            href="/dashboard#learning-log"
+            className="group flex items-center justify-between gap-3 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
           >
             <div className="flex items-center gap-3">
-              <Activity
-                className="h-5 w-5 flex-shrink-0 text-red"
+              <BookOpen
+                className="h-5 w-5 flex-shrink-0 text-teal-deep"
                 aria-hidden
               />
               <div>
                 <span className="font-semibold tracking-tight text-ink">
-                  Weekly pulse check
+                  Your weekly Learning Log
                 </span>
                 <p className="mt-0.5 text-sm text-meta">
-                  Complete your weekly check-in to stay active and retain access
-                  to GitHub, Google Docs, Slack, and Google Groups.
+                  A few lines each week on what you&apos;re figuring out. That&apos;s
+                  the check-in that keeps you in the cycle.
                 </p>
               </div>
             </div>
             <ArrowRight
-              className="h-4 w-4 flex-shrink-0 text-red transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+              className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
               aria-hidden
             />
           </Link>

--- a/app/(dashboard)/cycles/page.tsx
+++ b/app/(dashboard)/cycles/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Activity, ArrowRight } from "lucide-react";
+import { BookOpen, ArrowRight } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { StatusBadge } from "@/app/components/ui";
 import CyclePhaseIndicator from "./cycle-phase-indicator";
@@ -44,29 +44,29 @@ export default async function CyclesPage() {
         <CyclePhaseIndicator cycle={activeCycle} config={activeCycleConfig} />
       )}
 
-      {/* Pulse Check CTA — always-on requirement */}
+      {/* Learning Log — the weekly practice, framed calmly (it replaced the pulse check) */}
       {activeCycle && (
         <Link
-          href="/pulse-check"
-          className="group mb-4 flex items-center justify-between rounded-card border border-ink/10 border-l-4 border-l-red bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+          href="/dashboard#learning-log"
+          className="group mb-4 flex items-center justify-between rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
         >
           <div className="flex items-center gap-3">
-            <Activity
-              className="h-5 w-5 flex-shrink-0 text-red"
+            <BookOpen
+              className="h-5 w-5 flex-shrink-0 text-teal-deep"
               aria-hidden
             />
             <div>
               <span className="font-semibold tracking-tight text-ink">
-                Weekly pulse check
+                Your weekly Learning Log
               </span>
               <p className="text-sm text-meta">
-                Stay active &mdash; complete your check-in to keep access to
-                cycle tools.
+                A few lines on what you&apos;re figuring out &mdash; that&apos;s
+                the check-in.
               </p>
             </div>
           </div>
           <ArrowRight
-            className="h-4 w-4 flex-shrink-0 text-red transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+            className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
             aria-hidden
           />
         </Link>

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -59,7 +59,8 @@ export async function GET(request: Request) {
             hasPlaceholder
           );
 
-          return NextResponse.redirect(`${origin}/`);
+          // A returning member lands in the app, not on the public landing.
+          return NextResponse.redirect(`${origin}/dashboard`);
         } else {
           // No participant record — redirect to registration
           return NextResponse.redirect(`${origin}/register`);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import {
 import { getEvents, getResources, getMetros } from "@/lib/content/queries";
 import { publicSession } from "@/lib/auth/public-session";
 import { createServiceClient } from "@/lib/supabase/server";
+import { getRecruitingCycle } from "@/lib/cycle/active";
 
 export const metadata = {
   title: "The Upskilling Labs",
@@ -20,29 +21,50 @@ export const metadata = {
 // Auth-aware nav + live content tables — always rendered per request.
 export const dynamic = "force-dynamic";
 
+// "Summer 2026" from a start date — the banner's season label (no location
+// column exists yet; the local lab is surfaced separately).
+function seasonYear(dateStr: string | null): string | null {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return null;
+  const seasons = ["Winter", "Spring", "Summer", "Fall"];
+  return `${seasons[Math.floor(((d.getMonth() + 1) % 12) / 3)]} ${d.getFullYear()}`;
+}
+
 /* The public landing — onboarding-proto's view-landing: dark hero over
    photography, then browse-free sections (cycles · workshops · library ·
    labs) rendered from the content tables, ending in the open-source footer.
    The stories row and the survey CTA arrive with their stages. */
 export default async function LandingPage() {
-  const [{ signedIn, initials, avatarUrl }, events, resources, metros] =
-    await Promise.all([publicSession(), getEvents(), getResources(), getMetros()]);
+  const [{ signedIn, initials, avatarUrl }, events, resources, metros, recruitingCycle] =
+    await Promise.all([
+      publicSession(),
+      getEvents(),
+      getResources(),
+      getMetros(),
+      getRecruitingCycle(createServiceClient()).catch(() => null),
+    ]);
 
-  // The cycle banner's CTA: signed-in members go straight to the ceremony.
-  let activeCycleId: number | null = null;
-  try {
-    const supabase = createServiceClient();
-    const { data: cycle } = await supabase
-      .from("cycles")
-      .select("id")
-      .eq("status", "active")
-      .maybeSingle();
-    activeCycleId = cycle?.id ?? null;
-  } catch {
-    activeCycleId = null;
-  }
-  const joinCycleHref =
-    signedIn && activeCycleId ? `/cycles/${activeCycleId}/join` : "/login";
+  // The registration banner is driven by the recruiting cycle (the upcoming
+  // cohort if one is open, else the running one). Signed-in members go straight
+  // to the join ceremony; signed-out visitors enter the funnel at /login. A
+  // signed-in member with no open cycle lands on their dashboard — never
+  // bounced back to /login (the old fail-open).
+  const joinCycleHref = recruitingCycle
+    ? signedIn
+      ? `/cycles/${recruitingCycle.id}/join`
+      : "/login"
+    : signedIn
+      ? "/dashboard"
+      : "/login";
+  const bannerSeason = seasonYear(recruitingCycle?.start_date ?? null);
+  const bannerKickoff = recruitingCycle?.start_date
+    ? new Date(recruitingCycle.start_date).toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      })
+    : null;
 
   const now = new Date();
   const upcoming = events.filter((e) => new Date(e.start_at) >= now);
@@ -104,29 +126,60 @@ export default async function LandingPage() {
               How cycles work →
             </Link>
           </div>
-          <div className="cycle-banner s-cover grain on-dark">
-            <Orb />
-            <div className="cb-body">
-              <span className="cb-status">Registration Open Now</span>
-              <div className="lbl lbl-teal" style={{ margin: "14px 0 6px" }}>
-                Summer 2026 · Washington, DC
+          {recruitingCycle ? (
+            <div className="cycle-banner s-cover grain on-dark">
+              <Orb />
+              <div className="cb-body">
+                <span className="cb-status">
+                  {recruitingCycle.status === "upcoming"
+                    ? "Registration open now"
+                    : "Cohort in progress"}
+                </span>
+                {bannerSeason && (
+                  <div className="lbl lbl-teal" style={{ margin: "14px 0 6px" }}>
+                    {bannerSeason}
+                  </div>
+                )}
+                <h3 className="t-h2">{recruitingCycle.name}</h3>
+                {bannerKickoff && (
+                  <p className="t-body" style={{ marginTop: 8, maxWidth: "52ch" }}>
+                    Kicks off {bannerKickoff} — twelve weeks, one real project,
+                    with people who notice.
+                  </p>
+                )}
+                {recruitingCycle.mode === "open" && (
+                  <p className="t-small" style={{ marginTop: 6, color: "var(--od2)", maxWidth: "52ch" }}>
+                    An Open Cycle — the projects are open source, free for anyone
+                    to use and build on.
+                  </p>
+                )}
               </div>
-              <h3 className="t-h2">Civic &amp; Elections Cycle</h3>
-              <p className="t-body" style={{ marginTop: 8, maxWidth: "52ch" }}>
-                Kicks off July 14, 2026 · a three-month cohort shipping a real
-                civic project.
-              </p>
-              <p className="t-small" style={{ marginTop: 6, color: "var(--od2)", maxWidth: "52ch" }}>
-                An Open Cycle — the projects are open source, free for anyone
-                to use and build on.
-              </p>
+              <div className="cb-cta">
+                <Link className="btn btn-red btn-lg" href={joinCycleHref}>
+                  {signedIn ? "Join this cycle" : "Join The Labs"}
+                </Link>
+              </div>
             </div>
-            <div className="cb-cta">
-              <Link className="btn btn-red btn-lg" href={joinCycleHref}>
-                Join this cycle
-              </Link>
+          ) : (
+            <div className="cycle-banner s-cover grain on-dark">
+              <Orb />
+              <div className="cb-body">
+                <span className="cb-status">Next cycle coming soon</span>
+                <h3 className="t-h2" style={{ marginTop: 14 }}>
+                  No cycle is open right now
+                </h3>
+                <p className="t-body" style={{ marginTop: 8, maxWidth: "52ch" }}>
+                  The next Build Cycle is still being planned. Join The Labs and
+                  we&apos;ll tell you the moment registration opens.
+                </p>
+              </div>
+              <div className="cb-cta">
+                <Link className="btn btn-red btn-lg" href={joinCycleHref}>
+                  {signedIn ? "Go to your dashboard" : "Join The Labs"}
+                </Link>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </section>
 

--- a/lib/cycle/active.ts
+++ b/lib/cycle/active.ts
@@ -10,7 +10,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
    Both assume the ≤1-active / ≤1-upcoming invariants (migrations 00048/00049),
    so `.maybeSingle()` is safe. */
 
-const CYCLE_COLUMNS = "id, name, slug, start_date, end_date, status, sector_id";
+const CYCLE_COLUMNS =
+  "id, name, slug, start_date, end_date, status, mode, sector_id";
 
 export interface CycleRow {
   id: number;
@@ -19,6 +20,7 @@ export interface CycleRow {
   start_date: string | null;
   end_date: string | null;
   status: string;
+  mode: string;
   sector_id: number | null;
 }
 


### PR DESCRIPTION
## What & why

Part of the "get the basic app working well" pass. Three stale surfaces that no longer match the data model or the current weekly practice:

### 1. Landing registration banner — now live from the DB
The banner was hardcoded (`Civic & Elections Cycle · Summer 2026 · Washington, DC · Kicks off July 14, 2026`), and its **Join this cycle** CTA looked up `status='active'`. Under the sector lifecycle the recruiting cohort is now `upcoming` (Civics), so the CTA pointed at the *wrong* cohort (the active Energy cycle) — and fell open to `/login` for a signed-in member whenever the lookup missed.

- Banner renders from `getRecruitingCycle` — name, a season label derived from `start_date`, the kickoff date, and the open-source line gated on `cycle.mode`.
- No open cycle → a calm **"next cycle coming soon"** state instead of a fake "Registration Open Now".
- `joinCycleHref`: recruiting cycle's join ceremony for members · `/login` for visitors · `/dashboard` for a signed-in member with no open cycle (never bounced to `/login`).

### 2. Stale "Weekly pulse check" CTAs retired
The Learning Log replaced the pulse check as the weekly practice/gate, but the cycles list and cycle detail pages still showed a red, alarm-styled "complete your check-in to keep access" card pointing at `/pulse-check`. Both now point calmly to `/dashboard#learning-log` with the Learning Log framing.

### 3. Returning-member redirect
`app/api/auth/callback` sent an existing participant to `/` (public landing) after sign-in. Returning members now land on `/dashboard`.

## Files
- `app/page.tsx` — banner driven by `getRecruitingCycle`; season/kickoff helpers; fixed join href.
- `lib/cycle/active.ts` — add `mode` to the shared column list + `CycleRow`.
- `app/(dashboard)/cycles/page.tsx`, `app/(dashboard)/cycles/[cycle_id]/page.tsx` — pulse-check CTA → Learning Log pointer.
- `app/api/auth/callback/route.ts` — existing participant → `/dashboard`.

## Verification
- `npx tsc --noEmit` clean · `eslint` clean on changed files · `next build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_