### PR TITLE
Remove the breadcrumb "document bar" from the public pages

### DIFF
--- a/app/(public)/about/page.tsx
+++ b/app/(public)/about/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { Crumbs } from "@/app/components/content/teasers";
 
 /* The public About page — recomposed on the editorial "standards-manual" grid
    (ref: 1976 NASA Graphics Standards Manual, Column Five, The Futur): a document
@@ -16,11 +15,6 @@ export const metadata = {
   description:
     "We believe people are capable of far more than they’ve been given the opportunity to prove. That’s why The Upskilling Labs exists.",
 };
-
-const TRAIL: [string, string | null][] = [
-  ["Home", "/"],
-  ["About", null],
-];
 
 const BELIEFS = [
   "People are more capable than they realize.",
@@ -121,23 +115,6 @@ function RailQuote({ children }: { children: React.ReactNode }) {
 export default function AboutPage() {
   return (
     <>
-      {/* Document bar — identifier left, section ref right, rule under */}
-      <div className="container" style={{ paddingTop: 22 }}>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "baseline",
-            gap: 16,
-            paddingBottom: 12,
-          }}
-        >
-          <Crumbs trail={TRAIL} />
-          <span className="lbl">The Upskilling Labs · About</span>
-        </div>
-        <hr className="ed-rule" style={{ marginBottom: 0 }} />
-      </div>
-
       {/* ── Editorial header ── */}
       <section className="grain on-dark" style={{ background: "var(--ink)" }}>
         <div className="container" style={{ paddingTop: 88, paddingBottom: 88 }}>

--- a/app/(public)/build-cycles/page.tsx
+++ b/app/(public)/build-cycles/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { Crumbs } from "@/app/components/content/teasers";
 import { getEvents } from "@/lib/content/queries";
 import { fmtDate, fmtDay } from "@/lib/content/format";
 
@@ -20,11 +19,6 @@ export const metadata = {
   description:
     "Three months from now, you’ll have built something real. Pick a problem, team up, and see it through — in the open.",
 };
-
-const TRAIL: [string, string | null][] = [
-  ["Home", "/"],
-  ["Build Cycles", null],
-];
 
 // The current cycle's public shape, inlined from the prototype's
 // cycles/data.js (CYCLE_PUBLIC + SITUATIONS). These constants move to the
