### PR TITLE
Set up the repo for Claude Code agent teams

### DIFF
--- a/.claude/agents/backend.md
+++ b/.claude/agents/backend.md
@@ -1,0 +1,25 @@
+---
+name: backend
+description: Server logic — API route handlers under app/api/ and lib/ modules (auth, cycle, enrollment, moderator, content, learning-logs, participants). Not UI components or SQL migrations.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: sonnet
+---
+
+You own the **backend** surface of OLOS: `app/api/**/route.ts` and `lib/**` server
+logic. Do not edit UI components (the `frontend` teammate) or SQL migrations (the
+`migrations` teammate) — though you'll often need a migration written; coordinate with
+the `migrations` teammate rather than adding SQL yourself.
+
+Before writing, read:
+- `docs/ARCHITECTURE.md` — route groups, `proxy.ts` auth gate, the `lib/` map.
+- `SCHEMA.md` — the data model.
+- `lib/auth/CLAUDE.md` — **required reading before touching** anything in `lib/auth/`,
+  `app/api/auth/`, `app/(auth)/`, or `lib/email/`.
+
+**Single-owner zone:** the enrollment / moderator / admin surface (`lib/enrollment/`,
+`lib/moderator/`, `app/api/admin/pods/`, `app/api/moderator/pods/`) is tightly
+coupled — issues #110/#115/#117/#123/#125/#179 all touch it. One teammate should own
+this whole area at a time; don't split it across parallel teammates.
+
+Verify: `npm run lint`, `npm run test`, `npm run build` before marking a task done.
+New pure helpers in `lib/` should ship with a `*.test.ts` (Vitest).

--- a/.claude/agents/docs.md
+++ b/.claude/agents/docs.md
@@ -1,0 +1,18 @@
+---
+name: docs
+description: Documentation — Markdown under docs/ and the top-level *.md files (README, CONTRIBUTING, SCHEMA, DESIGN_SYSTEM). Keeps doc work off the code teammates' branches.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: sonnet
+---
+
+You own **documentation**: `docs/**` and the top-level `*.md` files (`README.md`,
+`CONTRIBUTING.md`, `SCHEMA.md`, `DESIGN_SYSTEM.md`, the audit docs). Don't edit code —
+that's the frontend/backend/migrations teammates.
+
+Keep docs accurate to the shipped code (grep the source rather than trusting older
+prose — the repo has a history of stale docs, e.g. the old FastAPI architecture brief).
+Match the existing structure and the "The Labs" naming rule. When you change the DB
+schema doc, note it's usually the `migrations` teammate who owns `SCHEMA.md` edits —
+coordinate to avoid conflicts.
+
+Check that any relative links you add resolve to real files before finishing.

--- a/.claude/agents/frontend.md
+++ b/.claude/agents/frontend.md
@@ -1,0 +1,23 @@
+---
+name: frontend
+description: UI work — React components, signed-in dashboard pages, and design-system styling. Owns app/components/ and the page.tsx / client components under app/(dashboard), app/(public), app/(auth). Not API routes or lib/ server logic.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: sonnet
+---
+
+You own the **frontend** surface of OLOS: `app/components/`, the page + client
+components under `app/(dashboard)/`, `app/(public)/`, `app/(auth)/`, and
+`app/globals.css`. Do not touch `app/api/**` or `lib/**` server logic — that's the
+`backend` teammate's area.
+
+Before writing UI, read:
+- `docs/ARCHITECTURE.md` — how the App Router + route groups are laid out.
+- `DESIGN_SYSTEM.md` — tokens, components, and the copy voice. Use design tokens
+  (`--ink`, `--teal`, `--paper`, …); never hardcode hex. Brand is "The Labs", never "TUL".
+
+**Shared-file caution:** the form primitives live in one file,
+`app/components/ui/form.tsx`. If more than one task touches it (e.g. form ARIA and
+dropdown styling), coordinate so only one of you edits it at a time — parallel edits
+overwrite each other.
+
+Verify your work: `npm run lint` and `npm run build` before marking a task done.

--- a/.claude/agents/migrations.md
+++ b/.claude/agents/migrations.md
@@ -1,0 +1,21 @@
+---
+name: migrations
+description: Database schema — SQL migrations under supabase/migrations/ and keeping SCHEMA.md in sync. Owns DDL; coordinates with the backend teammate on the code that reads new columns.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: sonnet
+---
+
+You own **database schema** changes: `supabase/migrations/*.sql` and the matching
+`SCHEMA.md` updates.
+
+**Before writing a migration:**
+- Read `supabase/CLAUDE.md` — the full conventions (header comment, idempotency, RLS,
+  `-- DOWN:` blocks, consolidation policy).
+- **Claim your migration number first.** `ls supabase/migrations/ | tail -1` to find the
+  next free number, and say which number you're taking on the task/issue so no other
+  teammate grabs it. Two branches using the same `000NN` collide on merge.
+- Run `npm run check:migrations` — it fails if two files share a numeric prefix. This
+  also runs in CI and as a task-completion hook, so a duplicate blocks your task.
+
+Update `SCHEMA.md` in the same change when you alter the schema. Do NOT apply migrations
+to production — a maintainer does that after `dev → main` (see `docs/environments.md`).

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,20 @@
+---
+name: reviewer
+description: Read-only code review through a single lens (correctness, security, performance, or test coverage). Makes NO file edits — reports findings back. Ideal for parallel PR review where each reviewer takes a different lens.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are a **read-only reviewer**. You do not edit files — you investigate and report
+findings (with `file:line` references and severity), then hand them back to the lead.
+
+You'll be spawned with a specific lens; stay in it so parallel reviewers don't overlap:
+- **correctness** — logic bugs, wrong states, unhandled cases, race conditions.
+- **security** — authz gaps, injection, unsafe `href`/render of user input, secret
+  handling. (OLOS specifics: RLS + service-role usage in `lib/supabase/`, the
+  `proxy.ts` public-path allowlist, `lib/auth/`.)
+- **performance** — N+1 queries, unnecessary sequential awaits, missing indexes.
+- **tests** — missing coverage on new `lib/` helpers; Vitest lives in `lib/**/*.test.ts`.
+
+Ground your review in `docs/ARCHITECTURE.md` and `SCHEMA.md`. Use `git diff` / `git show`
+to scope the change under review. Report only what you can support with evidence.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run lint)",
+      "Bash(npm run test)",
+      "Bash(npm run build)",
+      "Bash(npm run check:migrations)",
+      "Bash(npx tsc --noEmit)",
+      "Bash(npx eslint:*)",
+      "Bash(npx vitest:*)",
+      "Bash(node scripts/check-migration-numbers.mjs)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)"
+    ]
+  },
+  "hooks": {
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && node scripts/check-migration-numbers.mjs || exit 2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ scripts/dev/
 
 # superpowers skill runner (local tooling, not project source)
 .superpowers/
+
+# Claude Code: per-developer local settings (e.g. the experimental agent-teams
+# flag). The shared .claude/settings.json and .claude/agents/ ARE tracked.
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 @AGENTS.md
 
+## Orientation
+
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — how the codebase is organized (App Router, `lib/`, migrations, core concepts).
+- [CONTRIBUTING.md](CONTRIBUTING.md) — setup, the branch/PR workflow, and the "Working in parallel" rules (file ownership, claiming migration numbers).
+- [docs/agent-teams.md](docs/agent-teams.md) — running Claude Code agent teams on this repo (roles in `.claude/agents/`, ownership map, spawn prompts).
+
 ## Subdocs
 
 - [lib/auth/CLAUDE.md](lib/auth/CLAUDE.md) — sign-in flow, role resolution, invitation flow, and the `TUL_MVP_Spec.md`-vs-implementation deviations (Issues #44, #45). Read before touching anything in `lib/auth/`, `app/api/auth/`, `app/(auth)/`, or `lib/email/`.

--- a/docs/agent-teams.md
+++ b/docs/agent-teams.md
@@ -1,0 +1,84 @@
+# Running Claude Code agent teams on OLOS
+
+[Agent teams](https://code.claude.com/docs/en/agent-teams) let one Claude Code session
+(the *lead*) spawn several teammates that work in parallel, each in its own context,
+coordinating through a shared task list. This repo is set up to make that productive.
+It's an **experimental** feature and **off by default**.
+
+## Enable it (owner-local)
+
+The enabling env var is intentionally **not** checked in, so contributors aren't opted
+into an experimental feature. Turn it on for yourself by adding it to your gitignored
+`.claude/settings.local.json` in the repo:
+
+```json
+{ "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
+```
+
+(or to your global `~/.claude/settings.json`). What *is* checked in and shared with
+everyone: the pre-approved permissions and the migration-guard hook in
+`.claude/settings.json`, and the teammate role definitions in `.claude/agents/`.
+
+## What's already wired up
+
+- **Pre-approved permissions** (`.claude/settings.json`) — teammate permission prompts
+  bubble up to the lead and stall the team, so the safe dev commands (lint / test /
+  build / `check:migrations` / read-only git) are pre-allowed. Mutating git
+  (`push`/`commit`) is deliberately left prompting so the lead controls it.
+- **Migration-guard hook** — a `TaskCompleted` hook runs `check:migrations`, so a
+  teammate can't mark a task done if it introduced a duplicate migration number.
+- **Role definitions** (`.claude/agents/`) — spawn a teammate "using the `backend`
+  agent type", etc. Each role has a scoped tool set and points at the right area docs.
+- **Context for teammates** — teammates read `CLAUDE.md` (root + the nested ones) but
+  **not the lead's conversation history**. Put task-specific detail in the spawn prompt.
+
+## File-ownership map (avoid conflicts)
+
+Two teammates editing one file overwrite each other. Hand each teammate a
+non-overlapping zone — these match the roles in `.claude/agents/` and the
+"Working in parallel" section of [CONTRIBUTING.md](../CONTRIBUTING.md):
+
+| Zone (`agent type`) | Owns | Watch out for |
+|---|---|---|
+| `frontend` | `app/components/`, dashboard/public/auth page + client components, `globals.css` | `app/components/ui/form.tsx` is shared — one owner at a time |
+| `backend` | `app/api/**`, `lib/**` server logic | the enrollment/moderator/admin area is a **single-owner** zone (see below) |
+| `migrations` | `supabase/migrations/`, `SCHEMA.md` | claim the migration number first |
+| `docs` | `docs/**`, top-level `*.md` | `SCHEMA.md` usually belongs to `migrations` |
+| `reviewer` | read-only, no edits | give each reviewer a distinct lens |
+
+**Single-owner zone:** the enrollment / moderator / admin surface (`lib/enrollment/`,
+`lib/moderator/`, `app/api/admin/pods/`, `app/api/moderator/pods/`) is tightly coupled —
+issues #110, #115, #117, #123, #125, #179 all touch it. Assign it to **one** `backend`
+teammate; don't parallelize inside it.
+
+## Example spawn prompts
+
+**Parallel PR review** (the strongest starter use case — no code written):
+```
+Spawn three reviewer teammates on PR #NNN, each a different lens:
+one security, one performance, one test coverage. Have them report findings
+with file:line and severity, then synthesize.
+```
+
+**Forms polish** (isolated-enough to parallelize, with one shared-file caveat):
+```
+Spawn a frontend teammate to take the form issues: #105 (LinkedIn href hardening),
+#106 (form ARIA), #99 (propose-form → react-hook-form). #106 and #96 both touch
+form.tsx, so keep those on one teammate. Require plan approval before edits.
+```
+
+**Cross-layer feature** (frontend + backend + migration, cleanly split):
+```
+Spawn a backend teammate, a frontend teammate, and a migrations teammate to add
+<feature>. The migrations teammate writes the schema and claims its number first;
+backend wires the API; frontend builds the UI. Wait for all three before merging.
+```
+
+## Good to know (from the feature's limitations)
+
+- **One team per session; no nested teams** — only the lead spawns teammates.
+- **Start with research/review** before parallel implementation — clearer boundaries.
+- **Wait for teammates** — if the lead starts doing the work itself, tell it to wait.
+- **Approve permission prompts on the lead**, not the teammate — a teammate can't
+  approve on your behalf.
+- Teammates use **significantly more tokens** than one session. Start with 3–5.


### PR DESCRIPTION
## What

Prepares OLOS to work well with [Claude Code agent teams](https://code.claude.com/docs/en/agent-teams) (experimental multi-session orchestration). The repo had no `.claude/` config at all; this adds a checked-in kit so teammates get self-contained context, clean file-ownership boundaries, and pre-approved permissions (teammate prompts otherwise bubble to the lead and stall the team).

## Changes

- **`.claude/settings.json`** (shared) — pre-approved allowlist of safe dev commands (`lint`/`test`/`build`/`check:migrations`/`tsc`/`eslint`/`vitest`) + read-only git; mutating git stays prompting. A **`TaskCompleted` hook** runs `check:migrations` and blocks completion (exit 2) if a teammate introduced a duplicate migration number.
- **`.claude/agents/`** — five reusable teammate roles matching the ownership zones: `frontend`, `backend`, `migrations`, `docs`, and a read-only `reviewer` — each with a scoped tool set and pointers to the right area docs.
- **`docs/agent-teams.md`** — how to enable (owner-local flag), the file-ownership map, OLOS-tuned example spawn prompts (parallel PR review, forms cluster, cross-layer feature), and the feature's caveats.
- **`CLAUDE.md`** — orientation pointers to ARCHITECTURE / CONTRIBUTING / agent-teams (teammates read CLAUDE.md, not the lead's history — so the map belongs there).
- **`.gitignore`** — ignore `.claude/settings.local.json` (the per-dev experimental flag); `settings.json` + `agents/` stay tracked.

## Notes

- The experimental `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` flag is **intentionally not committed** — enable it owner-locally per `docs/agent-teams.md`, so contributors aren't opted into an experimental feature.
- Config + docs only — no product code, DB, or Supabase changes.

## Verify

- `.claude/settings.json` is valid JSON; all five agent files have valid frontmatter.
- Hook exit codes: passes (0) on the current tree; a temporary duplicate migration makes it exit 2 (blocks the task).
- `git check-ignore` confirms `settings.local.json` is ignored while `settings.json` + `agents/` are tracked. All new doc links resolve.
- Actual team behavior (spawning, panel, hook firing) is verified locally by the owner once the flag is enabled — it can't be exercised from a headless session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT

---
_Generated by [Claude Code](https://claude.ai/code/session_013dyCUbpEtpvNLSiW9xdutT)_