### PR TITLE
Mobile event cards: one-line info rows, bookmark icon, icon to card top-right

### DIFF
--- a/app/(dashboard)/learning/page.tsx
+++ b/app/(dashboard)/learning/page.tsx
@@ -153,8 +153,8 @@ export default async function LearningPage() {
         ) : (
           <div className="lcard" style={{ padding: 40 }}>
             <p className="t-body text-meta">
-              Nothing saved yet. Tap the heart on any session or guide to keep it
-              here.
+              Nothing saved yet. Tap the bookmark on any session or guide to keep
+              it here.
             </p>
           </div>
         )}

--- a/app/(dashboard)/learning/save-button.tsx
+++ b/app/(dashboard)/learning/save-button.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-/* The heart on a Learning card (onboarding-proto's toggleHeart). It sits inside
+/* The bookmark on a Learning card (onboarding-proto's toggleHeart). It sits inside
    the teaser's <Link>, so the click must NOT navigate — preventDefault +
    stopPropagation keep the save local. Optimistic: flip on click, reconcile
    from the server, roll back on failure. Toggle endpoint: POST /api/saved. */
@@ -78,7 +78,7 @@ export default function SaveButton({
         strokeLinecap="round"
         strokeLinejoin="round"
       >
-        <path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.6l-1-1a5.5 5.5 0 0 0-7.8 7.8l1 1L12 21l7.8-7.6 1-1a5.5 5.5 0 0 0 0-7.8Z" />
+        <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />
       </svg>
     </button>
   );

--- a/app/components/content/teasers.tsx
+++ b/app/components/content/teasers.tsx
@@ -58,14 +58,14 @@ export function EventTeaser({
   corner?: ReactNode;
 }) {
   return (
-    <Link className="card tappable event-card" href={`/events/${e.slug}`}>
-      <MediaFrame
-        img={e.img}
-        grad={e.grad}
-        tag={e.kind}
-        square
-        corner={corner}
-      />
+    <Link
+      className={`card tappable event-card${corner ? " has-save" : ""}`}
+      href={`/events/${e.slug}`}
+    >
+      <MediaFrame img={e.img} grad={e.grad} tag={e.kind} square />
+      {/* Save button lives at the card level (not inside the thumbnail) so it can
+          pin to the card's top-right on mobile, where the thumbnail is only 1/4 wide. */}
+      {corner}
       <div className="card-body">
         <div className="lbl lbl-teal">{fmtDate(e.start_at)}</div>
         <div className="t-h4 card-title" style={{ margin: "6px 0 4px" }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -571,6 +571,9 @@ button:focus-visible {
      event covers are 1:1 natively, so synced images render uncropped). */
   .media.sq, .cards.dense .media.sq { aspect-ratio: 1 / 1; }
   .cards.dense .t-h4 { font-size: 15px; line-height: 20px; }
+  /* Positioning context so the save button (a direct child of the event card,
+     not the thumbnail) can pin to the card's top-right corner. */
+  .card.event-card { position: relative; }
   /* Event teasers go horizontal on phones — square thumbnail (1/4 width) on
      the left, the vertically-stacked info on the right. `align-items:
      flex-start` keeps the media at its 1:1 aspect ratio instead of stretching. */
@@ -581,6 +584,12 @@ button:focus-visible {
        already carries the event's details, so drop it in this compact layout */
     .card.event-card .media .m-tag { display: none; }
     .card.event-card .card-body { flex: 1; min-width: 0; }
+    /* each info row is limited to a single line (ellipsis) in the compact layout */
+    .card.event-card .card-body .lbl,
+    .card.event-card .card-body .t-small { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .card.event-card .card-title { -webkit-line-clamp: 1; }
+    /* reserve room on the right for the save button pinned to the card's top-right */
+    .card.event-card.has-save .card-body { padding-right: 46px; }
   }
   @media (min-width: 700px) { .cards.dense { grid-template-columns: repeat(2, 1fr); } }
   @media (min-width: 768px) {


### PR DESCRIPTION
## What

Three refinements to the mobile event-card layout: single-line info rows, a heart→bookmark icon swap (global), and moving the save icon to the card's top-right on mobile.

## Changes

- **Bookmark icon (global):** swapped the heart `<path>` for a bookmark in `SaveButton` (`app/(dashboard)/learning/save-button.tsx`) — the only rendered save icon in the app — keeping the fill-when-saved toggle (outline unsaved / filled saved). Updated the matching "Tap the bookmark…" copy on `app/(dashboard)/learning/page.tsx`.
- **Icon to card top-right:** re-parented the save button from inside `MediaFrame` to a direct child of the `EventTeaser` card (`app/components/content/teasers.tsx`), and added `.card.event-card { position: relative }` so it anchors to the card. On mobile (thumbnail only 1/4 wide) this moves the icon from mid-card to the card's top-right; desktop is visually unchanged (full-width thumbnail → card-top-right == the old media-top-right).
- **One-line info rows (mobile ≤699px):** date/location get `white-space: nowrap` + ellipsis; the title clamps to 1 line (was 2). Cards that show a save icon (`has-save`) reserve right-side padding so the text never runs under the button.

## Verify

Compiled the real `globals.css` with the project's Tailwind v4 toolchain and measured the rendered markup in Chromium. At 390px: each info row is exactly 1 line, the save button's box sits at the card's top-right (within 12px of the card's top/right edges) with the info text ending ~4px before it (no overlap), and the bookmark renders outline/filled by state. At 900px the card reverts to the stacked grid with the icon over the full-width thumbnail and the long title wrapping to 2 lines. Eyeballed both screenshots.

- [x] `npm run lint` passes (0 errors; 8 pre-existing warnings unrelated to this change)
- [x] `npm run test` passes (39/39)
- [x] `npm run build` passes

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNX9AieGXahUVLsWmdxVrF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNX9AieGXahUVLsWmdxVrF)_