### PR TITLE
Public cycle info page (/c/[id]) + service-role-key guard

### DIFF
--- a/app/c/[cycle_id]/page.tsx
+++ b/app/c/[cycle_id]/page.tsx
@@ -1,0 +1,58 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { createServiceClient } from "@/lib/supabase/server";
+import { CycleInfo } from "@/app/components/cycle/cycle-info";
+
+// Public, shareable cycle information page (no auth). Renders non-sensitive
+// cycle info with a "Sign in to register" CTA — the shareable link for a wave of
+// new registrants. Distinct segment (/c/[id]) so it never collides with the
+// authenticated /cycles/[id] route.
+export default async function PublicCyclePage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const cycleId = parseInt(cycle_id, 10);
+  if (isNaN(cycleId)) notFound();
+
+  const supabase = createServiceClient();
+  const { data: cycle } = await supabase
+    .from("cycles")
+    .select(
+      "id, name, start_date, end_date, status, description, what_you_build"
+    )
+    .eq("id", cycleId)
+    .maybeSingle();
+
+  // Draft cycles are not yet public.
+  if (!cycle || cycle.status === "draft") notFound();
+
+  return (
+    <main className="flex-1">
+      <header className="border-b border-ink/10">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+          <span className="font-semibold tracking-tight text-ink">
+            The Upskilling Labs
+          </span>
+          <Link
+            href="/login"
+            className="text-sm font-semibold text-teal-deep hover:underline"
+          >
+            Sign in
+          </Link>
+        </div>
+      </header>
+      <div className="px-6 py-12">
+        <CycleInfo
+          cycle={cycle}
+          cta={
+            <Link href="/login" className="btn btn-teal btn-block">
+              Sign in to register
+            </Link>
+          }
+        />
+      </div>
+    </main>
+  );
+}

--- a/app/components/cycle/cycle-info.tsx
+++ b/app/components/cycle/cycle-info.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import { cycleInfoContent } from "@/lib/cycles/info";
+
+// Shared presentation for a cycle's public information page. Content is
+// admin-authored with a structured fallback; the caller supplies the
+// call-to-action (public page: "Sign in to register").
+export interface CycleInfoCycle {
+  id: number;
+  name: string;
+  start_date: string;
+  end_date: string;
+  status: string;
+  description?: string | null;
+  what_you_build?: string | null;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: "Draft",
+  upcoming: "Upcoming",
+  active: "Active",
+  closing: "Closing",
+  archived: "Archived",
+  closed: "Closed",
+};
+
+export function CycleInfo({
+  cycle,
+  cta,
+}: {
+  cycle: CycleInfoCycle;
+  cta?: ReactNode;
+}) {
+  const { description, whatYouBuild } = cycleInfoContent(cycle);
+  const startLong = new Date(cycle.start_date).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const endLong = new Date(cycle.end_date).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const upcoming = cycle.status === "upcoming";
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="lbl lbl-teal mb-3">
+        {STATUS_LABEL[cycle.status] ?? cycle.status}
+      </div>
+      <h1 className="t-h1 mb-3 text-ink">{cycle.name}</h1>
+      <p className="t-lede mb-8 text-meta">
+        {upcoming ? `Starts ${startLong}` : `${startLong} – ${endLong}`}
+      </p>
+
+      <div className="space-y-8 rounded-card border border-ink/10 bg-white p-6 shadow-card sm:p-8">
+        <section>
+          <h2 className="lbl mb-3">About this cycle</h2>
+          <p className="whitespace-pre-line leading-relaxed text-charcoal">
+            {description}
+          </p>
+        </section>
+        <section>
+          <h2 className="lbl mb-3">What you&rsquo;ll build</h2>
+          <p className="whitespace-pre-line leading-relaxed text-charcoal">
+            {whatYouBuild}
+          </p>
+        </section>
+      </div>
+
+      {cta && <div className="mt-8">{cta}</div>}
+    </div>
+  );
+}

