### PR TITLE
redesign(events): simplify preview cards to city, drop location pill, clamp title

### DIFF
--- a/app/components/content/teasers.tsx
+++ b/app/components/content/teasers.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 import Orb from "@/app/components/chrome/orb";
-import { fmtDate, CONTENT_TYPE_LABEL } from "@/lib/content/format";
+import { fmtDate, cityOf, CONTENT_TYPE_LABEL } from "@/lib/content/format";
 import type { EventRow, ResourceRow, MetroRow } from "@/lib/content/queries";
 
 /* Teaser cards — every card is the metadata for its real page (owner
@@ -62,17 +62,19 @@ export function EventTeaser({
       <MediaFrame
         img={e.img}
         grad={e.grad}
-        tag={e.kind || (e.location_type === "virtual" ? "Virtual" : "In person")}
+        tag={e.kind}
         square
         corner={corner}
       />
       <div className="card-body">
         <div className="lbl lbl-teal">{fmtDate(e.start_at)}</div>
-        <div className="t-h4" style={{ margin: "6px 0 4px" }}>
+        <div className="t-h4 card-title" style={{ margin: "6px 0 4px" }}>
           {e.anchor ? "✦ " : ""}
           {e.name}
         </div>
-        <p className="t-small">{e.location_name}</p>
+        <p className="t-small">
+          {e.location_type === "virtual" ? "Virtual" : cityOf(e.location_name)}
+        </p>
       </div>
     </Link>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -240,6 +240,7 @@ dialog::backdrop {
   }
   .lcard { background: var(--white); border: 1px solid var(--rule); border-radius: var(--r); }
   .card-body { padding: 18px 20px; }
+  .card-title { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
   .card-row { display: flex; align-items: center; gap: 10px; }
   .cards { display: grid; grid-template-columns: 1fr; gap: 16px; }
   .tappable:focus-visible { outline: 2px solid var(--teal); outline-offset: 2px; }

--- a/lib/content/format.ts
+++ b/lib/content/format.ts
@@ -29,6 +29,17 @@ export function fmtTime(iso: string): string {
   return `${h}${m ? ":" + String(m).padStart(2, "0") : ""} ${ap}`;
 }
 
+/** "…, Washington, DC 20001, USA" → "Washington". Falls back to the
+    original string if it can't find a state+ZIP segment. */
+export function cityOf(locationName: string | null): string {
+  if (!locationName) return "";
+  const parts = locationName.split(",").map((s) => s.trim()).filter(Boolean);
+  // The segment right before "ST ZIP" (e.g. "DC 20001") is the city.
+  const stateZipIdx = parts.findIndex((p) => /^[A-Z]{2}\s+\d{5}/.test(p));
+  if (stateZipIdx > 0) return parts[stateZipIdx - 1];
+  return locationName; // unparseable → keep current behavior
+}
+
 export const CONTENT_TYPE_LABEL: Record<string, string> = {
   guide: "Guide",
   recording: "Recording",


### PR DESCRIPTION
## What

Cleans up the event **preview cards** so they read as tidy teasers instead of dumping the full address and an always-on location pill.

## Changes

- Show just the **city** below the image (parsed from `location_name` via a new `cityOf` helper in `lib/content/format.ts`), or **"Virtual"** for virtual events.
- **Remove the Virtual / In person pill** (it was effectively always present since `kind` is null for every event today). The `kind` pill is kept for future use.
- **Clamp the event title to 2 lines** with an ellipsis (new `.card-title` class, following the existing `.story-quote` line-clamp pattern) so card heights stay even.
- No DB/type changes — city is derived at render time; other teaser cards are untouched.

## Verify

- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (39/39)
- [x] `npm run build` passes
- Spot-checked `cityOf` against live data shapes: `"…, Washington, DC 20001, USA"` → `Washington`, `"Microsoft Innovation Hub, …, Arlington, VA 22209"` → `Arlington`; virtual events short-circuit to "Virtual".

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RedhbNtdn1DF1z2aQeCbr4)_