### PR TITLE
Dashboard: show the setup checklist for members who haven't enrolled yet

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -38,7 +38,7 @@ export default async function DashboardPage() {
   const serviceClient = createServiceClient();
 
   const [{ data: participant }, { data: cycles }] = await Promise.all([
-    serviceClient.from("participants").select("id, preferred_name, first_name, last_name, profile_image_url").eq("auth_user_id", user.id).maybeSingle(),
+    serviceClient.from("participants").select("id, preferred_name, first_name, last_name, profile_image_url, bio, headline").eq("auth_user_id", user.id).maybeSingle(),
     serviceClient.from("cycles").select("id, name, slug, start_date, end_date, status").order("start_date", { ascending: false }),
   ]);
 
@@ -218,7 +218,48 @@ export default async function DashboardPage() {
     </section>
   );
 
-  // Empty state: no enrollment — the hero + a single join CTA card.
+  // Setup checklist — the onboarding home for a new member (prototype
+  // panel-dashboard: "checklist first"). Built here so it shows in EVERY state
+  // below, not only once enrolled: the profile step is always relevant; the
+  // cycle steps appear when a cycle is running. SetupChecklist collapses to a
+  // strip once every row is done.
+  const profileDone = !!(participant.bio || participant.headline);
+  const checklistItems: ChecklistItem[] = [
+    {
+      key: "profile",
+      label: "Complete your profile",
+      done: profileDone,
+      href: "/profile/edit",
+      cta: "Edit",
+    },
+    ...(activeCycle
+      ? [
+          {
+            key: "register",
+            label: `Register for ${activeCycle.name}`,
+            done: hasAgreement || enrollment?.status === "active",
+            href: `/cycles/${activeCycle.id}/join`,
+            cta: "Register",
+          },
+          {
+            key: "pod",
+            label: "Join a pod",
+            done: myPods.length > 0,
+            href: `/cycles/${activeCycle.id}/register-pods`,
+            cta: "Choose",
+          },
+          {
+            key: "log",
+            label: "Save your first Learning Log",
+            done: logCount > 0,
+            href: "#learning-log",
+            cta: "Log",
+          },
+        ]
+      : []),
+  ];
+
+  // Empty state: no enrollment — the onboarding checklist leads, then the join CTA.
   if (state === "no_enrollment" && activeCycle) {
     return (
       <div>
@@ -227,8 +268,9 @@ export default async function DashboardPage() {
           avatarUrl={avatarUrl}
           eyebrow="Member portal"
           greeting={`Welcome, ${displayName}`}
-          lede="You're almost in. Join the current Build Cycle to get started."
+          lede="You're almost in — here's how to get set up."
         />
+        <SetupChecklist items={checklistItems} />
         <Link
           href={`/cycles/${activeCycle.id}/join`}
           className="group flex items-center justify-between rounded-card border border-teal/30 bg-white p-8 shadow-card transition-colors duration-150 ease-out hover:border-teal hover:bg-teal/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
@@ -269,6 +311,7 @@ export default async function DashboardPage() {
           greeting={`Welcome, ${displayName}`}
           lede="Here's your home base at The Labs. The next Build Cycle will show up right here."
         />
+        {checklistItems.length > 0 && <SetupChecklist items={checklistItems} />}
         <EmptyState
           icon={Calendar}
           title="No cycle running right now"
@@ -280,41 +323,7 @@ export default async function DashboardPage() {
   }
 
   // Engaged state: user has a cycle_enrollments row — full dashboard chrome.
-
-  // Setup checklist — actionable rows, collapses to a strip once done
-  // (prototype panel-dashboard: checklist first).
-  const checklistItems: ChecklistItem[] = activeCycle
-    ? [
-        {
-          key: "profile",
-          label: "Complete your profile",
-          done: true,
-          href: "/profile/edit",
-          cta: "Edit",
-        },
-        {
-          key: "register",
-          label: `Register for ${activeCycle.name}`,
-          done: hasAgreement || enrollment?.status === "active",
-          href: `/cycles/${activeCycle.id}/join`,
-          cta: "Register",
-        },
-        {
-          key: "pod",
-          label: "Join a pod",
-          done: myPods.length > 0,
-          href: `/cycles/${activeCycle.id}/register-pods`,
-          cta: "Choose",
-        },
-        {
-          key: "log",
-          label: "Save your first Learning Log",
-          done: logCount > 0,
-          href: "#learning-log",
-          cta: "Log",
-        },
-      ]
-    : [];
+  // (checklistItems is built above the early returns so it renders in every state.)
 
   // "Up next" — the cycle actions whose window is open right now, as
   // dismissible cards (the rail shows timing; this gives the button).


### PR DESCRIPTION
## The report

A cofounder testing the reset flow: *"Test account reset isn't really working — it puts me back through reg flow but it doesn't drop me back on the onboarding checklist view."*

## Diagnosis

The **reset works correctly** — it deletes the participant + `cycle_enrollments` + journey rows, CASCADE-clears the satellites, and the email-keyed `testers` grant survives and re-applies `is_test` on re-signup. No stale client state is involved.

The bug is **server-side gating in the dashboard.** `SetupChecklist` was only built/rendered in the dashboard's "engaged" branch, which requires a `cycle_enrollments` row. Registration creates a `participants` row but **no enrollment** (that's created by the cycle-join ceremony). So a just-re-registered member hits the `no_enrollment` early return and sees only the bare "Join the current Build Cycle" card — the checklist is never reached. The design-source prototype shows the setup checklist to **every** signed-in member.

Secondary defect in the same code: the "Complete your profile" item was hardcoded `done: true`.

## Fix (`app/(dashboard)/dashboard/page.tsx` only)

- **Hoist `checklistItems` above the early returns** so it's in scope for every state. The "Complete your profile" step is always present; the cycle steps (Register / Join a pod / First Learning Log) are conditional on an active cycle.
- **Render `SetupChecklist` in the `no_enrollment` state** (it leads, above the join CTA) and the **`no_cycle` state** (profile step only). The engaged state is unchanged. The existing `checklistItems.length > 0` guard keeps an empty list from rendering a false "All done ✓".
- **Real profile completeness**: `done` is now `!!(participant.bio || participant.headline)` instead of hardcoded `true`; the participant select is widened to include `bio`/`headline`.

`setup-checklist.tsx` is untouched.

## Verification

- `tsc --noEmit`, `eslint`, `next build` — all clean.
- **Manual e2e (the real proof, on the preview):** avatar menu → **Reset Test Account** → sign back in → complete the funnel → the dashboard now shows the **"Get set up"** checklist with an actionable **Register for {cycle}** row (plus profile / pod / log), instead of only the bare join card.

## Notes (out of scope)
- Picking the "cycle" role at registration still routes to the join ceremony (`/cycles/{id}/join?from=signup`) by design; the dashboard checklist is now the reliable home for every other path and the post-join landing.
- Latent, separate: the funnel returns the *recruiting* cycle as `active_cycle_id` while the dashboard keys off the *operating* (`status='active'`) cycle — flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_