### PR TITLE
Mobile event thumbnails: rounded corners + 1/4 width

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -571,13 +571,13 @@ button:focus-visible {
      event covers are 1:1 natively, so synced images render uncropped). */
   .media.sq, .cards.dense .media.sq { aspect-ratio: 1 / 1; }
   .cards.dense .t-h4 { font-size: 15px; line-height: 20px; }
-  /* Event teasers go horizontal on phones — square thumbnail (1/5 width) on
+  /* Event teasers go horizontal on phones — square thumbnail (1/4 width) on
      the left, the vertically-stacked info on the right. `align-items:
      flex-start` keeps the media at its 1:1 aspect ratio instead of stretching. */
   @media (max-width: 699px) {
     .card.event-card { display: flex; align-items: flex-start; }
-    .card.event-card .media { flex: 0 0 20%; border-radius: 0; }
-    /* the kind badge can't fit legibly on a 1/5-width thumbnail — the card body
+    .card.event-card .media { flex: 0 0 25%; }
+    /* the kind badge can't fit legibly on a 1/4-width thumbnail — the card body
        already carries the event's details, so drop it in this compact layout */
     .card.event-card .media .m-tag { display: none; }
     .card.event-card .card-body { flex: 1; min-width: 0; }


### PR DESCRIPTION
## What

Follow-up to #201's horizontal mobile event-card layout: the thumbnail now keeps its rounded corners and is 1/4 the container width (was 1/5, with square corners).

## Changes

- `app/globals.css` (≤699px `.card.event-card .media`): dropped the `border-radius: 0` override so the thumbnail inherits `.media`'s `border-radius: var(--r)` — all four corners rounded again — and changed `flex: 0 0 20%` → `flex: 0 0 25%` for a 1/4-width thumbnail. It stays square via the existing `.media.sq` 1:1 aspect ratio.
- No other files change; the `event-card` class already exists on `EventTeaser`.

## Verify

Compiled the real `globals.css` with the project's Tailwind v4 toolchain and measured the rendered markup in Chromium at 390px: thumbnail is 24.9% of the card width (85×85, square), computed `border-radius` = 14px on all four corners, positioned left of the stacked info. At 900px it reverts to the stacked grid. Eyeballed the screenshot — the rounded thumbnail reads cleanly.

- [x] `npm run lint` passes (0 errors; 8 pre-existing warnings unrelated to this change)
- [x] `npm run test` passes (39/39)
- [x] `npm run build` passes

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNX9AieGXahUVLsWmdxVrF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNX9AieGXahUVLsWmdxVrF)_