### PR TITLE
Registration always lands on the dashboard; dashboard surfaces the recruiting cohort

### DIFF
--- a/app/(auth)/register/funnel.tsx
+++ b/app/(auth)/register/funnel.tsx
@@ -22,10 +22,10 @@ import {
      FLOWS('signup')   → SIGNUP_STEPS on the shared flow engine
    All user-facing copy is owner-approved — change it in the prototype first.
 
-   Post-signup role branching: picking "Join a Cycle" routes into the cycle
-   registration ceremony (the threshold — flows never silently chain; the
-   ceremony IS the seam). Everything else lands on the dashboard; mentor and
-   volunteer flows arrive with their stages.
+   Post-signup routing: every new member lands on the dashboard, whatever
+   intents they picked. The dashboard is the home base where the next steps
+   surface — the recruiting-cycle join CTA, the setup checklist, the Learning
+   Log — so the intents shape what a member sees there, not where they land.
    ════════════════════════════════════════════════════════════════════════ */
 
 /* The Participant Agreement — the single agreement everyone accepts to join,
@@ -218,13 +218,11 @@ export default function RegistrationFunnel({
         setStage("already");
         return null;
       }
-      // Role branch: the cycle is the commitment, and its seam is the
-      // threshold ceremony — never a silent chain into more questions.
-      if (roles.includes("cycle") && json.active_cycle_id) {
-        router.push(`/cycles/${json.active_cycle_id}/join?from=signup`);
-      } else {
-        router.push("/dashboard");
-      }
+      // Every new member lands on the dashboard, whatever intents they picked.
+      // The next steps (join the recruiting cycle, finish the setup checklist,
+      // start a Learning Log) surface there — no intent silently chains into
+      // another flow.
+      router.push("/dashboard");
       return null;
     }
     return json?.error || "Registration failed — try again.";

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -46,6 +46,15 @@ export default async function DashboardPage() {
 
   const activeCycle = cycles?.find((c) => c.status === "active") ?? null;
 
+  // The cohort a not-yet-enrolled member registers for: the newest cycle open
+  // for pre-registration (`upcoming`), if any. Mirrors getRecruitingCycle
+  // (lib/cycle/active.ts) — the signup funnel and the confirmation email
+  // already point new members at this cohort, so the dashboard's join CTA has
+  // to as well, or a member who signed up for the upcoming cohort lands here
+  // with no path to it. `cycles` is ordered start_date desc → the first match
+  // is the newest upcoming.
+  const upcomingCycle = cycles?.find((c) => c.status === "upcoming") ?? null;
+
   type PodMembership = { id: number; pod_id: number; pods: { id: number; name: string; status: string } };
   let activeCycleConfig = null;
   let enrollment = null;
@@ -91,6 +100,20 @@ export default async function DashboardPage() {
     myPods = (membershipResult.data as unknown as PodMembership[]) ?? [];
     hasAgreement = (agreementResult.count ?? 0) > 0;
     logCount = logResult.count ?? 0;
+  }
+
+  // Has the member already signed the upcoming cohort's Open Cycle Agreement?
+  // Drives the "Register" checklist row + the pre-registration confirmation so
+  // a member who's pre-registered for the next cohort isn't asked to do it
+  // again.
+  let preRegisteredUpcoming = false;
+  if (upcomingCycle) {
+    const { count } = await serviceClient
+      .from("cycle_agreements")
+      .select("id", { head: true, count: "exact" })
+      .eq("participant_id", participant.id)
+      .eq("cycle_id", upcomingCycle.id);
+    preRegisteredUpcoming = (count ?? 0) > 0;
   }
 
   // Determine pod registration window status
@@ -221,9 +244,24 @@ export default async function DashboardPage() {
   // Setup checklist — the onboarding home for a new member (prototype
   // panel-dashboard: "checklist first"). Built here so it shows in EVERY state
   // below, not only once enrolled: the profile step is always relevant; the
-  // cycle steps appear when a cycle is running. SetupChecklist collapses to a
-  // strip once every row is done.
+  // cycle steps appear when a cycle is running or open for registration.
+  // SetupChecklist collapses to a strip once every row is done.
   const profileDone = !!(participant.bio || participant.headline);
+
+  // The "Register" row leads to the cohort the member should register for. In
+  // the onboarding states (no active enrollment yet) that's the upcoming cohort
+  // when one is open for pre-registration — matching where the signup funnel
+  // routed them — otherwise the running cohort. Once the member is engaged in
+  // the active cycle the row reflects that cycle (and collapses when done), so
+  // an active member isn't nagged about the next cohort.
+  const onboarding = state === "no_cycle" || state === "no_enrollment";
+  const registerCycle =
+    onboarding && upcomingCycle ? upcomingCycle : activeCycle;
+  const registerDone =
+    onboarding && upcomingCycle
+      ? preRegisteredUpcoming
+      : hasAgreement || enrollment?.status === "active";
+
   const checklistItems: ChecklistItem[] = [
     {
       key: "profile",
@@ -232,15 +270,21 @@ export default async function DashboardPage() {
       href: "/profile/edit",
       cta: "Edit",
     },
-    ...(activeCycle
+    ...(registerCycle
       ? [
           {
             key: "register",
-            label: `Register for ${activeCycle.name}`,
-            done: hasAgreement || enrollment?.status === "active",
-            href: `/cycles/${activeCycle.id}/join`,
+            label: `Register for ${registerCycle.name}`,
+            done: registerDone,
+            href: `/cycles/${registerCycle.id}/join`,
             cta: "Register",
           },
+        ]
+      : []),
+    // Pod + Learning Log steps belong to the running cohort — an upcoming
+    // cohort has no pods yet — so these stay tied to the active cycle.
+    ...(activeCycle
+      ? [
           {
             key: "pod",
             label: "Join a pod",
@@ -259,7 +303,66 @@ export default async function DashboardPage() {
       : []),
   ];
 
-  // Empty state: no enrollment — the onboarding checklist leads, then the join CTA.
+  // Join / pre-register CTA card for the onboarding empty states, pointed at
+  // the cohort the member should register for. For an upcoming cohort the copy
+  // frames it as pre-registration; for the running cohort it's a straight join.
+  type CycleCardData = {
+    id: number;
+    name: string;
+    start_date: string | null;
+    end_date: string | null;
+  };
+  const joinCycleCard = (cycle: CycleCardData, upcoming: boolean) => (
+    <Link
+      href={`/cycles/${cycle.id}/join`}
+      className="group flex items-center justify-between rounded-card border border-teal/30 bg-white p-8 shadow-card transition-colors duration-150 ease-out hover:border-teal hover:bg-teal/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+    >
+      <div>
+        <h2 className="t-h3 text-ink">{cycle.name}</h2>
+        {cycle.start_date && cycle.end_date && (
+          <p className="mt-1 text-sm text-meta">
+            {new Date(cycle.start_date).toLocaleDateString()} &ndash;{" "}
+            {new Date(cycle.end_date).toLocaleDateString()}
+          </p>
+        )}
+        <p className="mt-3 text-sm text-meta">
+          {upcoming
+            ? "Pre-register now to claim your spot for the next cohort."
+            : "Complete this form to join the cycle."}
+        </p>
+      </div>
+      <span className="inline-flex items-center gap-1.5 text-base font-semibold tracking-tight text-teal-deep">
+        {upcoming ? "Pre-register" : `Join ${cycle.name}`}
+        <ArrowRight
+          className="h-5 w-5 transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+          aria-hidden
+        />
+      </span>
+    </Link>
+  );
+
+  // Shown instead of the join card once the member has signed the upcoming
+  // cohort's agreement — they're set; nothing to do until it starts.
+  const preRegisteredCard = (cycle: CycleCardData) => (
+    <div className="rounded-card border border-teal/30 bg-teal/[0.06] p-8 shadow-card">
+      <div className="lbl lbl-teal mb-2">You&apos;re pre-registered</div>
+      <h2 className="t-h3 text-ink">{cycle.name}</h2>
+      <p className="mt-2 text-sm text-meta">
+        You&apos;re all set for the next cohort
+        {cycle.start_date
+          ? ` — it kicks off ${new Date(cycle.start_date).toLocaleDateString(
+              "en-US",
+              { month: "long", day: "numeric" }
+            )}`
+          : ""}
+        . We&apos;ll open your next steps here when it starts.
+      </p>
+    </div>
+  );
+
+  // Empty state: no enrollment — the onboarding checklist leads, then the join
+  // CTA. When the next cohort is open for pre-registration, the CTA points at
+  // it (that's where signup routed the member), not the closing active cycle.
   if (state === "no_enrollment" && activeCycle) {
     return (
       <div>
@@ -271,36 +374,18 @@ export default async function DashboardPage() {
           lede="You're almost in — here's how to get set up."
         />
         <SetupChecklist items={checklistItems} />
-        <Link
-          href={`/cycles/${activeCycle.id}/join`}
-          className="group flex items-center justify-between rounded-card border border-teal/30 bg-white p-8 shadow-card transition-colors duration-150 ease-out hover:border-teal hover:bg-teal/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
-        >
-          <div>
-            <h2 className="t-h3 text-ink">
-              {activeCycle.name}
-            </h2>
-            <p className="mt-1 text-sm text-meta">
-              {new Date(activeCycle.start_date).toLocaleDateString()} &ndash;{" "}
-              {new Date(activeCycle.end_date).toLocaleDateString()}
-            </p>
-            <p className="mt-3 text-sm text-meta">
-              Complete this form to join the cycle.
-            </p>
-          </div>
-          <span className="inline-flex items-center gap-1.5 text-base font-semibold tracking-tight text-teal-deep">
-            Join {activeCycle.name}
-            <ArrowRight
-              className="h-5 w-5 transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
-              aria-hidden
-            />
-          </span>
-        </Link>
+        {upcomingCycle
+          ? preRegisteredUpcoming
+            ? preRegisteredCard(upcomingCycle)
+            : joinCycleCard(upcomingCycle, true)
+          : joinCycleCard(activeCycle, false)}
         <div className="mt-8">{logSectionFor(true)}</div>
       </div>
     );
   }
 
-  // Empty state: no active cycle at all
+  // Empty state: no active cycle. If the next cohort is already open for
+  // registration, lead with its join CTA instead of the "nothing running" note.
   if (state === "no_cycle") {
     return (
       <div>
@@ -309,14 +394,26 @@ export default async function DashboardPage() {
           avatarUrl={avatarUrl}
           eyebrow="Member portal"
           greeting={`Welcome, ${displayName}`}
-          lede="Here's your home base at The Labs. The next Build Cycle will show up right here."
+          lede={
+            upcomingCycle
+              ? "Here's your home base — the next Build Cycle is open for registration below."
+              : "Here's your home base at The Labs. The next Build Cycle will show up right here."
+          }
         />
         {checklistItems.length > 0 && <SetupChecklist items={checklistItems} />}
-        <EmptyState
-          icon={Calendar}
-          title="No cycle running right now"
-          description="Check back soon for the next Build Cycle."
-        />
+        {upcomingCycle ? (
+          preRegisteredUpcoming ? (
+            preRegisteredCard(upcomingCycle)
+          ) : (
+            joinCycleCard(upcomingCycle, true)
+          )
+        ) : (
+          <EmptyState
+            icon={Calendar}
+            title="No cycle running right now"
+            description="Check back soon for the next Build Cycle."
+          />
+        )}
         <div className="mt-8">{logSectionFor(true)}</div>
       </div>
     );

--- a/app/api/registrations/funnel/route.ts
+++ b/app/api/registrations/funnel/route.ts
@@ -187,9 +187,6 @@ export async function POST(request: NextRequest) {
     {
       participant_id: participant.id,
       created_at: participant.created_at,
-      // The funnel's role branch: picking "Join a Cycle" routes into the
-      // cycle registration ceremony for the recruiting cohort when one is open.
-      active_cycle_id: recruitingCycle?.id ?? null,
     },
     { status: 201 }
   );


### PR DESCRIPTION
## What

After registration, every new member now lands on the dashboard regardless of which role intents they picked. To make that work, the dashboard is extended so a not-yet-enrolled member sees a join CTA for the cohort they actually signed up for — the **recruiting** cohort (the newest `upcoming` cycle when one is open for pre-registration, else the active one).

Previously, picking the "Join a Cycle" intent routed the member straight into the cycle registration ceremony. Everyone now goes to the dashboard, and the dashboard presents the next step from there.

## Changes

- **Funnel** (`app/(auth)/register/funnel.tsx`): remove the post-signup role branch — every completed registration routes to `/dashboard`. Drop the now-unused `active_cycle_id` from the funnel registration response (`app/api/registrations/funnel/route.ts`), which only fed that branch.
- **Dashboard** (`app/(dashboard)/dashboard/page.tsx`): for the onboarding empty states (`no_enrollment` / `no_cycle`) and the setup checklist's Register row, target the recruiting cohort — the newest `upcoming` cycle when one is open, else the active one (mirrors `getRecruitingCycle`, the signup funnel, and the confirmation email):
  - not yet pre-registered → **"Pre-register for {upcoming}"** CTA → `/cycles/{id}/join`
  - already signed its agreement → a **"You're pre-registered"** confirmation card
  - Pod + Learning Log steps stay tied to the running cohort (an upcoming cohort has no pods yet); an active member's checklist still reflects their current cycle. All new behavior is gated on an `upcoming` cycle existing, so when the recruiting cohort *is* the active one the dashboard is unchanged.

Without this, during a pre-registration window (an active cohort running while the next one is open — the current dev state, with Energy & Climate active and Civics & Elections upcoming), a member who picked "Join a Cycle" would land pointed at the closing active cohort with no in-dashboard path to the one they joined.

## Verify

Drove the flow end-to-end against the dev database with a real authenticated session:
- Fresh cycle-intent registrant → dashboard renders **"Pre-register for Civics & Elections"** → `/cycles/5/join`; no "Join Energy" CTA, no `/cycles/2/join` link.
- After signing the Civics agreement → **"You're pre-registered"** card; checklist "Register" row flips to done. (Test rows cleaned up afterward.)

- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (39 tests)
- [x] `npm run build` passes

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C48WoykTExkYwVFBdFNQhz)_