### PR TITLE
Mobile: 85vh cycle banner + horizontal event cards

### DIFF
--- a/app/components/content/teasers.tsx
+++ b/app/components/content/teasers.tsx
@@ -58,7 +58,7 @@ export function EventTeaser({
   corner?: ReactNode;
 }) {
   return (
-    <Link className="card tappable" href={`/events/${e.slug}`}>
+    <Link className="card tappable event-card" href={`/events/${e.slug}`}>
       <MediaFrame
         img={e.img}
         grad={e.grad}

--- a/app/globals.css
+++ b/app/globals.css
@@ -536,6 +536,17 @@ button:focus-visible {
      event covers are 1:1 natively, so synced images render uncropped). */
   .media.sq, .cards.dense .media.sq { aspect-ratio: 1 / 1; }
   .cards.dense .t-h4 { font-size: 15px; line-height: 20px; }
+  /* Event teasers go horizontal on phones — square thumbnail (1/5 width) on
+     the left, the vertically-stacked info on the right. `align-items:
+     flex-start` keeps the media at its 1:1 aspect ratio instead of stretching. */
+  @media (max-width: 699px) {
+    .card.event-card { display: flex; align-items: flex-start; }
+    .card.event-card .media { flex: 0 0 20%; border-radius: 0; }
+    /* the kind badge can't fit legibly on a 1/5-width thumbnail — the card body
+       already carries the event's details, so drop it in this compact layout */
+    .card.event-card .media .m-tag { display: none; }
+    .card.event-card .card-body { flex: 1; min-width: 0; }
+  }
   @media (min-width: 700px) { .cards.dense { grid-template-columns: repeat(2, 1fr); } }
   @media (min-width: 768px) {
     .cards { grid-template-columns: repeat(2, 1fr); gap: 24px; }
@@ -574,7 +585,7 @@ button:focus-visible {
   .cycle-banner .cb-cta { position: relative; z-index: 1; width: 100%; }
   /* scrim between the orb and the banner's text/CTA — the orb never sits raw under content */
   .cycle-banner::after { content: ""; position: absolute; inset: 0; background: linear-gradient(90deg, rgba(0, 20, 27, 0) 35%, rgba(0, 20, 27, 0.55) 100%); pointer-events: none; }
-  @media (max-width: 699px) { .cycle-banner .m-orb { opacity: 0.4; } .cycle-banner::after { background: rgba(0, 20, 27, 0.35); } }
+  @media (max-width: 699px) { .cycle-banner { min-height: 85svh; justify-content: center; } .cycle-banner .m-orb { opacity: 0.4; } .cycle-banner::after { background: rgba(0, 20, 27, 0.35); } }
   .cb-status { display: inline-flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: var(--r); background: rgba(0, 148, 160, 0.22); border: 1px solid rgba(0, 148, 160, 0.55); color: #fff; font-size: 12px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; }
   .cb-status::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--teal); box-shadow: 0 0 0 4px rgba(0, 148, 160, 0.25); }
 


### PR DESCRIPTION
## What

On phones (≤699px), the homepage cycle banner now fills 85% of the viewport height so the cohort CTA is a proper above-the-fold hero, and event cards switch to a compact horizontal layout (square thumbnail left, info right).

## Changes

- **Cycle banner** (`app/globals.css`): on mobile, `min-height: 85svh` with `justify-content: center` so content is vertically centered in the taller banner.
- **Event cards** (`EventTeaser`): on mobile, the card becomes a flex row — a square thumbnail at `flex: 0 0 20%` (1/5 of the container width) on the left, with the date/title/location info stacked on the right. The kind badge is hidden in this compact layout since it can't fit legibly on the shrunken thumbnail.
- Applied via a new `event-card` class on `EventTeaser` (`app/components/content/teasers.tsx`), so resource/lab cards are unaffected.
- Both changes revert to the existing stacked/grid layouts at ≥700px.

## Verify

Compiled the real `globals.css` with the project's Tailwind v4 toolchain and measured the rendered component markup in Chromium: at 390px the banner is 85.0% of the viewport height and the event thumbnail is 19.9% of the card width (68×68, square, left of the info); at 900px both revert to the stacked/grid layout. Resource cards stay stacked at all widths.

- [x] `npm run lint` passes (0 errors; 8 pre-existing warnings unrelated to this change)
- [x] `npm run test` passes (39/39)
- [x] `npm run build` passes

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNX9AieGXahUVLsWmdxVrF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNX9AieGXahUVLsWmdxVrF)_