### PR TITLE
fix(sensemaker): allow public /survey path through the auth proxy

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -57,6 +57,7 @@ export async function proxy(request: NextRequest) {
       "/about",
       "/build-cycles",
       "/stories", // public Upskiller Spotlights — browses free, no auth
+      "/survey", // public field survey — account-free, anonymous submit
     ];
     const isPublicPath =
       request.nextUrl.pathname === "/" ||


### PR DESCRIPTION
## What

Follow-up to #183. The field survey is account-free, but `proxy.ts`'s `publicPaths` allowlist didn't include `/survey` — so anonymous visitors to `/survey/civics` were redirected to `/login` (the same gap `/stories` hit in #175). Without this, the "public" survey isn't actually reachable signed-out.

## Changes

- `proxy.ts`: add `/survey` to `publicPaths`, alongside `/stories` and the other public content routes.

## Verify

- [x] `npm run lint` passes (`proxy.ts`)
- [x] One-line allowlist addition mirroring the existing `/stories` entry; no behavior change for authed users.

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d)_