### PR TITLE
fix(survey): feather the hero orb + make it bigger and on-screen

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -373,10 +373,10 @@ dialog::backdrop {
 
   /* ── field-survey landing (full-width AIDA entry) ── */
   .landing-hero { position: relative; overflow: hidden; isolation: isolate; }
-  /* The real orb (public/assets/orb-mark.png) ships on a baked dark ground, so
-     mix-blend-mode:screen knocks the dark square out and lets the orb glow over
-     the cover. */
-  .landing-orb { position: absolute; right: -70px; bottom: -100px; width: 420px; height: 420px; object-fit: contain; opacity: 0.9; pointer-events: none; z-index: 0; mix-blend-mode: screen; }
+  /* The real orb (public/assets/orb-mark.png) ships on a baked dark (not pure
+     black) ground — a radial mask feathers the disc to transparent so the
+     square edge disappears entirely and the orb keeps its true colors. */
+  .landing-orb { position: absolute; right: -8%; bottom: -10%; width: min(90vw, 560px); height: min(90vw, 560px); object-fit: contain; opacity: 0.95; pointer-events: none; z-index: 0; -webkit-mask-image: radial-gradient(circle at 50% 50%, #000 50%, transparent 68%); mask-image: radial-gradient(circle at 50% 50%, #000 50%, transparent 68%); }
   .landing-scrim { position: absolute; inset: 0; z-index: 0; pointer-events: none; background: radial-gradient(130% 110% at 85% 100%, transparent 35%, rgba(0, 20, 27, 0.55) 82%); }
   .landing-hero-inner { position: relative; z-index: 1; padding-top: 64px; padding-bottom: 76px; }
   .landing-col { max-width: 720px; }
@@ -386,7 +386,7 @@ dialog::backdrop {
   .goal-fill { height: 100%; border-radius: inherit; background: var(--teal); transition: width 0.4s cubic-bezier(0.2, 0.7, 0.1, 1); }
   @media (min-width: 640px) { .landing-cta { width: auto; } }
   @media (min-width: 1024px) { .landing-hero-inner { padding-top: 100px; padding-bottom: 112px; } }
-  @media (max-width: 640px) { .landing-orb { width: 260px; height: 260px; right: -50px; bottom: -60px; opacity: 0.3; } }
+  @media (min-width: 1024px) { .landing-orb { right: 1%; bottom: 2%; width: min(46vw, 620px); height: min(46vw, 620px); } }
 
   /* ── google ── */
   .google-btn { display: flex; align-items: center; justify-content: center; gap: 12px; padding: 16px; border-radius: var(--r); background: var(--ink); color: #fff; font-weight: 600; font-size: 15px; border: none; cursor: pointer; width: 100%; }


### PR DESCRIPTION
## What

Two fixes to the landing hero orb (feedback from #191): the visible square edges, and the orb being too small + off-screen on load.

## Changes (CSS-only, `app/globals.css`)

- **Visible edges** — `mix-blend-mode: screen` was lightening the orb's baked *near-black-but-not-pure-black* background into a faint square. Replaced with a **radial `mask-image`** that feathers the disc to transparent, so the square disappears entirely and the orb keeps its true colors.
- **Size + position** — enlarged to `min(90vw, 560px)` (`min(46vw, 620px)` on desktop) and pulled on-screen (`right:-8% / bottom:-10%`; desktop `right:1% / bottom:2%`). Removed the `@media (max-width:640px)` override that shrank it to 260px at 0.3 opacity (the "too small on mobile" cause).

## Verify

- [x] `npm run build` passes
- [x] `npm run test` passes
- [ ] Preview `/survey/civics`: hero orb is large, on-screen on load, **no visible square edge** (feathered), true colors; responsive at 360/768/1024/1440. Mask stops / offsets easy to tune if it reads too hot or subtle.

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY4kdcx9fgSX8yTGkmoA6d)_