### PR TITLE
Guard migration-number collisions + document parallel workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm run check:migrations
       - run: npm run lint
       - run: npm run test
       - run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,34 @@ All work happens on **`dev`**. `main` is production.
 
 > Reviews route to the maintainers via [`.github/CODEOWNERS`](.github/CODEOWNERS).
 
+### Working in parallel
+
+Several people can work at once as long as branches stay segregated:
+
+- **One feature per branch, off `dev`.** Name it for the work (`fix/linkedin-url-guard`,
+  not `wip`). Don't stack unrelated changes.
+- **Claim shared surfaces first.** Before you start, check whether an open issue/PR
+  already touches your files. A few areas are collision-prone — coordinate (or take
+  the whole area) rather than editing them from two branches at once:
+  the shared form primitives (`app/components/ui/form.tsx`), and the
+  enrollment/moderator/admin surface (`lib/enrollment/`, `lib/moderator/`,
+  `app/api/admin/pods/`, `app/api/moderator/pods/`), which several issues touch together.
+- **Claim your migration number.** Say so on the issue before you write
+  `supabase/migrations/000NN_…`. Two branches grabbing the same number collide;
+  `npm run check:migrations` (also enforced in CI) catches a duplicate before merge.
+- **Rebase on `dev` before opening the PR**, and keep PRs small so reviews don't queue.
+- **Never target or push `main`.** It's production; only a maintainer promotes `dev → main`.
+
+### Branch protection (maintainers)
+
+`dev` and `main` should be protected so the workflow above is enforced, not just
+documented. Intended rules (GitHub → Settings → Branches):
+
+- Require a pull request before merging (≥1 approving review).
+- Require the **`ci`** status check to pass, with "require branches up to date."
+- Require review from Code Owners.
+- Restrict direct pushes (no bypassing the PR).
+
 ## Database migrations
 
 The database schema lives in `supabase/migrations/`, numbered sequentially
@@ -82,7 +110,9 @@ The database schema lives in `supabase/migrations/`, numbered sequentially
 migration file** — the files are the source of truth ([SCHEMA.md](SCHEMA.md) is the
 generated reference).
 
-- **Never reuse a migration number** — `ls supabase/migrations/ | tail -1` first.
+- **Never reuse a migration number** — `ls supabase/migrations/ | tail -1` first, and
+  claim it on the issue if others are working in parallel. `npm run check:migrations`
+  (run in CI) fails the build if two files share a numeric prefix.
 - Full conventions (header comments, idempotency, RLS, `-- DOWN:` blocks) are in
   [`supabase/CLAUDE.md`](supabase/CLAUDE.md).
 - Applying to dev vs prod is documented in

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "check:migrations": "node scripts/check-migration-numbers.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.98.0",

--- a/scripts/check-migration-numbers.mjs
+++ b/scripts/check-migration-numbers.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Fails if two migrations share the same numeric prefix. This is the parallel-work
+// hazard supabase/CLAUDE.md warns about ("never reuse a migration number") — two
+// contributors both grabbing 000NN on separate branches collide silently on merge.
+// Wired into CI so the collision goes red at PR-open, not at merge. Zero-dep.
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const migrationsDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "supabase",
+  "migrations"
+);
+
+const files = readdirSync(migrationsDir)
+  .filter((f) => f.endsWith(".sql"))
+  .sort();
+
+let ok = true;
+const byNumber = new Map(); // integer prefix -> [filenames]
+
+for (const f of files) {
+  const m = f.match(/^(\d+)/);
+  if (!m) {
+    console.error(`✗ migration has no leading number: ${f}`);
+    ok = false;
+    continue;
+  }
+  const n = Number(m[1]); // normalize so 0048 and 00048 collide
+  if (!byNumber.has(n)) byNumber.set(n, []);
+  byNumber.get(n).push(f);
+}
+
+const dupes = [...byNumber.entries()].filter(([, fs]) => fs.length > 1);
+if (dupes.length) {
+  console.error("✗ Duplicate migration numbers — renumber before merging:");
+  for (const [n, fs] of dupes.sort((a, b) => a[0] - b[0])) {
+    console.error(`    ${String(n).padStart(5, "0")}: ${fs.join(", ")}`);
+  }
+  console.error("\n  Each migration needs a unique numeric prefix — see supabase/CLAUDE.md.");
+  ok = false;
+}
+
+if (!ok) process.exit(1);
+console.log(`✓ ${files.length} migrations — all numeric prefixes unique.`);


### PR DESCRIPTION
## What

Makes `dev` safe for **uncoordinated parallel** contributors — closes the concrete collision hazards so several people can each take a branch without stepping on each other. Follows the contributor-docs foundation in #178.

## Changes

- **`scripts/check-migration-numbers.mjs`** (new, zero-dep) — fails if two migrations share a numeric prefix. This is the exact hazard `supabase/CLAUDE.md` warns about ("never reuse a migration number"): two branches both grabbing `000NN` collide silently on merge.
- **`.github/workflows/ci.yml`** — runs the guard as an early step (`npm run check:migrations`), so a colliding PR goes red at PR-open, not at merge. **`package.json`** — adds the `check:migrations` script for local use.
- **`CONTRIBUTING.md`** — a **"Working in parallel"** section (one feature per branch off `dev`; claim shared surfaces — the form primitives and the enrollment/moderator/admin area — and migration numbers before starting; rebase; never touch `main`), plus the intended **branch-protection rules** for maintainers.

## Verify

- `node scripts/check-migration-numbers.mjs` → passes on the current tree (52 migrations, all unique); a temporary duplicate makes it exit 1 with a clear message.
- `npm run check:migrations` wired into CI ahead of lint/test/build.
- `eslint` clean (only pre-existing warnings). Docs render; links resolve.
- No product code, database, or Supabase changes.

## Still owner-only (not in this PR)

**Branch protection** on `dev`/`main` — the enforcement backbone — is a repo-settings toggle only an admin can flip (documented in CONTRIBUTING). Without it, CI still isn't *required* and `main` can be pushed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_