### PR TITLE
Make Civics & Elections registration work end-to-end (dynamic banner + upcoming-cycle registration)

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/join/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/join/page.tsx
@@ -41,7 +41,13 @@ export default async function JoinCyclePage({
     .eq("id", cycleId)
     .single();
 
-  if (!cycle || cycle.status !== "active") redirect("/cycles");
+  // Registration is open for the running cohort ('active') AND the next cohort
+  // ('upcoming') — the Civics wave pre-registers before kickoff. The agreement
+  // route writes an 'inactive' enrollment either way; the reconciler activates
+  // it when the cycle starts. Anything else (draft/closed/archived) has no
+  // registration ceremony.
+  if (!cycle || (cycle.status !== "active" && cycle.status !== "upcoming"))
+    redirect("/cycles");
 
   // Already signed → the ceremony opens on the confirmation, not the pitch.
   const { data: agreement } = await serviceClient

--- a/app/(dashboard)/cycles/page.tsx
+++ b/app/(dashboard)/cycles/page.tsx
@@ -4,10 +4,14 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { StatusBadge } from "@/app/components/ui";
 import CyclePhaseIndicator from "./cycle-phase-indicator";
 
-type CycleStatus = "active" | "closed" | "draft";
+type CycleStatus = "active" | "upcoming" | "closed" | "draft";
 
-const STATUS_VARIANT: Record<CycleStatus, "active" | "inactive" | "draft"> = {
+const STATUS_VARIANT: Record<
+  CycleStatus,
+  "active" | "forming" | "inactive" | "draft"
+> = {
   active: "active",
+  upcoming: "forming", // anticipatory (teal), never the grey "inactive" fallback
   closed: "inactive",
   draft: "draft",
 };
@@ -36,6 +40,10 @@ export default async function CyclesPage() {
   }
 
   const otherCycles = cycles?.filter((c) => c.id !== activeCycle?.id) ?? [];
+  // An upcoming cohort is open for registration — surface it as its own
+  // "Register" section, never buried under "Past cycles".
+  const upcomingCycles = otherCycles.filter((c) => c.status === "upcoming");
+  const pastCycles = otherCycles.filter((c) => c.status !== "upcoming");
 
   return (
     <div>
@@ -97,14 +105,50 @@ export default async function CyclesPage() {
         </Link>
       )}
 
-      {/* Past / other cycles */}
-      {otherCycles.length > 0 && (
+      {/* Upcoming — open for registration. The CTA goes to the registration
+          ceremony (/join), not the read-only info view. */}
+      {upcomingCycles.length > 0 && (
+        <>
+          <h2 className="lbl mb-4">Open for registration</h2>
+          <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {upcomingCycles.map((cycle) => (
+              <Link
+                key={cycle.id}
+                href={`/cycles/${cycle.id}/join`}
+                className="group rounded-card border border-teal/30 bg-teal/10 p-6 transition-colors duration-150 ease-out hover:border-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <h3 className="t-h4 text-ink">{cycle.name}</h3>
+                  <StatusBadge variant={STATUS_VARIANT.upcoming}>
+                    {cycle.status}
+                  </StatusBadge>
+                </div>
+                <p className="mt-2 text-sm text-meta">
+                  Starts {new Date(cycle.start_date).toLocaleDateString()}
+                </p>
+                <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold tracking-tight text-teal-deep">
+                  Register
+                  <ArrowRight
+                    className="h-4 w-4 transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+                    aria-hidden
+                  />
+                </span>
+              </Link>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Past / other cycles — closed, archived, draft (never upcoming) */}
+      {pastCycles.length > 0 && (
         <>
           <h2 className="lbl mb-4">
-            {activeCycle ? "Past cycles" : "Build cycles"}
+            {activeCycle || upcomingCycles.length > 0
+              ? "Past cycles"
+              : "Build cycles"}
           </h2>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {otherCycles.map((cycle) => {
+            {pastCycles.map((cycle) => {
               const variant =
                 STATUS_VARIANT[cycle.status as CycleStatus] ?? "inactive";
               return (

--- a/app/api/cycles/[cycle_id]/agreement/route.ts
+++ b/app/api/cycles/[cycle_id]/agreement/route.ts
@@ -33,7 +33,10 @@ export const POST = withAuth(
 
     const supabase = createServiceClient();
 
-    // Verify cycle is active
+    // Registration is open for the running cohort ('active') and the next one
+    // ('upcoming') — the upcoming cohort pre-registers before kickoff. The
+    // enrollment written below is 'inactive' either way; activation stays with
+    // reconcileEnrollmentActivation (§3.7).
     const { data: cycle } = await supabase
       .from("cycles")
       .select("id, status")
@@ -43,7 +46,7 @@ export const POST = withAuth(
     if (!cycle) {
       return NextResponse.json({ error: "Cycle not found" }, { status: 404 });
     }
-    if (cycle.status !== "active") {
+    if (cycle.status !== "active" && cycle.status !== "upcoming") {
       return NextResponse.json(
         { error: "This cycle is not currently accepting registrations" },
         { status: 400 }

--- a/app/api/cycles/[cycle_id]/interest/route.ts
+++ b/app/api/cycles/[cycle_id]/interest/route.ts
@@ -26,7 +26,9 @@ export const POST = withAuth(
 
     const supabase = createServiceClient();
 
-    // Verify cycle is active
+    // Open for the running cohort ('active') and the next one ('upcoming') —
+    // the upcoming cohort collects interest pre-kickoff. The enrollment written
+    // below stays 'inactive' until the reconciler activates it.
     const { data: cycle } = await supabase
       .from("cycles")
       .select("id, status")
@@ -36,7 +38,7 @@ export const POST = withAuth(
     if (!cycle) {
       return NextResponse.json({ error: "Cycle not found" }, { status: 404 });
     }
-    if (cycle.status !== "active") {
+    if (cycle.status !== "active" && cycle.status !== "upcoming") {
       return NextResponse.json(
         { error: "This cycle is not currently accepting interest" },
         { status: 400 }

--- a/lib/cycle/active.ts
+++ b/lib/cycle/active.ts
@@ -38,10 +38,17 @@ export async function getOperatingCycle(
 export async function getRecruitingCycle(
   supabase: SupabaseClient
 ): Promise<CycleRow | null> {
+  // The newest cohort open for registration: the most recent `upcoming` cycle
+  // (by start date). Ordered + limited rather than assuming a single upcoming
+  // row, so the banner still resolves (to the newest) if more than one is ever
+  // open, instead of erroring and blanking. Falls back to the running `active`
+  // cohort when nothing is upcoming.
   const { data: upcoming } = await supabase
     .from("cycles")
     .select(CYCLE_COLUMNS)
     .eq("status", "upcoming")
+    .order("start_date", { ascending: false })
+    .limit(1)
     .maybeSingle();
   if (upcoming) return upcoming as CycleRow;
   return getOperatingCycle(supabase);


### PR DESCRIPTION
## What

Makes registering for the **Civics & Elections** cohort (`upcoming`) work end-to-end on dev. Two commits:

### 1. Dynamic landing banner (`lib/cycle/active.ts`)
`getRecruitingCycle` now orders `upcoming` cycles by `start_date` and takes the newest, instead of a bare `.maybeSingle()` that errors/blanks the banner if more than one upcoming row exists. Falls back to the active cohort when none is upcoming. The landing banner ("Registration open now") reads this.

### 2. Upcoming-cycle registration (the dead-end fix)
A live test on dev proved the banner's **"Join this cycle"** CTA was a dead-end: three identical `status !== "active"` gates rejected `upcoming` cycles, and `/cycles` filed the upcoming cycle under **"Past cycles"** with no register path.

- **Un-gate** the join ceremony (`app/(dashboard)/cycles/[cycle_id]/join/page.tsx`) + agreement + interest API routes to accept `status === "active" || status === "upcoming"`. Both API routes already write an **`inactive`** enrollment; the reconciler activates it at kickoff — no other change.
- **`/cycles`**: pull `upcoming` out of "Past cycles" into an **"Open for registration"** section whose card links to the registration ceremony (`/join`), with a positive (teal) status badge instead of the grey `inactive` fallback.

No ceremony changes needed — its confirmation already handles a not-yet-started cycle ("You're registered ✓ / See you at Kickoff").

## Verification (live, dev Supabase, as a signed-in participant)

| Check | Before | After |
|---|---|---|
| `/cycles/5/join` | redirect to `/cycles` | ✅ renders the ceremony |
| `POST /api/cycles/5/agreement` | 400 | ✅ 201 (writes agreement + `inactive` enrollment) |
| `/cycles` | Civics under "Past cycles", no CTA | ✅ under "Open for registration" with Register CTA |

`npx tsc --noEmit` clean; eslint clean (one pre-existing unrelated warning). Seeded test rows removed after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFovVVkpdwAbJepkWghZkR