### PR TITLE
Drop the section header from the home Spotlights row

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,17 +118,6 @@ export default async function LandingPage() {
       {spotlights.length > 0 && (
         <section className="section s-white sec-after-hero" id="sec-stories">
           <div className="container">
-            <div className="section-head">
-              <div>
-                <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
-                  Upskiller Spotlights
-                </div>
-                <h2 className="t-h2">Real people, real practice</h2>
-              </div>
-              <Link className="see" href="/stories">
-                Upskilling Stories →
-              </Link>
-            </div>
             <div className="story-row">
               {spotlights.slice(0, 6).map((s) => (
                 <Link


### PR DESCRIPTION
## What

On the landing page, the Upskiller Spotlights section led with a header block — eyebrow ("Upskiller Spotlights"), heading ("Real people, real practice"), a "Upskilling Stories →" read-all link, and the `.section-head` divider rule. This removes that whole block so the section is just the spotlight cards (the story row + the "Share your story" CTA card).

## Change

- `app/page.tsx` — delete the `.section-head` div from `#sec-stories`. The divider was that element's `border-bottom`, so it goes with it. No CSS change needed; every other section keeps its header.

## Verify

- `npx tsc --noEmit` + `eslint app/page.tsx` — clean.
- On the dev preview the landing Spotlights section shows only the cards, no header/divider/link above them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_