@@ -95,10 +89,6 @@ export default async function BuildCyclesPage() {
 
   return (
     <>
-      <div className="container">
-        <Crumbs trail={TRAIL} />
-      </div>
-
       {/* ── Dark hero (the generator's darkHero()) ── */}
       <section className="grain" style={{ background: "var(--ink)", color: "#fff" }}>
         <div className="reading" style={{ paddingTop: 56, paddingBottom: 56 }}>

--- a/app/(public)/code-of-conduct/page.tsx
+++ b/app/(public)/code-of-conduct/page.tsx
@@ -12,11 +12,6 @@ export const metadata = {
     "The expectations for everyone who takes part in The Upskilling Labs community.",
 };
 
-const TRAIL: [string, string | null][] = [
-  ["Home", "/"],
-  ["Code of Conduct", null],
-];
-
 const h2 = { marginTop: 44, marginBottom: 12 } as const;
 const p = { marginBottom: 16 } as const;
 
@@ -38,7 +33,6 @@ export default function CodeOfConductPage() {
       eyebrow="Community"
       title="Code of Conduct"
       lede="The expectations for everyone who takes part — so the Labs stays a place where anyone can show up, contribute, and belong."
-      trail={TRAIL}
     >
       <p className="t-small" style={{ marginBottom: 28 }}>
         Effective date: July 6, 2026

--- a/app/(public)/contact/page.tsx
+++ b/app/(public)/contact/page.tsx
@@ -12,11 +12,6 @@ export const metadata = {
     "Get in touch with The Upskilling Labs — partnerships, sponsorship, venues, and general questions.",
 };
 
-const TRAIL: [string, string | null][] = [
-  ["Home", "/"],
-  ["Contact", null],
-];
-
 const h2 = { marginTop: 44, marginBottom: 12 } as const;
 const p = { marginBottom: 16 } as const;
 
@@ -32,7 +27,6 @@ export default function ContactPage() {
       eyebrow="Get in touch"
       title="Partner with us"
       lede="Interested in supporting our mission? We’re always looking for people and organizations to build with."
-      trail={TRAIL}
     >
       <p className="t-body" style={p}>
         The Upskilling Labs runs in the open and grows through partnership. Whether

--- a/app/(public)/donate/page.tsx
+++ b/app/(public)/donate/page.tsx
@@ -14,11 +14,6 @@ export const metadata = {
     "By giving today, you’re helping build a new institution for the future. The Upskilling Labs is a fiscally sponsored 501(c)(3) project of Superbloom Design.",
 };
 
-const TRAIL: [string, string | null][] = [
-  ["Home", "/"],
-  ["Donate", null],
-];
-
 const h2 = { marginTop: 44, marginBottom: 16 } as const;
 const p = { marginBottom: 16 } as const;
 
@@ -39,7 +34,6 @@ export default function DonatePage() {
       eyebrow="Support The Labs"
       title="Make an impact today"
       lede="By giving today, you’re helping build a new institution for the future. Your contributions directly support the work we do."
-      trail={TRAIL}
     >
       <a className="btn btn-red btn-lg" href={DONATE_URL} target="_blank" rel="noopener">
         Give now

--- a/app/(public)/events/[slug]/page.tsx
+++ b/app/(public)/events/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { Crumbs, EventTeaser } from "@/app/components/content/teasers";
+import { EventTeaser } from "@/app/components/content/teasers";
 import { getEvent, getEvents } from "@/lib/content/queries";
 import { fmtDate, fmtDay, fmtTime } from "@/lib/content/format";
 import { publicSession } from "@/lib/auth/public-session";
@@ -110,11 +110,6 @@ export default async function EventPage({
 
   return (
     <>
-      <div className="container">
-        <Crumbs
-          trail={[["Home", "/"], ["Events", "/events"], [e.name, null]]}
-        />
-      </div>
       <div className="container">
         <div className="detail" style={{ marginTop: 16 }}>
           <div className="detail-main">

--- a/app/(public)/events/page.tsx
+++ b/app/(public)/events/page.tsx
@@ -1,4 +1,4 @@
-import { Crumbs, EventTeaser } from "@/app/components/content/teasers";
+import { EventTeaser } from "@/app/components/content/teasers";
 import { getEvents } from "@/lib/content/queries";
 
 /* The public events directory — the generator's directoryPage('events'):
@@ -22,9 +22,6 @@ export default async function EventsPage() {
 
   return (
     <>
-      <div className="container">
-        <Crumbs trail={[["Home", "/"], ["Events", null]]} />
-      </div>
       <section className="section">
         <div className="container">
           <div className="section-head">

--- a/app/(public)/get-involved/page.tsx
+++ b/app/(public)/get-involved/page.tsx
@@ -13,11 +13,6 @@ export const metadata = {
     "Everything the Labs does is made possible by volunteers. Mentor, help at an event, or help build the Labs itself.",
 };
 
-const TRAIL: [string, string | null][] = [
-  ["Home", "/"],
-  ["Get Involved", null],
-];
-
 const h2 = { marginTop: 44, marginBottom: 16 } as const;
 
 const TEAMS: [string, string][] = [
@@ -35,7 +30,6 @@ export default function GetInvolvedPage() {
       eyebrow="Volunteer with The Labs"
       title="Everything we do is made possible by volunteers."
       lede="Whether you’re sharing your expertise, showing up to support an event, or helping build the Labs from the ground up, there’s a place for you here."
-      trail={TRAIL}
     >
       <h2 className="t-h2" style={h2}>Join us for a day — or a build cycle</h2>
       <p className="t-body" style={{ marginBottom: 16 }}>

--- a/app/(public)/library/[slug]/page.tsx
+++ b/app/(public)/library/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
 import {
-  Crumbs,
   MediaFrame,
   ResourceTeaser,
 } from "@/app/components/content/teasers";
@@ -65,9 +64,6 @@ export default async function ResourcePage({
 
   return (
     <>
-      <div className="container">
-        <Crumbs trail={[["Home", "/"], ["Library", "/library"], [r.title, null]]} />
-      </div>
       <div className="container">
         <div className="detail" style={{ marginTop: 16 }}>
           <div className="detail-main">

--- a/app/(public)/library/page.tsx
+++ b/app/(public)/library/page.tsx
@@ -1,4 +1,4 @@
-import { Crumbs, ResourceTeaser } from "@/app/components/content/teasers";
+import { ResourceTeaser } from "@/app/components/content/teasers";
 import { getResources } from "@/lib/content/queries";
 
 /* The Learning Library directory — the prototype generator's
@@ -20,9 +20,6 @@ export default async function LibraryPage() {
 
   return (
     <>
-      <div className="container">
-        <Crumbs trail={[["Home", "/"], ["Library", null]]} />
-      </div>
       <section className="section">
         <div className="container">
           <div className="section-head">

--- a/app/(public)/local-labs/[slug]/page.tsx
+++ b/app/(public)/local-labs/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import {
-  Crumbs,
   EventTeaser,
   LabTeaser,
   MediaFrame,
@@ -77,19 +76,10 @@ export default async function LabPage({
   const m = await getMetro(slug);
   if (!m) notFound();
 
-  const crumbs = (
-    <div className="container">
-      <Crumbs
-        trail={[["Home", "/"], ["Local labs", "/local-labs"], [labTitle(m), null]]}
-      />
-    </div>
-  );
-
   if (m.status === "active") {
     const events = (await getEvents()).slice(0, 3);
     return (
       <>
-        {crumbs}
         <section
           className="grain"
           style={{
@@ -226,7 +216,6 @@ export default async function LabPage({
 
   return (
     <>
-      {crumbs}
       <div className="container">
         <div className="detail" style={{ marginTop: 16 }}>
           <div className="detail-main">

--- a/app/(public)/local-labs/page.tsx
+++ b/app/(public)/local-labs/page.tsx
@@ -1,4 +1,3 @@
-import { Crumbs } from "@/app/components/content/teasers";
 import MetroSearch from "@/app/components/content/metro-search";
 import { getMetros } from "@/lib/content/queries";
 
@@ -23,9 +22,6 @@ export default async function LabsPage() {
 
   return (
     <>
-      <div className="container">
-        <Crumbs trail={[["Home", "/"], ["Local labs", null]]} />
-      </div>
       <section className="section">
         <div className="container">
           <div className="section-head">

--- a/app/(public)/privacy/page.tsx
+++ b/app/(public)/privacy/page.tsx
@@ -12,11 +12,6 @@ export const metadata = {
     "How The Upskilling Labs collects, uses, and protects your information on the OLOS platform.",
 };
 
-const TRAIL: [string, string | null][] = [
-  ["Home", "/"],
-  ["Privacy Policy", null],
-];
-
 const h2 = { marginTop: 44, marginBottom: 12 } as const;
 const p = { marginBottom: 16 } as const;
 
@@ -26,7 +21,6 @@ export default function PrivacyPage() {
       eyebrow="Legal"
       title="Privacy Policy"
       lede="What we collect through OLOS, how we use it, and the choices you have."
-      trail={TRAIL}
     >
       <p className="t-small" style={{ marginBottom: 28 }}>
         Effective date: July 3, 2026

--- a/app/(public)/stories/[slug]/page.tsx
+++ b/app/(public)/stories/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Crumbs } from "@/app/components/content/teasers";
 import Orb from "@/app/components/chrome/orb";
 import {
   getSpotlight,
@@ -90,10 +89,6 @@ export default async function SpotlightPage({
 
   return (
     <>
-      <div className="container">
-        <Crumbs trail={[["Home", "/"], ["Stories", "/stories"], [s.name, null]]} />
-      </div>
-
       {/* On-brand dark hero */}
       <section className="grain on-dark" style={{ background: "var(--ink)" }}>
         <div className="container" style={{ paddingTop: 48, paddingBottom: 48 }}>

--- a/app/(public)/stories/page.tsx
+++ b/app/(public)/stories/page.tsx
@@ -1,4 +1,3 @@
-import { Crumbs } from "@/app/components/content/teasers";
 import { getPublishedSpotlights } from "@/lib/content/spotlights";
 import StoriesClient from "./stories-client";
 
@@ -21,10 +20,6 @@ export default async function StoriesPage() {
 
   return (
     <>
-      <div className="container">
-        <Crumbs trail={[["Home", "/"], ["Stories", null]]} />
-      </div>
-
       {/* Dark hero (the generator's darkHero()) */}
       <section className="grain" style={{ background: "var(--ink)", color: "#fff" }}>
         <div className="reading" style={{ paddingTop: 56, paddingBottom: 56 }}>

--- a/app/(public)/team/page.tsx
+++ b/app/(public)/team/page.tsx
@@ -13,11 +13,6 @@ export const metadata = {
     "The people behind The Upskilling Labs — the National Capital Region leadership team, board, and advisors.",
 };
 
-const TRAIL: [string, string | null][] = [
-  ["Home", "/"],
-  ["The Team", null],
-];
-
 // [name | null-if-open, role]
 const LEADERSHIP: [string | null, string][] = [
   ["Madhu Jalan", "Programs & Events Co-Lead"],
@@ -72,7 +67,6 @@ export default function TeamPage() {
       eyebrow="National Capital Region"
       title="Meet the team"
       lede="The people building The Upskilling Labs — in the open, alongside a community of volunteers."
-      trail={TRAIL}
     >
       <Group title="Leadership team" members={LEADERSHIP} />
       <Group title="Our board" members={BOARD} />

--- a/app/(public)/terms/page.tsx
+++ b/app/(public)/terms/page.tsx
@@ -12,11 +12,6 @@ export const metadata = {
     "The terms that govern your use of the OLOS platform operated by The Upskilling Labs.",
 };
 
-const TRAIL: [string, string | null][] = [
-  ["Home", "/"],
-  ["Terms of Service", null],
-];
-
 const h2 = { marginTop: 44, marginBottom: 12 } as const;
 const p = { marginBottom: 16 } as const;
 
@@ -26,7 +21,6 @@ export default function TermsPage() {
       eyebrow="Legal"
       title="Terms of Service"
       lede="The terms you agree to when you create an account or use OLOS."
-      trail={TRAIL}
     >
       <p className="t-small" style={{ marginBottom: 28 }}>
         Effective date: July 3, 2026

--- a/app/components/chrome/prose-page.tsx
+++ b/app/components/chrome/prose-page.tsx
@@ -1,5 +1,3 @@
-import { Crumbs } from "@/app/components/content/teasers";
-
 /* Shared shell for the simple public prose pages (legal, contact, team,
    get-involved, donate): the same dark hero + 760px reading column the About
    page uses, factored out so each page only supplies its body. Server
@@ -8,34 +6,15 @@ export function ProsePage({
   eyebrow,
   title,
   lede,
-  trail,
   children,
 }: {
   eyebrow: string;
   title: string;
   lede?: React.ReactNode;
-  trail: [string, string | null][];
   children: React.ReactNode;
 }) {
   return (
     <>
-      {/* Document bar — crumbs left, identifier right, rule under */}
-      <div className="container" style={{ paddingTop: 22 }}>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "baseline",
-            gap: 16,
-            paddingBottom: 12,
-          }}
-        >
-          <Crumbs trail={trail} />
-          <span className="lbl">The Upskilling Labs</span>
-        </div>
-        <hr className="ed-rule" style={{ marginBottom: 0 }} />
-      </div>
-
       {/* ── Editorial header ── */}
       <section className="grain on-dark" style={{ background: "var(--ink)" }}>
         <div className="container" style={{ paddingTop: 88, paddingBottom: 88 }}>

--- a/app/components/content/teasers.tsx
+++ b/app/components/content/teasers.tsx
@@ -127,16 +127,3 @@ export function LabTeaser({ metro: m }: { metro: MetroRow }) {
     </Link>
   );
 }
-
-export function Crumbs({ trail }: { trail: [string, string | null][] }) {
-  return (
-    <div className="crumbs">
-      {trail.map(([label, href], i) => (
-        <span key={label} style={{ display: "contents" }}>
-          {i > 0 && <span className="sep">/</span>}
-          {href ? <Link href={href}>{label}</Link> : <span>{label}</span>}
-        </span>
-      ))}
-    </div>
-  );
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -649,11 +649,6 @@ button:focus-visible {
     .cards.dense { grid-template-columns: repeat(auto-fit, minmax(min(100%, 170px), 1fr)); gap: 20px; }
   }
 
-  /* ── kv label + crumbs ── */
-  .crumbs { display: flex; align-items: center; gap: 8px; padding: 20px 0 0; font-size: 13px; color: var(--meta); }
-  .crumbs a { color: var(--teal-deep); text-decoration: none; font-weight: 600; }
-  .crumbs .sep { color: var(--meta-soft); }
-
   /* ── gate / alert banner (white card, colored left edge) ── */
   .gate-banner { background: var(--white); border: 1px solid var(--rule); border-left: 4px solid var(--red); border-radius: var(--r); padding: 20px 22px; }
   .gate-banner.unlocked { border-left-color: var(--teal); }


### PR DESCRIPTION
## What

Removes the secondary navigation bar — the breadcrumb trail (Home / Events, Home / About, …) shown below the site nav on every public page except the landing. On the About and legal/prose pages it was wrapped in a "document bar" (breadcrumbs + a "The Upskilling Labs" identifier + a rule); on the directory/detail pages it stood on its own. The landing page never had one, so this drops it everywhere else and each public page now leads straight into its own header.

## Changes

- Drop the crumbs container from the events, library, local-labs, stories and build-cycles directory pages and their `[slug]` detail pages.
- Drop the whole document bar from About and from the shared `ProsePage` shell (contact, team, get-involved, donate, code-of-conduct, privacy, terms), removing the now-unused `trail` prop and per-page `TRAIL` constants.
- Retire the now-dead `Crumbs` component and its `.crumbs` styles (the admin dashboard's separate `Breadcrumbs` is untouched).

## Verify

- [x] `npm run lint` passes (0 errors; only pre-existing warnings in unrelated dashboard/api files)
- [x] `npm run test` passes (50 tests)
- [x] `npm run build` passes
- [x] `npx tsc --noEmit` clean

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012G3qvYB2StXPN3wKya9jVf)_