### PR TITLE
Events agenda polish: uniform card sizes + one slim toolbar

### DIFF
--- a/app/(public)/events/page.tsx
+++ b/app/(public)/events/page.tsx
@@ -23,12 +23,8 @@ export default async function EventsPage() {
   const events = await getEvents();
 
   // Server clock, passed down so the SSR and hydrated upcoming/past splits
-  // agree. Same in-progress rule as the island (end_at fallback start_at).
+  // agree with the island's in-progress rule (end_at fallback start_at).
   const nowMs = new Date().getTime();
-  const upcomingCount = events.filter(
-    (e) => new Date(e.end_at ?? e.start_at).getTime() >= nowMs
-  ).length;
-  const pastCount = events.length - upcomingCount;
 
   return (
     <section className="section">
@@ -36,13 +32,13 @@ export default async function EventsPage() {
         <div className="section-head">
           <div>
             <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
-              Events & workshops · {upcomingCount} upcoming · {pastCount} past
+              Events & workshops
             </div>
             <h1 className="t-h2">Drop into a session</h1>
           </div>
         </div>
-        <p className="t-lede" style={{ marginBottom: 28 }}>
-          Free and public, every one. ✦ marks the cycle’s six anchor events.
+        <p className="t-small" style={{ marginTop: -10, marginBottom: 14 }}>
+          Free and public, every one. ✦ marks the cycle’s anchor events.
         </p>
         {/* The island reads useSearchParams — Suspense keeps Next happy. */}
         <Suspense>

--- a/app/components/content/events-agenda.tsx
+++ b/app/components/content/events-agenda.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { CalendarX2, SearchX } from "lucide-react";
-import { EmptyState, FilterDropdown, Tabs } from "@/app/components/ui";
+import { EmptyState, FilterDropdown } from "@/app/components/ui";
 import { fmtMonth, monthKey } from "@/lib/content/format";
 import type { EventRow } from "@/lib/content/queries";
 import { EventTeaser } from "./teasers";
@@ -193,32 +193,39 @@ export default function EventsAgenda({
     set({ q: "", loc: null, anchor: false, kind: null });
   };
 
-  const countBadge = (n: number) => (
-    <span className="text-xs text-meta tabular-nums">{n}</span>
-  );
+  const isFiltered = !!q || activeFilterCount > 0;
 
   return (
-    <div>
-      <input
-        type="text"
-        placeholder="Search sessions and venues…"
-        value={qInput}
-        onChange={(e) => setQInput(e.target.value)}
-        aria-label="Search events"
-        className="w-full max-w-xl rounded-card border border-ink/10 bg-white px-3.5 py-2.5 text-base text-ink placeholder:text-meta-soft focus:border-teal focus:outline-none focus:ring-[3px] focus:ring-teal/15 transition-[border-color,box-shadow] duration-150"
-      />
-
-      <Tabs
-        className="mt-5"
-        value={view}
-        onValueChange={(v) => set({ view: v as View })}
-        tabs={[
-          { value: "upcoming", label: "Upcoming", badge: countBadge(filteredUpcoming.length) },
-          { value: "past", label: "Past", badge: countBadge(filteredPast.length) },
-        ]}
-      />
-
-      <div className="mt-4 flex flex-wrap items-center gap-2">
+    <div className="agenda">
+      {/* One slim toolbar — segmented view toggle, compact search, filter
+          chips, kind dropdown, reset — so the cards start near the fold. */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="seg" role="group" aria-label="Upcoming or past events">
+          {(
+            [
+              { key: "upcoming", label: "Upcoming", n: filteredUpcoming.length },
+              { key: "past", label: "Past", n: filteredPast.length },
+            ] as const
+          ).map((v) => (
+            <button
+              key={v.key}
+              type="button"
+              className={view === v.key ? "active" : undefined}
+              aria-pressed={view === v.key}
+              onClick={() => set({ view: v.key })}
+            >
+              {v.label} <span className="tabular-nums">{v.n}</span>
+            </button>
+          ))}
+        </div>
+        <input
+          type="text"
+          placeholder="Search sessions and venues…"
+          value={qInput}
+          onChange={(e) => setQInput(e.target.value)}
+          aria-label="Search events"
+          className="h-[38px] w-full rounded-card border border-ink/10 bg-white px-3 text-sm text-ink placeholder:text-meta-soft focus:border-teal focus:outline-none focus:ring-[3px] focus:ring-teal/15 transition-[border-color,box-shadow] duration-150 md:w-60"
+        />
         {LOC_FILTERS.map((f) => {
           const active = loc === f.key;
           return (
@@ -237,6 +244,7 @@ export default function EventsAgenda({
           type="button"
           className={`chip${anchor ? " active" : ""}`}
           aria-pressed={anchor}
+          title="The cycle's anchor events"
           onClick={() => set({ anchor: !anchor })}
         >
           ✦ Anchor events
@@ -259,15 +267,12 @@ export default function EventsAgenda({
             Reset filters ({activeFilterCount})
           </button>
         )}
+        {isFiltered && shown.length > 0 && (
+          <span className="text-xs text-meta tabular-nums">
+            {shown.length} of {total}
+          </span>
+        )}
       </div>
-
-      {shown.length > 0 && (
-        <p className="mb-3 mt-6 text-sm text-meta tabular-nums">
-          {shown.length === total
-            ? `${total} ${total === 1 ? "session" : "sessions"}`
-            : `${shown.length} of ${total} sessions`}
-        </p>
-      )}
 
       {shown.length === 0 ? (
         <div className="mt-6">

--- a/app/globals.css
+++ b/app/globals.css
@@ -309,7 +309,9 @@ dialog::backdrop {
   .see { cursor: pointer; }
   /* agenda month header — lighter than .section-head (a 2px ink rule repeated
      per month over-weights the hierarchy); hairline rule, ink weight. */
-  .month-head { font-weight: 600; font-size: 14px; line-height: 20px; letter-spacing: 0.01em; color: var(--ink); margin: 30px 0 14px; padding-bottom: 8px; border-bottom: 1px solid var(--rule); }
+  .month-head { font-weight: 600; font-size: 14px; line-height: 20px; letter-spacing: 0.01em; color: var(--ink); margin: 26px 0 12px; padding-bottom: 8px; border-bottom: 1px solid var(--rule); }
+  /* first month sits right under the toolbar — keep the fold tight */
+  .agenda > section:first-child .month-head { margin-top: 14px; }
 
   /* ── cards (teasers) ── */
   .card { background: var(--white); border: 1px solid var(--rule); border-radius: var(--r); overflow: hidden; transition: transform 0.2s cubic-bezier(0.2, 0.7, 0.1, 1), box-shadow 0.2s; }
@@ -333,6 +335,10 @@ dialog::backdrop {
   .chip { flex-shrink: 0; padding: 9px 16px; border-radius: var(--r); border: 1px solid var(--rule); background: var(--white); font-size: 13px; font-weight: 600; color: var(--charcoal); cursor: pointer; white-space: nowrap; transition: all 0.14s; }
   .chip.active { background: var(--ink); color: #fff; border-color: var(--ink); }
   .chip:active { transform: scale(0.97); }
+  /* segmented toggle (events agenda Upcoming/Past) — chip grammar, one container */
+  .seg { display: inline-flex; align-items: center; border: 1px solid var(--rule); border-radius: var(--r); background: var(--white); padding: 3px; gap: 2px; flex-shrink: 0; }
+  .seg button { border: none; background: none; font-family: inherit; font-size: 13px; font-weight: 600; color: var(--charcoal); padding: 6px 12px; border-radius: calc(var(--r) - 4px); cursor: pointer; white-space: nowrap; transition: background 0.14s, color 0.14s; }
+  .seg button.active { background: var(--ink); color: #fff; }
 
   /* ── kv rows + status pills ── */
   .kv { display: flex; gap: 12px; padding: 10px 0; border-bottom: 1px solid var(--rule); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -649,7 +649,10 @@ button:focus-visible {
   }
   @media (min-width: 1024px) {
     .cards.three { grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr)); }
-    .cards.dense { grid-template-columns: repeat(auto-fit, minmax(min(100%, 170px), 1fr)); gap: 20px; }
+    /* auto-FILL (not auto-fit): keep empty tracks so a short row — e.g. an
+       agenda month with two events — renders the same card size as a full
+       one, instead of stretching a few cards across the whole row. */
+    .cards.dense { grid-template-columns: repeat(auto-fill, minmax(min(100%, 170px), 1fr)); gap: 20px; }
   }
 
   /* ── gate / alert banner (white card, colored left edge) ── */


### PR DESCRIPTION
## What

Two follow-ups to the events agenda (#206): cards keep the same size in every row, and the controls condense from four stacked rows into one slim toolbar so events sit near the fold.

## Changes

- **Uniform card sizes**: `.cards.dense` desktop grid switches `auto-fit` → `auto-fill`, keeping empty column tracks so a month with two events renders the same card size as a full month instead of stretching oversized cards. Also fixes the same sparse-row stretch on any other dense grid (e.g. Learning's Saved section).
- **Slim toolbar** (`events-agenda.tsx`): the search row, underline-tabs row, filter row, and count line collapse into a single wrapping toolbar — a Luma-style `Upcoming N | Past M` segmented toggle (new `.seg` control in globals.css, chip grammar), a compact `h-[38px]` search box (full-width only on phones), the Online/In-person/✦ chips (the ✦ legend moves to a tooltip), the Kind dropdown, reset, and an inline "n of m" readout shown only while filtering.
- **Slimmer public header**: eyebrow drops its duplicate counts (they live on the toggle now); the `t-lede` paragraph becomes a tight `t-small` one-liner; month headers pull up under the toolbar (`.agenda > section:first-child .month-head`).
- No state-machine changes — filters, URL deep-links, and back/forward behave exactly as before; `/learning#events` inherits the condensed layout via the shared island.

## Verify

- [x] `npm run lint` passes (0 errors; 8 pre-existing warnings elsewhere)
- [x] `npm run test` passes (53 tests)
- [x] `npm run build` passes

Preview spot-check: `/events` — first month's cards visible without scrolling at desktop; a 2-event month shows normal-size cards; toggle/filters/search/deep-links unchanged; 375px shows search on its own line with chips wrapping beneath.

## Database

- [x] No schema change, **or** a migration was added under `supabase/migrations/`
      (new number, `SCHEMA.md` updated). Prod migrations are applied by a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJR3N2wPkk6VTHHp86cdLx

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJR3N2wPkk6VTHHp86cdLx)_