--- a/lib/cycles/info.ts
+++ b/lib/cycles/info.ts
@@ -1,0 +1,27 @@
+// Cycle information-page content. Admins may author per-cycle copy
+// (cycles.description / cycles.what_you_build); when a field is blank we fall
+// back to the standard "how a Build Cycle works" copy so every cycle has a
+// complete info page even before anyone edits it.
+
+export const CYCLE_INFO_FALLBACK = {
+  description:
+    "A Build Cycle is a thirteen-week sprint where you join a small pod, take on a real problem that matters to you, and ship something with a team — supported by mentors and the whole Labs community.",
+  whatYouBuild:
+    "You'll go from a problem to a working project: pick a problem the community votes to tackle, form a pod, propose and vote on solutions, then build it and show your work at the closing Showcase. You walk away with something real, proof of it on your profile, and people who've seen what you can do.",
+} as const;
+
+export interface CycleInfoContent {
+  description: string;
+  whatYouBuild: string;
+}
+
+export function cycleInfoContent(cycle: {
+  description?: string | null;
+  what_you_build?: string | null;
+}): CycleInfoContent {
+  return {
+    description: cycle.description?.trim() || CYCLE_INFO_FALLBACK.description,
+    whatYouBuild:
+      cycle.what_you_build?.trim() || CYCLE_INFO_FALLBACK.whatYouBuild,
+  };
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -27,10 +27,35 @@ export async function createClient() {
   );
 }
 
+// Validate the service-role key up front so a misconfigured key fails LOUD with
+// a clear message. A malformed key (empty, or accidentally wrapped in angle
+// brackets like "<sb_secret_...>") otherwise makes every service-role query fail
+// with "Invalid API key", which surfaces to users as being silently bounced to
+// /register — a very confusing outage to diagnose.
+function requireServiceRoleKey(): string {
+  const key = (process.env.SUPABASE_SERVICE_ROLE_KEY ?? "").trim();
+  if (!key) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is not set.");
+  }
+  if (key.startsWith("<") || key.endsWith(">")) {
+    throw new Error(
+      "SUPABASE_SERVICE_ROLE_KEY looks malformed — it is wrapped in angle brackets. " +
+        "Set it to the raw key value with no surrounding <> characters."
+    );
+  }
+  if (!/^(sb_secret_|sb_|eyJ)/.test(key)) {
+    throw new Error(
+      "SUPABASE_SERVICE_ROLE_KEY does not look like a Supabase service key " +
+        "(expected to start with 'sb_secret_' or a JWT 'eyJ')."
+    );
+  }
+  return key;
+}
+
 export function createServiceClient() {
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    requireServiceRoleKey(),
     {
       cookies: {
         getAll() {

--- a/proxy.ts
+++ b/proxy.ts
@@ -50,6 +50,7 @@ export async function proxy(request: NextRequest) {
       "/login",
       "/api/",
       "/register",
+      "/c/", // public shareable cycle info pages — browses free, no auth
       "/events",
       "/library",
       "/local-labs",

--- a/supabase/migrations/00054_cycle_info_content.sql
+++ b/supabase/migrations/00054_cycle_info_content.sql
@@ -1,0 +1,7 @@
+-- Cycle information-page content — optional admin-authored copy for the public
+-- cycle page (/c/[id]). NULL falls back to standard "how a Build Cycle works"
+-- copy in the app (lib/cycles/info.ts), so every cycle has a complete page even
+-- before anyone edits it.
+
+ALTER TABLE cycles ADD COLUMN IF NOT EXISTS description TEXT;
+ALTER TABLE cycles ADD COLUMN IF NOT EXISTS what_you_build TEXT;


### PR DESCRIPTION
Adds the two genuinely net-new pieces `dev` was missing, cleanly on top of `dev` (no migration-number collisions, no changes to dev's existing upcoming-cycle registration / sector model).

- **Public `/c/[id]` cycle info page** — shareable, no-auth page with a "Sign in to register" CTA; the link to hand a wave of new registrants. Shared `CycleInfo` component + admin-authorable copy (`cycles.description` / `what_you_build`, migration `00054`) with a structured fallback so every cycle has a complete page even before anyone edits it. `/c/` added to the public paths.
- **Fail-loud `SUPABASE_SERVICE_ROLE_KEY` guard** — a malformed key (empty / angle-bracket-wrapped) now throws a clear error instead of silently bouncing every logged-in user to `/register`.

Typecheck clean. Supersedes #193 (that PR tried to merge a stale-`main`-based branch and conflicted with / duplicated dev's already-shipped registration model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFovVVkpdwAbJepkWghZkR)_