### PR TITLE
feat(survey): full-width AIDA landing with live response counter

### DIFF
--- a/app/(survey)/survey/[slug]/page.tsx
+++ b/app/(survey)/survey/[slug]/page.tsx
@@ -1,5 +1,9 @@
 import { notFound } from "next/navigation";
-import { getOpenFieldSurvey } from "@/lib/content/surveys";
+import {
+  getOpenFieldSurvey,
+  getFieldSurveyResponseCount,
+  RESPONSE_GOAL,
+} from "@/lib/content/surveys";
 import SurveyFlow from "./survey-flow";
 
 /* The public field survey (SENSEMAKING_FLOW.md §3) — account-free, anonymous by
@@ -34,11 +38,15 @@ export default async function SurveyPage({
   const survey = await getOpenFieldSurvey(slug);
   if (!survey) notFound();
 
+  const responseCount = await getFieldSurveyResponseCount(survey.id);
+
   return (
     <SurveyFlow
       slug={survey.share_slug}
       domain={survey.problem_domain ?? "the field"}
       about={survey.about}
+      responseCount={responseCount}
+      responseGoal={RESPONSE_GOAL}
     />
   );
 }

--- a/app/(survey)/survey/[slug]/survey-flow.tsx
+++ b/app/(survey)/survey/[slug]/survey-flow.tsx
@@ -110,12 +110,16 @@ export default function SurveyFlow({
   slug,
   domain,
   about,
+  responseCount,
+  responseGoal,
 }: {
   slug: string;
   domain: string;
   about: string | null;
+  responseCount: number;
+  responseGoal: number;
 }) {
-  const [stage, setStage] = useState<"welcome" | "flow" | "done">("welcome");
+  const [stage, setStage] = useState<"landing" | "flow" | "done">("landing");
   // Bumping this remounts FlowScreen with a fresh answer set ("Share another").
   const [runKey, setRunKey] = useState(0);
   const steps = useMemo(() => surveySteps(domain), [domain]);
@@ -155,9 +159,15 @@ export default function SurveyFlow({
     return json?.error || "Something went wrong — try again.";
   };
 
-  if (stage === "welcome") {
+  if (stage === "landing") {
     return (
-      <Welcome domain={domain} about={about} onBegin={() => setStage("flow")} />
+      <Landing
+        domain={domain}
+        about={about}
+        count={responseCount}
+        goal={responseGoal}
+        onBegin={() => setStage("flow")}
+      />
     );
   }
 
@@ -181,60 +191,174 @@ export default function SurveyFlow({
       finalLabel="Submit observation"
       submittingLabel="Submitting…"
       onComplete={submit}
-      onExit={() => setStage("welcome")}
+      onExit={() => setStage("landing")}
     />
   );
 }
 
-/* ── Welcome cover — branded orb hero, then Begin ── */
-function Welcome({
+/* ── Landing — the full-width, responsive AIDA entry that fronts the flow.
+   A scrolling content page (NOT the .onboard sheet, which locks scroll):
+   Attention hero (+ live counter) → Interest → Desire → Action, then Begin
+   drops into the one-question flow. Copy is DRAFT (owner-approvable, ported
+   from the prototype byte-for-byte per DESIGN_INTENT §1). ── */
+function Landing({
   domain,
   about,
+  count,
+  goal,
   onBegin,
 }: {
   domain: string;
   about: string | null;
+  count: number;
+  goal: number;
   onBegin: () => void;
 }) {
   return (
-    <div className="view light onboard s-paper">
-      <div className="sheet">
-        <div className="topbar">
-          <span className="lbl">The Upskilling Labs</span>
+    <div className="flex min-h-screen flex-col">
+      {/* Attention — full-bleed hero */}
+      <section className="s-cover grain on-dark landing-hero">
+        <span className="landing-orb" aria-hidden>
+          <Orb />
+        </span>
+        <div className="landing-scrim" aria-hidden />
+        <div className="container landing-hero-inner">
+          <div className="landing-col">
+            <div className="lbl" style={{ marginBottom: 28 }}>
+              The Upskilling Labs
+            </div>
+            <div className="lbl lbl-teal" style={{ marginBottom: 16 }}>
+              Field survey · {domain}
+            </div>
+            <h1 className="t-display" style={{ marginBottom: 18 }}>
+              You see something the data misses.
+            </h1>
+            <p className="t-lede" style={{ marginBottom: 4, maxWidth: "40ch" }}>
+              {about ??
+                `You live in a field. You notice what's stuck, what's broken, what keeps coming back. Tell us — that's where the next ${domain} Build Cycle begins.`}
+            </p>
+            <GoalCounter count={count} goal={goal} />
+            <button
+              className="btn btn-red btn-lg landing-cta"
+              onClick={onBegin}
+            >
+              Share what you&rsquo;re seeing →
+            </button>
+            <p className="t-small" style={{ marginTop: 16 }}>
+              ~2 minutes · no account needed · anonymous by default
+            </p>
+          </div>
         </div>
-        <div className="vscroll pad" style={{ paddingTop: 8 }}>
-          <div className="media m-teal" style={{ marginBottom: 24 }}>
-            <span className="m-tag">{domain}</span>
-            <Orb />
+      </section>
+
+      {/* Interest — why an observation matters */}
+      <section className="section s-white">
+        <div className="container" style={{ maxWidth: 760 }}>
+          <div className="lbl lbl-teal" style={{ marginBottom: 12 }}>
+            Why it matters
           </div>
-          <div className="lbl lbl-teal" style={{ marginBottom: 14 }}>
-            Field survey · ~2 minutes
-          </div>
-          <h1 className="t-h1" style={{ marginBottom: 14 }}>
-            Tell us what you&rsquo;re seeing.
-          </h1>
-          <p className="t-lede" style={{ marginBottom: 24 }}>
-            {about ??
-              "Observations from people closest to a problem are where the best projects begin."}
+          <h2 className="t-h2" style={{ marginBottom: 16 }}>
+            The best projects start with what someone noticed.
+          </h2>
+          <p className="t-lede" style={{ margin: 0 }}>
+            Not a report. Not a headline. A person who was close enough to see
+            what wasn&rsquo;t working. Your observation is that starting point —
+            weighed by who&rsquo;s speaking, and read by the people deciding what
+            to build next.
           </p>
-          <ul className="survey-intro-list">
-            <li>
-              Your observation joins an open, participant-built insights
-              repository that shapes the problems the next {domain} Build Cycle
-              takes on — everything built from it is open-source.
-            </li>
-            <li>
-              Answer only what you want. Most questions are optional and you can
-              skip them.
-            </li>
-            <li>Voluntary and anonymous — contact info is yours to share or not.</li>
-          </ul>
         </div>
-        <div className="actionbar light-bar">
-          <button className="btn btn-teal btn-block" onClick={onBegin}>
-            Begin
+      </section>
+
+      {/* Desire — where it goes */}
+      <section className="section s-white">
+        <div className="container" style={{ maxWidth: 760 }}>
+          <div className="lbl lbl-teal" style={{ marginBottom: 12 }}>
+            Where it goes
+          </div>
+          <h2 className="t-h2" style={{ marginBottom: 24 }}>
+            Your observation joins an open commons.
+          </h2>
+          <div className="cards two">
+            <div className="lcard" style={{ padding: 24 }}>
+              <h3 className="t-h4" style={{ marginBottom: 6 }}>
+                Open by default
+              </h3>
+              <p className="t-body text-meta" style={{ margin: 0 }}>
+                Everything built from these observations is open-source — free
+                for anyone to use, including you.
+              </p>
+            </div>
+            <div className="lcard" style={{ padding: 24 }}>
+              <h3 className="t-h4" style={{ marginBottom: 6 }}>
+                One of {goal.toLocaleString()}
+              </h3>
+              <p className="t-body text-meta" style={{ margin: 0 }}>
+                We&rsquo;re gathering {goal.toLocaleString()} field observations
+                to choose the problems this cycle takes on. Add yours.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Action — the closing ask */}
+      <section
+        className="s-cover grain on-dark"
+        style={{ padding: "72px 0", textAlign: "center" }}
+      >
+        <div className="container" style={{ maxWidth: 640 }}>
+          <h2 className="t-h2" style={{ marginBottom: 22 }}>
+            Tell us what you&rsquo;re seeing.
+          </h2>
+          <button
+            className="btn btn-red btn-lg landing-cta"
+            onClick={onBegin}
+          >
+            Share your observation →
           </button>
+          <p className="t-small" style={{ marginTop: 16 }}>
+            Voluntary and anonymous. Answer only what you want.
+          </p>
         </div>
+      </section>
+    </div>
+  );
+}
+
+/* The live count toward the campaign goal — real number, no baseline. */
+function GoalCounter({ count, goal }: { count: number; goal: number }) {
+  const pct = goal > 0 ? Math.min(100, Math.round((count / goal) * 100)) : 0;
+  const reached = count >= goal;
+  const label = reached
+    ? `Goal reached — ${count.toLocaleString()} and counting`
+    : count === 0
+      ? "Be one of the first"
+      : `of ${goal.toLocaleString()} observations`;
+
+  return (
+    <div className="landing-goal">
+      <span
+        className="lbl lbl-teal"
+        style={{ display: "inline-flex", alignItems: "center", gap: 8 }}
+      >
+        <span className="live-dot" aria-hidden />
+        Live count
+      </span>
+      <div className="t-stat tabular-nums" style={{ marginTop: 8 }}>
+        {count.toLocaleString()}
+      </div>
+      <div className="lbl" style={{ marginTop: 4 }}>
+        {label}
+      </div>
+      <div
+        className="goal-bar"
+        role="progressbar"
+        aria-valuenow={Math.min(count, goal)}
+        aria-valuemin={0}
+        aria-valuemax={goal}
+        aria-label={`${count} of ${goal} observations collected`}
+      >
+        <div className="goal-fill" style={{ width: `${pct}%` }} />
       </div>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -371,6 +371,21 @@ dialog::backdrop {
   .survey-intro-list li::before { content: ""; position: absolute; left: 3px; top: 8px; width: 6px; height: 6px; border-radius: 50%; background: var(--teal); }
   .survey-join { border: 1px solid var(--tint-edge); background: var(--tint); border-radius: var(--r); padding: 20px; }
 
+  /* ── field-survey landing (full-width AIDA entry) ── */
+  .landing-hero { position: relative; overflow: hidden; isolation: isolate; }
+  .landing-orb { position: absolute; right: -70px; bottom: -100px; width: 420px; height: 420px; opacity: 0.4; pointer-events: none; z-index: 0; }
+  .landing-orb > .m-orb { display: block; width: 100%; height: 100%; }
+  .landing-scrim { position: absolute; inset: 0; z-index: 0; pointer-events: none; background: radial-gradient(130% 110% at 85% 100%, transparent 35%, rgba(0, 20, 27, 0.55) 82%); }
+  .landing-hero-inner { position: relative; z-index: 1; padding-top: 64px; padding-bottom: 76px; }
+  .landing-col { max-width: 720px; }
+  .landing-goal { margin: 28px 0 32px; }
+  .landing-cta { width: 100%; }
+  .goal-bar { width: 100%; max-width: 440px; height: 8px; border-radius: var(--r); background: rgba(255, 255, 255, 0.14); overflow: hidden; margin-top: 14px; }
+  .goal-fill { height: 100%; border-radius: inherit; background: var(--teal); transition: width 0.4s cubic-bezier(0.2, 0.7, 0.1, 1); }
+  @media (min-width: 640px) { .landing-cta { width: auto; } }
+  @media (min-width: 1024px) { .landing-hero-inner { padding-top: 100px; padding-bottom: 112px; } }
+  @media (max-width: 640px) { .landing-orb { width: 260px; height: 260px; right: -50px; bottom: -60px; opacity: 0.3; } }
+
   /* ── google ── */
   .google-btn { display: flex; align-items: center; justify-content: center; gap: 12px; padding: 16px; border-radius: var(--r); background: var(--ink); color: #fff; font-weight: 600; font-size: 15px; border: none; cursor: pointer; width: 100%; }
   .google-btn:active { transform: scale(0.98); }

--- a/lib/content/surveys.ts
+++ b/lib/content/surveys.ts
@@ -32,3 +32,25 @@ export async function getOpenFieldSurvey(
     .maybeSingle();
   return (data as FieldSurvey) ?? null;
 }
+
+// The campaign target the landing counter counts toward — a fixed number, not
+// per-survey config (promote to a field_surveys column if that ever changes).
+export const RESPONSE_GOAL = 1000;
+
+/**
+ * How many observations a field survey has collected — the live count the
+ * landing shows against RESPONSE_GOAL. Excludes moderated-out (rejected) rows,
+ * so it reads as real observations, not spam. Index-backed by
+ * idx_survey_responses_survey; cheap under the page's force-dynamic render.
+ */
+export async function getFieldSurveyResponseCount(
+  surveyId: number
+): Promise<number> {
+  const supabase = createServiceClient();
+  const { count } = await supabase
+    .from("survey_responses")
+    .select("id", { count: "exact", head: true })
+    .eq("field_survey_id", surveyId)
+    .neq("moderation_status", "rejected");
+  return count ?? 0;
+}


### PR DESCRIPTION
## What

Replaces the survey's narrow ~560px centered welcome sheet with a **full-width, responsive landing** that explains what the field survey is for and why it matters (AIDA, subtly; Red Antler voice), and shows a **live count of observations collected toward a goal of 1,000**. The CTA drops into the **unchanged** one-question flow.

## Changes

- **`survey-flow.tsx`** — replace `Welcome` with a full-width `Landing`: **Attention** hero (big `t-display` headline + live `GoalCounter` + red CTA) → **Interest** (why an observation matters) → **Desire** (`.cards two` — open commons / one of 1,000) → **Action** bookend. Built entirely from the existing full-bleed section system (`s-cover grain on-dark`, `section`/`container`, `t-display`/`t-stat`, the orb behind a scrim). Stage machine renamed `welcome`→`landing`; **`flow`, `done`, `FlowScreen`, and `submit` untouched.**
- **Live counter** — real count via new `getFieldSurveyResponseCount` (excludes `rejected`) against `RESPONSE_GOAL = 1000` (a constant — no migration). `page.tsx` is already `force-dynamic`, so it re-reads per request: live, no client polling, **no fake baseline** (the voice states numbers exactly). Edge states handled: `0` → "Be one of the first"; `≥ goal` → clamp + "and counting".
- **`globals.css`** — only new CSS is the landing hero/orb/scrim helpers + `.goal-bar`/`.goal-fill`; everything else reuses existing tokens.
- **Responsive** — token scaling (`t-display` 44→76, `t-stat` 64→88, `--pad`, `.section`), CTA block→auto ≥640, orb opacity drop on small screens.

**Copy is DRAFT / owner-approvable** — final copy is authored in the prototype and ported byte-for-byte (`DESIGN_INTENT.md §1`).

## Verify

- [x] `npm run lint` passes
- [x] `npm run test` passes (39/39)
- [x] `npm run build` passes
- [ ] Runtime drive on the **Vercel preview** (OLOS-dev has migration `00053`): `/survey/civics` → full-width landing renders (hero, live counter + bar, CTA) → **Begin** → unchanged one-question flow → submit → unchanged Done. Check the `count === 0` state and responsive at 360/768/1024/1440. *(Couldn't drive locally — no Supabase in the build env.)*

## Database

- [x] No schema change — new read query only; the POST payload and `survey_responses` table are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d)_