### PR TITLE
Landing: sticky nav bounded to the hero + hero copy fades on scroll

### DIFF
--- a/app/components/chrome/hero-fade.tsx
+++ b/app/components/chrome/hero-fade.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/* The landing hero copy fades — and drifts up a touch — as the hero scrolls
+   out of view: a scroll-linked opacity ramp over the hero's own height. Runs
+   on a passive listener, batched into one rAF per frame, and writes styles
+   imperatively so it never triggers a React re-render. Honours
+   prefers-reduced-motion (no effect at all — the copy stays put, fully
+   visible). Wraps the server-rendered hero copy; the .hero-inner class it
+   carries is what the layout CSS targets, unchanged from before. */
+export default function HeroFade({ children }: { children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const hero = el.closest(".hero-band") as HTMLElement | null;
+    let raf = 0;
+
+    const apply = () => {
+      raf = 0;
+      // Fade to nothing over ~two-thirds of the hero's height, so the copy is
+      // gone well before the hero's bottom clears the viewport.
+      const span = (hero?.offsetHeight ?? window.innerHeight) * 0.68;
+      const p = span > 0 ? Math.min(Math.max(window.scrollY / span, 0), 1) : 0;
+      el.style.opacity = String(1 - p);
+      el.style.transform = `translate3d(0, ${(-p * 44).toFixed(1)}px, 0)`;
+      // Once invisible, don't let the faded buttons swallow clicks.
+      el.style.pointerEvents = p >= 1 ? "none" : "";
+    };
+
+    const onScroll = () => {
+      if (!raf) raf = requestAnimationFrame(apply);
+    };
+
+    el.style.willChange = "opacity, transform";
+    apply(); // seed the state — covers a reload at a non-zero scroll offset
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <div className="hero-inner" ref={ref}>
+      {children}
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -686,8 +686,11 @@ button:focus-visible {
   .ham-menu .nav-link { color: var(--od2); font-size: 16px; font-weight: 500; padding: 15px 2px; border-radius: 0; border-bottom: 1px solid rgba(255, 255, 255, 0.08); }
   .ham-menu .nav-link:last-child { border-bottom: none; }
   .ham-menu .nav-link:hover { color: var(--od1); background: transparent; }
-  /* the landing variant: fixed over the hero, gradient fade */
-  .sitenav.overhero { position: fixed; top: 0; left: 0; right: 0; background: linear-gradient(to bottom, var(--ink) 0%, transparent 100%); }
+  /* the landing variant: sticky over the hero (gradient fade), bounded to the
+     hero by .hero-shell — the bar rides the top while the hero is on screen,
+     then scrolls away with it. The base .sitenav is already sticky/top:0;
+     overhero only re-skins it with the fade and keeps it transparent. */
+  .sitenav.overhero { position: sticky; top: 0; background: linear-gradient(to bottom, var(--ink) 0%, transparent 100%); }
   .sitenav.overhero .ham-menu { background: var(--ink); }
   @media (min-width: 1024px) {
     .sitenav .nav-links { display: flex; }
@@ -702,6 +705,13 @@ button:focus-visible {
   }
 
   /* ── landing hero band ── */
+  /* The shell is the sticky nav's containing block: the nav sticks to the top
+     while the shell (== the hero) is on screen, then unsticks and scrolls off
+     with it. --hero-nav-h is the bar's height (min-height of .sitenav-inner);
+     the hero is pulled up by it so the photo still runs full-bleed behind the
+     translucent bar, exactly as the old fixed nav did. */
+  .hero-shell { position: relative; --hero-nav-h: 76px; }
+  .hero-shell > .hero-band { margin-top: calc(-1 * var(--hero-nav-h)); }
   .hero-band { position: relative; z-index: 2; overflow: hidden; border-radius: 0 0 calc(var(--r) * 3) calc(var(--r) * 3); margin-bottom: calc(-3 * var(--r)); min-height: calc(100svh + calc(var(--r) * 3)); display: flex; align-items: flex-end; background: none; }
   .hero-scrim { position: absolute; top: 0; left: 0; right: 0; height: 190px; z-index: 3; pointer-events: none; background: linear-gradient(to bottom, var(--ink) 0%, rgba(0, 20, 27, 0.55) 45%, transparent 100%); }
   .hero-band::before { z-index: 2; } /* grain sits over the tint */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import PublicNav from "@/app/components/chrome/public-nav";
+import HeroFade from "@/app/components/chrome/hero-fade";
 import OrbDefs from "@/app/components/chrome/orb-defs";
 import Orb from "@/app/components/chrome/orb";
 import { OsFooter } from "@/app/components/chrome/site-footers";
@@ -77,40 +78,43 @@ export default async function LandingPage() {
   return (
     <div className="flex min-h-screen flex-col">
       <OrbDefs />
-      <PublicNav signedIn={signedIn} initials={initials} avatarUrl={avatarUrl} overHero />
 
-      {/* ── Hero ── */}
-      <div className="hero-band s-cover grain on-dark">
-        <div className="hero-scrim" aria-hidden="true" />
-        <div className="hero-photo" aria-hidden="true" />
-        <div className="hero-tint" aria-hidden="true" />
-        <div className="hero-inner">
-          <h1 className="t-display">
-            Find your people.
-            <br />
-            Build your edge.
-          </h1>
-          <div className="hero-cta">
-            <p className="t-lede" style={{ marginBottom: 24 }}>
-              The Labs isn’t a class you sit through. It’s where you practice
-              becoming the person you want to be — on real problems, with
-              people who notice.
-            </p>
-            {signedIn ? (
-              <Link className="btn btn-teal btn-lg" href="/dashboard">
-                Go to your dashboard
-              </Link>
-            ) : (
-              <>
-                <Link className="btn btn-red btn-lg" href="/login">
-                  Join The Labs
+      {/* ── Hero ── The nav + hero share one shell so the nav stays sticky only
+          while the hero is on screen, then scrolls away with it. */}
+      <div className="hero-shell">
+        <PublicNav signedIn={signedIn} initials={initials} avatarUrl={avatarUrl} overHero />
+        <div className="hero-band s-cover grain on-dark">
+          <div className="hero-scrim" aria-hidden="true" />
+          <div className="hero-photo" aria-hidden="true" />
+          <div className="hero-tint" aria-hidden="true" />
+          <HeroFade>
+            <h1 className="t-display">
+              Find your people.
+              <br />
+              Build your edge.
+            </h1>
+            <div className="hero-cta">
+              <p className="t-lede" style={{ marginBottom: 24 }}>
+                The Labs isn’t a class you sit through. It’s where you practice
+                becoming the person you want to be — on real problems, with
+                people who notice.
+              </p>
+              {signedIn ? (
+                <Link className="btn btn-teal btn-lg" href="/dashboard">
+                  Go to your dashboard
                 </Link>
-                <Link className="btn btn-ghost btn-lg hero-login" href="/login">
-                  Log in
-                </Link>
-              </>
-            )}
-          </div>
+              ) : (
+                <>
+                  <Link className="btn btn-red btn-lg" href="/login">
+                    Join The Labs
+                  </Link>
+                  <Link className="btn btn-ghost btn-lg hero-login" href="/login">
+                    Log in
+                  </Link>
+                </>
+              )}
+            </div>
+          </HeroFade>
         </div>
       </div>
 


### PR DESCRIPTION
## What

Make the public bar on the landing page (`/`) sticky **only while the hero is on screen**, and fade the hero copy out as the hero scrolls away. Previously the bar was `position: fixed`, so it stayed pinned to the top over every section below the hero.

## Changes

- Wrap the nav + hero in a `.hero-shell` and switch `.sitenav.overhero` from `position: fixed` to `position: sticky`. The shell becomes the sticky containing block, so the bar rides the top through the hero, then unsticks and scrolls off with it.
- Pull the hero up under the bar (`margin-top: calc(-1 * var(--hero-nav-h))`) so the photo still runs full-bleed behind the translucent nav — visually identical to the old fixed bar, only the scroll behavior changed.
- Add `HeroFade`, a small client wrapper around the hero copy that ramps its opacity `1 → 0` (with a slight upward drift) over ~two-thirds of the hero's height. rAF-batched on a passive scroll listener, writes styles imperatively (no re-renders), drops pointer events once invisible, and no-ops under `prefers-reduced-motion`.
- Scope: `overHero` / `.hero-band` are used only by the landing page, so no other page is affected.

## Verify

- [x] `npm run lint` passes (0 errors; pre-existing warnings only)
- [x] `npm run test` passes (39/39)
- [x] `npm run build` passes
- Also verified the sticky + fade mechanism in Chromium across desktop (1280×800) and mobile (390×844): the nav stays stuck at `top:0` through the hero and is fully gone once scrolled past it; hero opacity ramps `1 → 0`; the full-bleed photo behind the nav and the rounded-corner section tuck are both preserved.

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmV1biu1pr5LdXP9rQkL9o)_