### PR TITLE
feat(sensemaker): public field-survey intake at /survey/[slug]

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -547,6 +547,59 @@ erDiagram
 
 ---
 
+## ERD — Data Sensemaker (field survey → Ortelius groundwork)
+
+The intake bedrock of the Data Sensemaker (`docs/SENSEMAKING_FLOW.md` §3, `docs/ORTELIUS_KNOWLEDGE_GRAPH.md` §3a) — the public, account-free field survey that replaces the Civics & Elections Google Form and seeds the first Ortelius provenance node. Gate-free (a form + storage, no in-app LLM). The AI-assisted extraction, canvas, and `asset_links`/`content_embeddings` graph build additively on top; the envelope columns here land day one so nothing at this leaf is ever migrated.
+
+```mermaid
+erDiagram
+    field_surveys {
+        int id PK
+        int cycle_id FK "nullable"
+        int sector_id FK "nullable"
+        varchar title
+        varchar problem_domain
+        text about
+        varchar share_slug UK
+        varchar status "draft/open/closed"
+        boolean allow_anonymous
+        varchar consent_version
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    survey_responses {
+        bigint id PK
+        int field_survey_id FK
+        int participant_id FK "NULL for anonymous"
+        text observation
+        text_array standpoint
+        smallint salience "1-5, nullable"
+        text prior_attempts
+        boolean consent_participation
+        varchar consent_version
+        boolean contactable
+        varchar submitter_name
+        varchar submitter_email
+        varchar submitter_phone
+        boolean mentor_interest
+        text source_url
+        varchar moderation_status "pending/approved/rejected"
+        int schema_version
+        text ip_hash
+        timestamptz created_at
+    }
+
+    cycles ||--o{ field_surveys : "runs"
+    sectors ||--o{ field_surveys : "homes"
+    field_surveys ||--o{ survey_responses : "collects"
+    participants ||--o{ survey_responses : "submits"
+```
+
+**`field_surveys` / `survey_responses` (migration `00053`):** the field-survey intake (`docs/SENSEMAKING_FLOW.md` §3). `field_surveys` is the instrument — one row per sector/cycle problem domain, seeded idempotently for Civics & Elections (`share_slug='civics'`, `status='open'`). The public page `/survey/[slug]` renders it (the survey-specific `about` lede from the row; the "what is the Labs / where do insights go" copy is boilerplate in the page). `survey_responses` is the observation bedrock: `observation` is the required evidence body every future `extract` derives from; `standpoint[]` feeds the coverage/diversity signal (never a credibility weight — `ORTELIUS_NORTHSTAR.md` §6); `salience`, `prior_attempts` (archaeology), and the contact fields are optional. Two distinct consents: `consent_participation` (required, gates submit) and `contactable` (optional). The **nullable `participant_id`** is the load-bearing anonymous public path; `mentor_interest` is a recruiting side-channel. **Ortelius groundwork columns land day one:** `source_url` (the evidence-producer gap, `ORTELIUS §5` gap #6), `consent_version`, `moderation_status`, and `schema_version` (gap #12 — versioned from day one). Every response is retained; curation is a later temporal overlay, never a delete (owner decision 2026-07-05). RLS: `field_surveys` anon-SELECT-`open`-only (mirrors spotlights/events); `survey_responses` has **no public policy** — all writes go through the service-role `POST /api/surveys/[slug]/responses` (member session binds `participant_id`; anonymous path is per-IP throttled via `lib/api/rate-limit.ts`, `moderation_status='pending'`), and reads stay service-role until a consented atlas surface ships.
+
+---
+
 ## Table Summary
 
 | Table | Group | Purpose |
@@ -579,4 +632,6 @@ erDiagram
 | `profile_updates` | Practice | Member updates feed — written ONLY by Learning Log shares |
 | `saved_items` | Practice | A member's saved events/resources (the /learning hearts) — polymorphic by slug |
 | `spotlights` | Public Content | Upskiller Spotlights + their submission pipeline (public /stories) |
+| `field_surveys` | Data Sensemaker | The field-survey instrument — one row per sector/cycle problem domain (public `/survey/[slug]`) |
+| `survey_responses` | Data Sensemaker | Field observations — the evidence bedrock; anon-capable, the first Ortelius provenance node |
 | `testers` | Testing | Email-keyed tester grant — survives the tester's full self-reset |

--- a/app/(public)/survey/[slug]/page.tsx
+++ b/app/(public)/survey/[slug]/page.tsx
@@ -1,0 +1,110 @@
+import { notFound } from "next/navigation";
+import { Crumbs } from "@/app/components/content/teasers";
+import { getOpenFieldSurvey } from "@/lib/content/surveys";
+import SurveyForm from "./survey-form";
+
+/* The public field survey (SENSEMAKING_FLOW.md §3) — account-free, anonymous
+   by default, the bedrock evidence layer that feeds the Data Sensemaker.
+   Replaces the Civics & Elections Google Form. One instrument per share_slug;
+   the survey-specific lede comes from the row, the "what is the Labs / where do
+   insights go" copy is boilerplate here. */
+
+// Reads the instrument per request (public, auth-aware nav); never prerendered.
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const survey = await getOpenFieldSurvey(slug);
+  if (!survey) return { title: "Field survey · The Upskilling Labs" };
+  return {
+    title: `${survey.title} · The Upskilling Labs`,
+    description:
+      survey.about ??
+      "Share what you're seeing in the field — the observations that shape what we build.",
+  };
+}
+
+export default async function SurveyPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const survey = await getOpenFieldSurvey(slug);
+  if (!survey) notFound();
+
+  const domain = survey.problem_domain ?? "the field";
+
+  return (
+    <>
+      <div className="container">
+        <Crumbs trail={[["Home", "/"], ["Field survey", null]]} />
+      </div>
+
+      {/* Dark hero */}
+      <section className="grain" style={{ background: "var(--ink)", color: "#fff" }}>
+        <div
+          className="container"
+          style={{ maxWidth: 760, paddingTop: 56, paddingBottom: 56 }}
+        >
+          {survey.problem_domain && (
+            <div className="lbl lbl-teal" style={{ marginBottom: 16 }}>
+              {survey.problem_domain} · field survey
+            </div>
+          )}
+          <h1 className="t-h1" style={{ maxWidth: "22ch" }}>
+            {survey.title}
+          </h1>
+          {survey.about && (
+            <p
+              className="t-lede"
+              style={{ marginTop: 18, maxWidth: "58ch", color: "var(--od2)" }}
+            >
+              {survey.about}
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* Context + the form */}
+      <section className="section">
+        <div className="container" style={{ maxWidth: 760 }}>
+          {/* Two boilerplate context blocks — constant across surveys */}
+          <div className="lcard" style={{ padding: 28, marginBottom: 28 }}>
+            <h2 className="t-h4" style={{ marginBottom: 8 }}>
+              What is The Upskilling Labs?
+            </h2>
+            <p className="t-body text-meta" style={{ marginBottom: 20 }}>
+              The Upskilling Labs is a free workforce-development and community
+              organization that helps professionals build not just AI literacy,
+              but the skills and capacity to identify problems, lead initiatives,
+              and drive real outcomes in the age of AI. Its flagship program is
+              the quarterly Build Cycle — each one focused on a different
+              sector-based theme, taking upskillers from understanding a problem
+              as a community, to prototyping solutions in small teams, to a
+              public showcase.
+            </p>
+            <h2 className="t-h4" style={{ marginBottom: 8 }}>
+              Where do my insights go?
+            </h2>
+            <p className="t-body text-meta" style={{ margin: 0 }}>
+              Your insights help shape the problems Upskillers choose to explore
+              in the upcoming {domain} Build Cycle. They join an open insights
+              repository — contributed by subject-matter experts, practitioners,
+              and members of the public — that participants draw on as they form
+              their problem frames. Everything Upskillers produce is accessible
+              and open-source. Submissions are voluntary and anonymous unless you
+              choose to share your contact information.
+            </p>
+          </div>
+
+          <SurveyForm slug={survey.share_slug} domain={domain} />
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/(public)/survey/[slug]/survey-form.tsx
+++ b/app/(public)/survey/[slug]/survey-form.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import { useState } from "react";
+import { STANDPOINTS } from "@/lib/validations/survey-response";
+
+/* The field-survey form (SENSEMAKING_FLOW.md §3). Onboarding-minded ordering:
+   lead with the observation (the reason they came), then optional context,
+   then contact, with the required participation consent as the last gate
+   before submit. Anonymous by default — contact fields are opt-in.
+   Posts to /api/surveys/[slug]/responses. */
+
+type Standpoint = (typeof STANDPOINTS)[number];
+
+const STANDPOINT_LABELS: Record<Standpoint, string> = {
+  work_in_field: "I work in this field",
+  affected: "I've been personally affected by it",
+  tried_to_fix: "I've tried to fix something like this before",
+  research: "I research or study this area",
+  pay_attention: "I just pay close attention",
+  other: "Other",
+};
+
+const SALIENCE_LOW = "I noticed it in passing";
+const SALIENCE_HIGH = "This is something I think about a lot";
+
+const fieldStyle: React.CSSProperties = {
+  width: "100%",
+  border: "1px solid var(--rule)",
+  borderRadius: "var(--r)",
+  padding: 14,
+  font: "inherit",
+  fontSize: 16,
+  background: "var(--white)",
+};
+
+function Req() {
+  return (
+    <span className="text-red" aria-hidden style={{ marginLeft: 2 }}>
+      *
+    </span>
+  );
+}
+
+export default function SurveyForm({
+  slug,
+  domain,
+}: {
+  slug: string;
+  domain: string;
+}) {
+  const [observation, setObservation] = useState("");
+  const [standpoint, setStandpoint] = useState<Set<Standpoint>>(new Set());
+  const [salience, setSalience] = useState<number | null>(null);
+  const [priorAttempts, setPriorAttempts] = useState("");
+  const [contactable, setContactable] = useState(false);
+  const [mentorInterest, setMentorInterest] = useState(false);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [consent, setConsent] = useState(false);
+
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggleStandpoint = (s: Standpoint) =>
+    setStandpoint((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s);
+      else next.add(s);
+      return next;
+    });
+
+  async function submit() {
+    setError(null);
+    if (!observation.trim()) {
+      return setError("Tell us what you're seeing — a sentence is plenty.");
+    }
+    if (!consent) {
+      return setError("Please confirm the consent below to submit.");
+    }
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/surveys/${slug}/responses`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          observation: observation.trim(),
+          consent_participation: true,
+          standpoint: [...standpoint],
+          salience,
+          prior_attempts: priorAttempts.trim(),
+          contactable,
+          mentor_interest: mentorInterest,
+          submitter_name: name.trim(),
+          submitter_email: email.trim(),
+          submitter_phone: phone.trim(),
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Something went wrong — try again.");
+      }
+      setDone(true);
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong — try again.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (done) {
+    return (
+      <div className="lcard" style={{ padding: 40, textAlign: "center" }}>
+        <div className="t-h3" style={{ marginBottom: 8 }}>
+          Thank you — your observation is in ✓
+        </div>
+        <p
+          className="t-body text-meta"
+          style={{ maxWidth: "52ch", margin: "0 auto 20px" }}
+        >
+          It joins the {domain} insights repository that Upskillers draw on as
+          they form their problem frames. Seen something else worth sharing?
+        </p>
+        <button
+          className="btn btn-ghost-teal"
+          type="button"
+          onClick={() => {
+            setObservation("");
+            setStandpoint(new Set());
+            setSalience(null);
+            setPriorAttempts("");
+            setContactable(false);
+            setMentorInterest(false);
+            setName("");
+            setEmail("");
+            setPhone("");
+            setConsent(false);
+            setDone(false);
+          }}
+        >
+          Share another observation
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="card"
+      style={{ padding: 28 }}
+      onSubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+      noValidate
+    >
+      {/* 1 — the observation (required) */}
+      <div style={{ marginBottom: 28 }}>
+        <label className="lbl" htmlFor="observation" style={{ display: "block", marginBottom: 6 }}>
+          What are you observing in the field of {domain.toLowerCase()}?
+          <Req />
+        </label>
+        <p className="t-small text-meta" style={{ marginBottom: 10 }}>
+          What do you see that feels stuck, broken, or missing? Is there
+          anything that keeps being a problem no matter what people try? A
+          sentence is fine. So is a page — there&rsquo;s no right format.
+        </p>
+        <textarea
+          id="observation"
+          rows={6}
+          value={observation}
+          onChange={(e) => setObservation(e.target.value)}
+          placeholder="Just tell us what you see."
+          style={{ ...fieldStyle, resize: "vertical" }}
+          required
+        />
+      </div>
+
+      {/* 2 — optional context */}
+      <fieldset style={{ border: 0, padding: 0, margin: "0 0 28px" }}>
+        <legend className="lbl" style={{ marginBottom: 6 }}>
+          What is your experience with this?{" "}
+          <span className="text-meta" style={{ fontWeight: 400 }}>
+            (optional)
+          </span>
+        </legend>
+        <div style={{ display: "grid", gap: 8, marginTop: 10 }}>
+          {STANDPOINTS.map((s) => {
+            const checked = standpoint.has(s);
+            return (
+              <label
+                key={s}
+                className="tappable"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "10px 12px",
+                  border: `1px solid ${checked ? "var(--teal)" : "var(--rule)"}`,
+                  borderRadius: "var(--r)",
+                  cursor: "pointer",
+                  background: checked ? "var(--teal-wash, rgba(0,0,0,0.02))" : "transparent",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggleStandpoint(s)}
+                  style={{ width: 18, height: 18, accentColor: "var(--teal)" }}
+                />
+                <span className="t-body">{STANDPOINT_LABELS[s]}</span>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* 3 — salience 1–5 */}
+      <fieldset style={{ border: 0, padding: 0, margin: "0 0 28px" }}>
+        <legend className="lbl" style={{ marginBottom: 10 }}>
+          How much does this matter to you personally?{" "}
+          <span className="text-meta" style={{ fontWeight: 400 }}>
+            (optional)
+          </span>
+        </legend>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {[1, 2, 3, 4, 5].map((n) => {
+            const active = salience === n;
+            return (
+              <button
+                key={n}
+                type="button"
+                aria-pressed={active}
+                onClick={() => setSalience(active ? null : n)}
+                style={{
+                  flex: "1 1 44px",
+                  minWidth: 44,
+                  padding: "12px 0",
+                  border: `1px solid ${active ? "var(--teal)" : "var(--rule)"}`,
+                  borderRadius: "var(--r)",
+                  background: active ? "var(--teal)" : "var(--white)",
+                  color: active ? "#fff" : "var(--ink)",
+                  font: "inherit",
+                  fontWeight: 600,
+                  cursor: "pointer",
+                  transition: "all 120ms",
+                }}
+              >
+                {n}
+              </button>
+            );
+          })}
+        </div>
+        <div
+          className="t-small text-meta"
+          style={{ display: "flex", justifyContent: "space-between", marginTop: 8, gap: 12 }}
+        >
+          <span>{SALIENCE_LOW}</span>
+          <span style={{ textAlign: "right" }}>{SALIENCE_HIGH}</span>
+        </div>
+      </fieldset>
+
+      {/* 4 — prior attempts */}
+      <div style={{ marginBottom: 32 }}>
+        <label className="lbl" htmlFor="prior" style={{ display: "block", marginBottom: 6 }}>
+          Has anyone tried to address this before?{" "}
+          <span className="text-meta" style={{ fontWeight: 400 }}>
+            (optional)
+          </span>
+        </label>
+        <p className="t-small text-meta" style={{ marginBottom: 10 }}>
+          Even if it didn&rsquo;t work — especially if it didn&rsquo;t work. What
+          happened?
+        </p>
+        <textarea
+          id="prior"
+          rows={3}
+          value={priorAttempts}
+          onChange={(e) => setPriorAttempts(e.target.value)}
+          style={{ ...fieldStyle, resize: "vertical" }}
+        />
+      </div>
+
+      {/* 5 — staying in touch (optional, opt-in) */}
+      <div
+        style={{
+          borderTop: "1px solid var(--rule)",
+          paddingTop: 24,
+          marginBottom: 28,
+        }}
+      >
+        <h3 className="t-h4" style={{ marginBottom: 4 }}>
+          Staying in touch{" "}
+          <span className="text-meta" style={{ fontWeight: 400, fontSize: "0.85em" }}>
+            (optional)
+          </span>
+        </h3>
+        <p className="t-small text-meta" style={{ marginBottom: 16 }}>
+          Your submission is anonymous unless you fill these in.
+        </p>
+
+        <label
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 10,
+            marginBottom: 16,
+            cursor: "pointer",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={contactable}
+            onChange={(e) => setContactable(e.target.checked)}
+            style={{ width: 18, height: 18, marginTop: 2, accentColor: "var(--teal)" }}
+          />
+          <span className="t-body">
+            I&rsquo;m open to being contacted by program participants.
+            <span className="text-meta" style={{ display: "block", fontSize: "0.9em", marginTop: 2 }}>
+              If participants use your observation, they may reach out with
+              follow-up questions or to acknowledge your contribution. Your
+              contact info is shared only with those participants.
+            </span>
+          </span>
+        </label>
+
+        <div style={{ display: "grid", gap: 14 }}>
+          <div>
+            <label className="lbl" htmlFor="name" style={{ display: "block", marginBottom: 6 }}>
+              Your name
+            </label>
+            <input
+              id="name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Priya Shah"
+              style={fieldStyle}
+            />
+          </div>
+          <div>
+            <label className="lbl" htmlFor="email" style={{ display: "block", marginBottom: 6 }}>
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              style={fieldStyle}
+            />
+          </div>
+          <div>
+            <label className="lbl" htmlFor="phone" style={{ display: "block", marginBottom: 6 }}>
+              Phone{" "}
+              <span className="text-meta" style={{ fontWeight: 400 }}>
+                (if you prefer call or text over email)
+              </span>
+            </label>
+            <input
+              id="phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              style={fieldStyle}
+            />
+          </div>
+        </div>
+
+        <label
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 10,
+            marginTop: 16,
+            cursor: "pointer",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={mentorInterest}
+            onChange={(e) => setMentorInterest(e.target.checked)}
+            style={{ width: 18, height: 18, marginTop: 2, accentColor: "var(--teal)" }}
+          />
+          <span className="t-body">
+            I&rsquo;m interested in volunteering as a mentor in the {domain} Build
+            Cycle.
+            <span className="text-meta" style={{ display: "block", fontSize: "0.9em", marginTop: 2 }}>
+              Please add your name and email above so we can reach you.
+            </span>
+          </span>
+        </label>
+      </div>
+
+      {/* 6 — required consent + submit */}
+      <div
+        style={{
+          borderTop: "1px solid var(--rule)",
+          paddingTop: 24,
+        }}
+      >
+        <label
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 10,
+            marginBottom: 20,
+            cursor: "pointer",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={consent}
+            onChange={(e) => setConsent(e.target.checked)}
+            style={{ width: 18, height: 18, marginTop: 2, accentColor: "var(--teal)" }}
+            aria-required
+          />
+          <span className="t-small">
+            <strong>
+              Consent to participation
+              <Req />
+            </strong>
+            <span style={{ display: "block", marginTop: 4 }} className="text-meta">
+              I have read and understood the above. I consent to my submission
+              being used by The Upskilling Labs in the development of public
+              projects and shared with program participants for research and
+              project-development purposes.
+            </span>
+          </span>
+        </label>
+
+        {error && (
+          <p
+            className="t-small"
+            role="alert"
+            style={{ color: "var(--red)", marginBottom: 12 }}
+          >
+            {error}
+          </p>
+        )}
+
+        <button
+          className="btn btn-teal btn-block btn-lg"
+          type="submit"
+          disabled={busy}
+        >
+          {busy ? "Submitting…" : "Submit observation"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/api/surveys/[slug]/responses/route.ts
+++ b/app/api/surveys/[slug]/responses/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { dbError } from "@/lib/api/errors";
+import { hashIp, requestIp, windowStart } from "@/lib/api/rate-limit";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { surveyResponseSchema } from "@/lib/validations/survey-response";
+
+// Field-survey observation intake (SENSEMAKING_FLOW.md §3) — the public,
+// account-free submission that replaces the Civics & Elections Google Form.
+// Gate-free: it's a form + storage, no in-app LLM.
+//
+// - Signed-in members are bound to their participant_id (from the session,
+//   never the body); their name/email default from the account but the form
+//   may override the display fields.
+// - Anonymous visitors submit freely when the survey allows it — the nullable
+//   participant_id is the anonymous path. Per-IP window cap guards abuse,
+//   mirroring the event RSVP + story endpoints (lib/api/rate-limit).
+// Every response is retained (moderation_status='pending'); curation is a
+// later temporal overlay, never a delete (owner decision 2026-07-05).
+const ANON_SUBMIT_LIMIT = 10;
+const ANON_SUBMIT_WINDOW_MS = 60 * 60 * 1000;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const supabase = createServiceClient();
+
+  const { data: survey } = await supabase
+    .from("field_surveys")
+    .select("id, allow_anonymous, consent_version")
+    .eq("share_slug", slug)
+    .eq("status", "open")
+    .maybeSingle();
+  if (!survey) {
+    return NextResponse.json(
+      { error: "This survey isn't open." },
+      { status: 404 }
+    );
+  }
+
+  // Member path: session identity binds participant_id (trusted from session).
+  let participantId: number | null = null;
+  try {
+    const authClient = await createClient();
+    const {
+      data: { user },
+    } = await authClient.auth.getUser();
+    if (user) {
+      const { data: participant } = await supabase
+        .from("participants")
+        .select("id")
+        .eq("auth_user_id", user.id)
+        .maybeSingle();
+      if (participant) participantId = participant.id;
+    }
+  } catch {
+    // Signed-out or auth unavailable — fall through to the anonymous path.
+  }
+
+  if (!participantId && !survey.allow_anonymous) {
+    return NextResponse.json(
+      { error: "Please sign in to contribute to this survey." },
+      { status: 403 }
+    );
+  }
+
+  const ipHash = hashIp(requestIp(request));
+
+  // Anonymous path: per-IP window cap before accepting the write.
+  if (!participantId) {
+    const { count } = await supabase
+      .from("survey_responses")
+      .select("id", { count: "exact", head: true })
+      .eq("ip_hash", ipHash)
+      .gte("created_at", windowStart(ANON_SUBMIT_WINDOW_MS));
+    if ((count ?? 0) >= ANON_SUBMIT_LIMIT) {
+      return NextResponse.json(
+        { error: "Thanks — you've submitted a few already. Try again later." },
+        { status: 429 }
+      );
+    }
+  }
+
+  const body = await parseBody(request, surveyResponseSchema);
+  if (isErrorResponse(body)) return body;
+
+  const email = body.submitter_email ? body.submitter_email.toLowerCase() : null;
+  const { error } = await supabase.from("survey_responses").insert({
+    field_survey_id: survey.id,
+    participant_id: participantId,
+    observation: body.observation,
+    standpoint: body.standpoint ?? [],
+    salience: body.salience ?? null,
+    prior_attempts: body.prior_attempts || null,
+    consent_participation: body.consent_participation,
+    consent_version: survey.consent_version,
+    contactable: body.contactable ?? false,
+    submitter_name: body.submitter_name || null,
+    submitter_email: email,
+    submitter_phone: body.submitter_phone || null,
+    mentor_interest: body.mentor_interest ?? false,
+    ip_hash: ipHash,
+  });
+  if (error) return dbError(error, "survey-response");
+
+  return NextResponse.json({ submitted: true }, { status: 201 });
+}

--- a/lib/content/surveys.ts
+++ b/lib/content/surveys.ts
@@ -1,0 +1,34 @@
+import { createServiceClient } from "@/lib/supabase/server";
+
+// Field-survey reads (SENSEMAKING_FLOW.md §3). The public /survey/[slug] page
+// renders the instrument; responses are written through the service-role API.
+
+export interface FieldSurvey {
+  id: number;
+  cycle_id: number | null;
+  sector_id: number | null;
+  title: string;
+  problem_domain: string | null;
+  about: string | null;
+  share_slug: string;
+  status: "draft" | "open" | "closed";
+  allow_anonymous: boolean;
+  consent_version: string;
+}
+
+const SURVEY_COLUMNS =
+  "id, cycle_id, sector_id, title, problem_domain, about, share_slug, status, allow_anonymous, consent_version";
+
+/** An open survey by its public share slug, or null. */
+export async function getOpenFieldSurvey(
+  slug: string
+): Promise<FieldSurvey | null> {
+  const supabase = createServiceClient();
+  const { data } = await supabase
+    .from("field_surveys")
+    .select(SURVEY_COLUMNS)
+    .eq("share_slug", slug)
+    .eq("status", "open")
+    .maybeSingle();
+  return (data as FieldSurvey) ?? null;
+}

--- a/lib/validations/survey-response.ts
+++ b/lib/validations/survey-response.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+// Field-survey observation submission (SENSEMAKING_FLOW.md §3). Public and
+// anon-capable: only the observation body and participation consent are
+// required — everything else (standpoint, salience, prior attempts, contact)
+// is optional, mirroring the Google Form this replaces. Enforced server-side
+// by POST /api/surveys/[slug]/responses; consent_version is stamped from the
+// field_surveys row, never trusted from the client.
+
+// Structured standpoints — feed the coverage/diversity signal, never a
+// credibility weight (ORTELIUS_NORTHSTAR.md §6). Values are stable keys; the
+// form owns their display labels.
+export const STANDPOINTS = [
+  "work_in_field",
+  "affected",
+  "tried_to_fix",
+  "research",
+  "pay_attention",
+  "other",
+] as const;
+
+export const surveyResponseSchema = z.object({
+  observation: z
+    .string()
+    .trim()
+    .min(1, "Tell us what you're seeing")
+    .max(8000, "That's a lot — trim it down a little"),
+  // Required participation consent gates the submission — must be explicitly true.
+  consent_participation: z.literal(true, {
+    error: "Please confirm the consent to continue",
+  }),
+  standpoint: z.array(z.enum(STANDPOINTS)).max(6).optional().default([]),
+  salience: z.number().int().min(1).max(5).nullable().optional(),
+  prior_attempts: z.string().trim().max(4000).optional().or(z.literal("")),
+  contactable: z.boolean().optional().default(false),
+  mentor_interest: z.boolean().optional().default(false),
+  submitter_name: z.string().trim().max(200).optional().or(z.literal("")),
+  submitter_email: z
+    .string()
+    .trim()
+    .email("That email doesn't look right")
+    .max(320)
+    .optional()
+    .or(z.literal("")),
+  submitter_phone: z.string().trim().max(40).optional().or(z.literal("")),
+});
+
+export type SurveyResponseInput = z.infer<typeof surveyResponseSchema>;

--- a/supabase/migrations/00053_field_survey_intake.sql
+++ b/supabase/migrations/00053_field_survey_intake.sql
@@ -1,0 +1,113 @@
+-- 00053_field_survey_intake.sql
+-- SENSEMAKING_FLOW.md §3 (the bedrock) + ORTELIUS_KNOWLEDGE_GRAPH.md §3a — the
+-- field-survey intake: the first buildable, gate-free slice of the Data
+-- Sensemaker. Replaces the Civics & Elections Google Form with a public,
+-- account-free submission surface at /survey/[share_slug], and lays the first
+-- Ortelius provenance node (`survey_responses`) — every observation is a node,
+-- curation is a later temporal overlay (owner decision 2026-07-05).
+--
+-- Two tables:
+--   field_surveys    — the instrument (one row per sector/cycle problem domain)
+--   survey_responses — the observations (the evidence bedrock; anon-capable)
+--
+-- Governance: gate-free. Collecting consented observations is a form + storage;
+-- no in-app LLM. The Ortelius envelope columns land day one so downstream
+-- (extraction, canvas, asset_links) is additive, never a rewrite: `source_url`
+-- (the evidence-producer gap, ORTELIUS §5 gap #6), `consent_version`,
+-- `moderation_status`, `schema_version` (ORTELIUS §5 gap #12 — versioned from
+-- day one), and the nullable `participant_id` anonymous path.
+--
+-- Idempotent + re-runnable.
+--
+-- DOWN:
+--   DROP TABLE IF EXISTS survey_responses;
+--   DROP TABLE IF EXISTS field_surveys;
+
+-- ── field_surveys — the instrument ─────────────────────────────────────────
+-- One row per sector/cycle problem domain. `about` holds the survey-specific
+-- lede; the boilerplate "What is the Labs / where do insights go" copy lives in
+-- the page. Public reads are gated on status='open'; writes are service-role.
+CREATE TABLE IF NOT EXISTS field_surveys (
+  id              SERIAL PRIMARY KEY,
+  cycle_id        INT REFERENCES cycles(id),          -- nullable: survey can precede its cycle
+  sector_id       INT REFERENCES sectors(id),         -- nullable: the durable commons home
+  title           VARCHAR(200) NOT NULL,
+  problem_domain  VARCHAR(200),                        -- e.g. "Civics & Elections"
+  about           TEXT,                                -- survey-specific lede copy
+  share_slug      VARCHAR(200) UNIQUE NOT NULL,        -- /survey/{share_slug}
+  status          VARCHAR(20) NOT NULL DEFAULT 'draft'
+                    CHECK (status IN ('draft', 'open', 'closed')),
+  allow_anonymous BOOLEAN NOT NULL DEFAULT true,
+  consent_version VARCHAR(20) NOT NULL DEFAULT 'civics-2026-07',
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_field_surveys_status ON field_surveys(status);
+CREATE INDEX IF NOT EXISTS idx_field_surveys_sector ON field_surveys(sector_id);
+
+DROP TRIGGER IF EXISTS trg_field_surveys_updated_at ON field_surveys;
+CREATE TRIGGER trg_field_surveys_updated_at BEFORE UPDATE ON field_surveys
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ── survey_responses — the observations (the evidence bedrock) ──────────────
+-- Nullable `participant_id` is the load-bearing anonymous-public path
+-- (/s/[share_slug]). Every response is retained as a node; `moderation_status`
+-- and later swipe/second signals are a temporal overlay, never a delete.
+CREATE TABLE IF NOT EXISTS survey_responses (
+  id                    BIGSERIAL PRIMARY KEY,
+  field_survey_id       INT NOT NULL REFERENCES field_surveys(id) ON DELETE CASCADE,
+  participant_id        INT REFERENCES participants(id),  -- NULL = anonymous public submit
+  -- the observation body — the source every future `extract` derives from
+  observation           TEXT NOT NULL,
+  standpoint            TEXT[] NOT NULL DEFAULT '{}',       -- multi-select; feeds coverage/diversity
+  salience              SMALLINT CHECK (salience BETWEEN 1 AND 5),  -- 1–5 intensity, nullable
+  prior_attempts        TEXT,                              -- archaeology, nullable
+  -- consent + contact (two distinct consents; SENSEMAKING_FLOW §3)
+  consent_participation BOOLEAN NOT NULL,                  -- required; gates submit (enforced in API)
+  consent_version       VARCHAR(20) NOT NULL,
+  contactable           BOOLEAN NOT NULL DEFAULT false,    -- separate, optional contact consent
+  submitter_name        VARCHAR(200),
+  submitter_email       VARCHAR(320),
+  submitter_phone       VARCHAR(40),
+  mentor_interest       BOOLEAN NOT NULL DEFAULT false,    -- recruiting side-channel
+  -- Ortelius groundwork (additive later, never a rewrite)
+  source_url            TEXT,                              -- evidence producer (uploaded-source origin)
+  moderation_status     VARCHAR(20) NOT NULL DEFAULT 'pending'
+                          CHECK (moderation_status IN ('pending', 'approved', 'rejected')),
+  schema_version        INT NOT NULL DEFAULT 1,
+  ip_hash               VARCHAR(64),                       -- sha256(ip) — per-IP submit throttle
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_survey_responses_survey ON survey_responses(field_survey_id);
+CREATE INDEX IF NOT EXISTS idx_survey_responses_ip ON survey_responses(ip_hash, created_at);
+CREATE INDEX IF NOT EXISTS idx_survey_responses_moderation ON survey_responses(moderation_status);
+CREATE INDEX IF NOT EXISTS idx_survey_responses_participant ON survey_responses(participant_id);
+
+-- ── RLS ────────────────────────────────────────────────────────────────────
+-- field_surveys: public SELECT of open surveys (the page reads the instrument
+-- anonymously). survey_responses: no public policy — every write goes through
+-- the service-role API route (which forces moderation_status='pending' and
+-- stamps ip_hash), and reads stay service-role until a consented atlas surface
+-- ships. Mirrors the spotlights (00051) anon-SELECT-published posture.
+ALTER TABLE field_surveys ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS field_surveys_select_open ON field_surveys;
+CREATE POLICY field_surveys_select_open ON field_surveys FOR SELECT
+  USING (status = 'open');
+
+ALTER TABLE survey_responses ENABLE ROW LEVEL SECURITY;
+-- (no policy: service-role only — writes via /api/surveys/[slug]/responses)
+
+-- ── Seed the Civics & Elections instrument ─────────────────────────────────
+-- The one config row the /survey/civics page renders. Idempotent.
+INSERT INTO field_surveys (title, problem_domain, about, share_slug, status, allow_anonymous)
+VALUES (
+  'Civics & Elections: Field Survey',
+  'Civics & Elections',
+  'Observations from people closest to a problem are where the best projects begin. The Upskilling Labs collects observations from workers, researchers, community members, and the general public to identify the problems worth tackling in each cycle.',
+  'civics',
+  'open',
+  true
+)
+ON CONFLICT (share_slug) DO NOTHING;


### PR DESCRIPTION
## What

The first buildable, gate-free slice of the Data Sensemaker (`docs/SENSEMAKING_FLOW.md` §3): a public, account-free field survey at `/survey/civics` that replaces the Civics & Elections Google Form and seeds the first Ortelius provenance node. No in-app LLM — it's a form + storage.

## Changes

- **migration `00053_field_survey_intake.sql`** — `field_surveys` (the instrument, seeded idempotently for Civics & Elections at `share_slug='civics'`, `status='open'`) + `survey_responses` (the observation bedrock, anon-capable via nullable `participant_id`). Ortelius groundwork columns land day one so extraction/canvas/`asset_links` build additively, never a rewrite: `source_url`, `consent_version`, `moderation_status`, `schema_version`.
- **`POST /api/surveys/[slug]/responses`** — service-role write; signed-in members bind `participant_id` from the session; the anonymous path is per-IP throttled (`lib/api/rate-limit.ts`, shared with RSVP/stories). Every response retained (`moderation_status='pending'`); curation is a later temporal overlay, never a delete (owner decision 2026-07-05).
- **`/survey/[slug]` page + form** — onboarding-minded ordering: leads with the observation, tiers the optional context (experience / salience 1–5 / prior attempts / contact), required participation consent as the last gate. Anonymous by default; contact fields opt-in.
- **`SCHEMA.md`** — new Data Sensemaker ERD + table-summary rows.
- RLS: `field_surveys` anon-SELECT-`open`; `survey_responses` service-role only.

## Verify

- [x] `npm run lint` passes
- [x] `npm run test` passes (39/39)
- [x] `npm run build` passes — both `/survey/[slug]` and `/api/surveys/[slug]/responses` compile under Next 16

Not yet runtime-driven: no Supabase was reachable in the build environment, so the migration is static-checked only — see Database.

## Database

- [x] Migration `00053_field_survey_intake.sql` added (new number after `00052`; `SCHEMA.md` updated). **Prod/dev migrations are applied by a maintainer** — `/survey/civics` will 404 until `00053` is applied to the target Supabase (it seeds the one `field_surveys` config row the page reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d)_