### PR TITLE
Landing: fill the events section to capacity across months

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,8 @@ import {
   ResourceTeaser,
 } from "@/app/components/content/teasers";
 import { getEvents, getResources, getMetros } from "@/lib/content/queries";
+import type { EventRow } from "@/lib/content/queries";
+import { monthKey } from "@/lib/content/format";
 import { publicSession } from "@/lib/auth/public-session";
 import { createServiceClient } from "@/lib/supabase/server";
 import { getRecruitingCycle } from "@/lib/cycle/active";
@@ -69,9 +71,38 @@ export default async function LandingPage() {
       })
     : null;
 
+  // Fill the events section to capacity — a dozen cards — sampled round-robin
+  // across upcoming months so one busy month can't monopolize the section
+  // (getEvents() is start_at ASC, so each month bucket stays soonest-first).
+  // If upcoming events run short, top up with the most recent past ones.
+  const LANDING_EVENT_CAP = 12;
   const now = new Date();
-  const upcoming = events.filter((e) => new Date(e.start_at) >= now);
-  const landingEvents = (upcoming.length >= 6 ? upcoming : events).slice(0, 6);
+  const upcoming = events.filter(
+    (e) => new Date(e.end_at ?? e.start_at) >= now
+  );
+  const byMonth = new Map<string, EventRow[]>();
+  for (const e of upcoming) {
+    const k = monthKey(e.start_at);
+    byMonth.set(k, [...(byMonth.get(k) ?? []), e]);
+  }
+  const buckets = [...byMonth.values()];
+  const picked: EventRow[] = [];
+  for (let round = 0; picked.length < LANDING_EVENT_CAP; round++) {
+    const before = picked.length;
+    for (const bucket of buckets) {
+      if (bucket[round]) picked.push(bucket[round]);
+      if (picked.length >= LANDING_EVENT_CAP) break;
+    }
+    if (picked.length === before) break; // every bucket exhausted
+  }
+  picked.sort((a, b) => a.start_at.localeCompare(b.start_at));
+  if (picked.length < LANDING_EVENT_CAP) {
+    const recentPast = events
+      .filter((e) => new Date(e.end_at ?? e.start_at) < now)
+      .reverse(); // ASC in → newest first
+    picked.push(...recentPast.slice(0, LANDING_EVENT_CAP - picked.length));
+  }
+  const landingEvents = picked;
   const landingResources = resources.slice(0, 6);
   const landingLabs = metros.slice(0, 4);
 
@@ -279,7 +310,9 @@ export default async function LandingPage() {
               All events →
             </Link>
           </div>
-          <div className="cards dense">
+          {/* `.all` lifts the landing six-card cap — this section runs at
+              full capacity (LANDING_EVENT_CAP) across months. */}
+          <div className="cards dense all">
             {landingEvents.map((e) => (
               <EventTeaser key={e.slug} event={e} />
             ))}


### PR DESCRIPTION
## What

The landing page's events section sliced the next six events chronologically — with one busy month, all six cards were from the same month and the grid sat half-empty on wide screens. It now fills to capacity with month diversity.

## Changes

- Twelve cards instead of six, rendered with `.cards.dense.all` so the landing six-card desktop cap doesn't hide the second row.
- Events are sampled **round-robin across upcoming months** (each bucket soonest-first), then re-sorted chronologically — so a busy current month can't monopolize the section and later months are represented.
- If upcoming events run short of twelve, the section tops up with the most recent past events (newest first).
- The "upcoming" test now matches the agenda's rule (`end_at ?? start_at` — in-progress events still count as upcoming).

## Verify

- [x] `npm run lint` passes (0 errors; 8 pre-existing warnings elsewhere)
- [x] `npm run test` passes (53 tests)
- [x] `npm run build` passes

Preview spot-check: landing `#sec-events` shows two full rows spanning multiple months in date order.

## Database

- [x] No schema change, **or** a migration was added under `supabase/migrations/`
      (new number, `SCHEMA.md` updated). Prod migrations are applied by a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJR3N2wPkk6VTHHp86cdLx

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJR3N2wPkk6VTHHp86cdLx)_