### PR TITLE
fix(survey): use the real orb image, not the SVG stand-in

### DIFF
--- a/app/(survey)/survey/[slug]/survey-flow.tsx
+++ b/app/(survey)/survey/[slug]/survey-flow.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import Orb from "@/app/components/chrome/orb";
 import {
   FlowScreen,
   type FlowStep,
@@ -218,9 +217,13 @@ function Landing({
     <div className="flex min-h-screen flex-col">
       {/* Attention — full-bleed hero */}
       <section className="s-cover grain on-dark landing-hero">
-        <span className="landing-orb" aria-hidden>
-          <Orb />
-        </span>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          className="landing-orb"
+          src="/assets/orb-mark.png"
+          alt=""
+          aria-hidden
+        />
         <div className="landing-scrim" aria-hidden />
         <div className="container landing-hero-inner">
           <div className="landing-col">
@@ -377,9 +380,21 @@ function Done({
       <div className="sheet">
         <div className="topbar" />
         <div className="vscroll pad" style={{ paddingTop: 8 }}>
-          <div className="media m-teal" style={{ marginBottom: 24 }}>
+          <div className="media" style={{ marginBottom: 24 }}>
             <span className="m-tag">Received ✓</span>
-            <Orb />
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/assets/orb-mark.png"
+              alt=""
+              aria-hidden
+              style={{
+                position: "absolute",
+                inset: 0,
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+              }}
+            />
           </div>
           <div className="lbl lbl-teal" style={{ marginBottom: 14 }}>
             Thank you

--- a/app/globals.css
+++ b/app/globals.css
@@ -373,8 +373,10 @@ dialog::backdrop {
 
   /* ── field-survey landing (full-width AIDA entry) ── */
   .landing-hero { position: relative; overflow: hidden; isolation: isolate; }
-  .landing-orb { position: absolute; right: -70px; bottom: -100px; width: 420px; height: 420px; opacity: 0.4; pointer-events: none; z-index: 0; }
-  .landing-orb > .m-orb { display: block; width: 100%; height: 100%; }
+  /* The real orb (public/assets/orb-mark.png) ships on a baked dark ground, so
+     mix-blend-mode:screen knocks the dark square out and lets the orb glow over
+     the cover. */
+  .landing-orb { position: absolute; right: -70px; bottom: -100px; width: 420px; height: 420px; object-fit: contain; opacity: 0.9; pointer-events: none; z-index: 0; mix-blend-mode: screen; }
   .landing-scrim { position: absolute; inset: 0; z-index: 0; pointer-events: none; background: radial-gradient(130% 110% at 85% 100%, transparent 35%, rgba(0, 20, 27, 0.55) 82%); }
   .landing-hero-inner { position: relative; z-index: 1; padding-top: 64px; padding-bottom: 76px; }
   .landing-col { max-width: 720px; }


### PR DESCRIPTION
## What

The survey landing hero and Done screen rendered the SVG `<Orb/>` component — a "photography stand-in." Swap both for the **real brand orb**, `public/assets/orb-mark.png`.

## Changes

- **Landing hero** — the real orb ships on a **baked dark ground** (RGB, no alpha), so a plain placement would show a dark square. Rendered with `mix-blend-mode: screen` so the dark background knocks out and the orb glows over the cover.
- **Done screen** — the orb is a self-contained dark tile, so it's shown as the framed `.media` image (`object-fit: cover`) rather than a corner flourish; dropped the `m-teal` gradient.
- Removed the now-unused `Orb` import; dropped the orphaned `.landing-orb > .m-orb` rule.
- **Scope:** the survey surface only — the SVG `<Orb/>` stays in use across the rest of the app (homepage hero, cycle banner, spotlight fallbacks), where the stand-in is intentional.

## Verify

- [x] `npm run lint` passes
- [x] `npm run test` passes (39/39)
- [x] `npm run build` passes
- [ ] Preview `/survey/civics`: the hero + Done orb are the **real orb image** (teal/red orb), the hero orb glows cleanly over the cover with no dark square edge, and the Done frame shows the orb tile. Two files changed.

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d)_