### PR TITLE
Make /stories public — Upskiller Spotlights browse free

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -56,6 +56,7 @@ export async function proxy(request: NextRequest) {
       "/labs", // old path — next.config redirects it to /local-labs
       "/about",
       "/build-cycles",
+      "/stories", // public Upskiller Spotlights — browses free, no auth
     ];
     const isPublicPath =
       request.nextUrl.pathname === "/" ||


### PR DESCRIPTION
## Bug

Anonymous visitors to `/stories` were redirected to `/login`. Spotlights are meant to browse free (public, no auth), like the rest of the public content.

## Cause

When `/stories` shipped (PR #171) it wasn't added to `proxy.ts`'s `publicPaths` allowlist, so the middleware treated it as a protected route and bounced logged-out users to `/login`.

## Fix

Add `/stories` to `publicPaths`, next to `/events`, `/library`, `/local-labs`, `/about`, `/build-cycles`. The `/api/` entry already covers the public "share your story" submission endpoint, and the page reads spotlights via the service client, so nothing else was gating it.

## Verification
- `tsc` / `eslint` / `next build` clean.
- After deploy: `/stories` (and the landing spotlights row's links) open for a logged-out visitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_