### PR TITLE
Publishing prep: unified privacy policy, apex domain, drop draft language

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,7 +14,7 @@ RESEND_API_KEY=re_your_api_key_here
 RESEND_FROM_EMAIL=noreply@enroll.theupskillinglabs.org
 
 # Public app URL (used to build magic links in emails)
-NEXT_PUBLIC_APP_URL=https://olos.theupskillinglabs.org
+NEXT_PUBLIC_APP_URL=https://theupskillinglabs.org
 
 # External integrations (Week 2+)
 # SLACK_BOT_TOKEN=

--- a/.env.local.example
+++ b/.env.local.example
@@ -14,7 +14,7 @@ RESEND_API_KEY=re_your_api_key_here
 RESEND_FROM_EMAIL=noreply@enroll.theupskillinglabs.org
 
 # Public app URL (used to build magic links in emails)
-NEXT_PUBLIC_APP_URL=https://app.theupskillinglabs.org
+NEXT_PUBLIC_APP_URL=https://olos.theupskillinglabs.org
 
 # External integrations (Week 2+)
 # SLACK_BOT_TOKEN=

--- a/app/(auth)/login/login-card.tsx
+++ b/app/(auth)/login/login-card.tsx
@@ -133,8 +133,8 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
 
   const finePrint = (
     <p className="t-small">
-      We only access your name and email. Already a member? Same door — Google
-      signs you in either way.
+      We only access your name, email, and profile picture. Already a member?
+      Same door — Google signs you in either way.
     </p>
   );
 

--- a/app/(public)/code-of-conduct/page.tsx
+++ b/app/(public)/code-of-conduct/page.tsx
@@ -1,8 +1,7 @@
 import { ProsePage } from "@/app/components/chrome/prose-page";
 
 /* Code of Conduct — hosted on-site. Copy mirrors docs/legal/CODE_OF_CONDUCT.md
-   (the source of truth); keep the two in sync. Note: newly authored — pending
-   org/board review before it is treated as final. */
+   (the source of truth); keep the two in sync when either changes. */
 
 export const dynamic = "force-dynamic";
 

--- a/app/(public)/privacy/page.tsx
+++ b/app/(public)/privacy/page.tsx
@@ -2,36 +2,50 @@ import { ProsePage } from "@/app/components/chrome/prose-page";
 
 /* Privacy Policy — hosted on-site (previously only linked to GitHub markdown).
    Copy mirrors docs/legal/PRIVACY_POLICY.md (the source of truth); keep the two
-   in sync when either changes. */
+   in sync when either changes. Covers the unified site + platform now that the
+   marketing site folds into this app. */
 
 export const dynamic = "force-dynamic";
 
 export const metadata = {
   title: "Privacy Policy · The Upskilling Labs",
   description:
-    "How The Upskilling Labs collects, uses, and protects your information on the OLOS platform.",
+    "How The Upskilling Labs collects, uses, and protects your information across theupskillinglabs.org and the OLOS platform.",
 };
 
 const h2 = { marginTop: 44, marginBottom: 12 } as const;
 const p = { marginBottom: 16 } as const;
+
+function List({ items }: { items: string[] }) {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      {items.map((t) => (
+        <div className="kv" key={t}>
+          <span className="t-body">{t}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export default function PrivacyPage() {
   return (
     <ProsePage
       eyebrow="Legal"
       title="Privacy Policy"
-      lede="What we collect through OLOS, how we use it, and the choices you have."
+      lede="What we collect across our website and the OLOS platform, how we use it, and the choices you have."
     >
       <p className="t-small" style={{ marginBottom: 28 }}>
-        Effective date: July 3, 2026
+        Effective date: July 9, 2026
       </p>
 
       <p className="t-body" style={p}>
-        The Upskilling Labs, Inc. (“The Labs,” “we,” “us”) operates OLOS (Open Labs
-        OS), a platform supporting peer-driven learning cycles and community
-        programs for people navigating career transitions. This Privacy Policy
-        explains what information we collect through OLOS, how we use it, and the
-        choices you have.
+        The Upskilling Labs, Inc. (“The Labs,” “we,” “us”) operates
+        theupskillinglabs.org and OLOS (Open Labs OS), the platform behind it —
+        supporting peer-driven learning cycles and community programs for people
+        navigating career transitions. This Privacy Policy explains what
+        information we collect, how we use it, and the choices you have. It
+        covers both our public website and the OLOS platform.
       </p>
       <p className="t-body" style={p}>
         This Privacy Policy is part of the Participant Agreement every member accepts
@@ -46,38 +60,63 @@ export default function PrivacyPage() {
         Calendar, or other Google data).
       </p>
       <p className="t-body" style={p}>
-        <strong>Through registration and program forms:</strong> If you register as
-        a participant, volunteer, or mentor, we may collect your name, email
-        address, ZIP code, current work situation, role or program interests, and
-        any consents you provide during onboarding.
+        <strong>Through forms on our site:</strong> When you fill out a form — to
+        register, join a program, volunteer, mentor, partner, donate, subscribe to
+        updates, or contact us — we may collect your name, email address, phone
+        number (if you provide it), ZIP code, current work situation, role or
+        program interests, responses to interest and background questions, and any
+        consents you provide.
       </p>
       <p className="t-body" style={p}>
         <strong>Through your use of the platform:</strong> We keep records of your
         program enrollments, role assignments (e.g., moderator, mentor), and
         participation status within cycles and pods.
       </p>
+      <p className="t-body" style={p}>
+        <strong>Cookies:</strong> We use a strictly necessary cookie to keep you
+        signed in (set by Supabase Auth). We do not use advertising or third-party
+        tracking cookies.
+      </p>
 
       <h2 className="t-h2" style={h2}>2. How we use your information</h2>
       <p className="t-body" style={p}>We use the information we collect to:</p>
-      <div style={{ marginBottom: 16 }}>
-        {[
+      <List
+        items={[
           "Create and manage your account and participant profile",
           "Match you to relevant cycles, pods, events, or mentorship opportunities",
-          "Send you programmatic communications (e.g., invitations, onboarding steps, cycle updates) via email",
+          "Send you communications — invitations, onboarding steps, cycle updates, newsletters, and program announcements — via email",
+          "Coordinate programming and events with collaborating organizations",
           "Operate moderator and admin tools that support program delivery",
+          "Report to our funders and fiscal sponsor for grant administration and compliance",
           "Improve and maintain the platform",
-        ].map((t) => (
-          <div className="kv" key={t}>
-            <span className="t-body">{t}</span>
-          </div>
-        ))}
-      </div>
+        ]}
+      />
       <p className="t-body" style={p}>
         We do not sell your personal information, and we do not use it for
         advertising.
       </p>
 
-      <h2 className="t-h2" style={h2}>3. How we store and protect information</h2>
+      <h2 className="t-h2" style={h2}>3. How we share your information</h2>
+      <p className="t-body" style={p}>
+        We share personal information only as needed to run our programs:
+      </p>
+      <div style={{ marginBottom: 16 }}>
+        {[
+          ["Our fiscal sponsor (Superbloom)", "for administrative and grant-management purposes"],
+          ["Funders", "for reporting and compliance"],
+          ["Collaborating organizations", "to coordinate programming and events"],
+          ["Service providers", "the vendors listed below, who process data on our behalf"],
+        ].map(([name, use]) => (
+          <div className="kv" key={name}>
+            <span className="t-body">
+              <strong>{name}</strong> — {use}
+            </span>
+          </div>
+        ))}
+      </div>
+      <p className="t-body" style={p}>We do not sell your personal information.</p>
+
+      <h2 className="t-h2" style={h2}>4. How we store and protect information</h2>
       <p className="t-body" style={p}>
         Your information is stored in a hosted Postgres database (via Supabase) with
         access controls limiting who on our team can view participant data.
@@ -85,15 +124,16 @@ export default function PrivacyPage() {
         your Google password.
       </p>
 
-      <h2 className="t-h2" style={h2}>4. Third-party services</h2>
+      <h2 className="t-h2" style={h2}>5. Third-party services</h2>
       <p className="t-body" style={p}>
-        We use the following third-party services to operate OLOS:
+        We use the following third-party services to operate The Upskilling Labs:
       </p>
       <div style={{ marginBottom: 16 }}>
         {[
           ["Google", "for account sign-in (OAuth)"],
           ["Supabase", "for database hosting and authentication infrastructure"],
-          ["Resend", "for transactional and invitation emails sent from theupskillinglabs.org domains"],
+          ["Resend", "for transactional, invitation, and program emails sent from theupskillinglabs.org domains"],
+          ["Slack", "for community coordination"],
         ].map(([name, use]) => (
           <div className="kv" key={name}>
             <span className="t-body">
@@ -107,32 +147,49 @@ export default function PrivacyPage() {
         for their own purposes.
       </p>
 
-      <h2 className="t-h2" style={h2}>5. Data retention and deletion</h2>
+      <h2 className="t-h2" style={h2}>6. Data retention and deletion</h2>
       <p className="t-body" style={p}>
-        We retain participant data for as long as your account is active or as needed
-        to operate our programs. You may request deletion of your account and
-        associated data at any time by contacting us at the address below.
+        We retain personal data for as long as your account is active or as needed
+        to operate our programs and meet legal and reporting obligations. You may
+        request deletion of your account and associated data at any time by
+        contacting us at the address below.
       </p>
 
-      <h2 className="t-h2" style={h2}>6. Children’s privacy</h2>
+      <h2 className="t-h2" style={h2}>7. Your choices</h2>
+      <p className="t-body" style={p}>You may:</p>
+      <List
+        items={[
+          "Opt out of newsletter and program emails at any time using the “unsubscribe” link in any such email (we will still send essential account and program messages)",
+          "Request access to, correction of, or deletion of your personal information by contacting us",
+        ]}
+      />
+
+      <h2 className="t-h2" style={h2}>8. Children’s privacy</h2>
       <p className="t-body" style={p}>
-        OLOS is not directed at children under 13, and we do not knowingly collect
-        information from children under 13.
+        The Upskilling Labs is not directed to children under 13, and we do not
+        knowingly collect personal information from children under 13.
       </p>
 
-      <h2 className="t-h2" style={h2}>7. Changes to this policy</h2>
+      <h2 className="t-h2" style={h2}>9. Changes to this policy</h2>
       <p className="t-body" style={p}>
         We may update this Privacy Policy from time to time. Material changes will be
         reflected by an updated effective date above.
       </p>
 
-      <h2 className="t-h2" style={h2}>8. Contact us</h2>
+      <h2 className="t-h2" style={h2}>10. Contact us</h2>
       <p className="t-body" style={p}>
         Questions about this policy or your data can be sent to{" "}
         <a className="see" href="mailto:hq@theupskillinglabs.org">
           hq@theupskillinglabs.org
         </a>
-        .
+        , or by mail to:
+      </p>
+      <p className="t-body" style={p}>
+        The Upskilling Labs
+        <br />
+        712 H St NE PMB 143
+        <br />
+        Washington, DC 20002
       </p>
     </ProsePage>
   );

--- a/app/api/registrations/funnel/route.ts
+++ b/app/api/registrations/funnel/route.ts
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest) {
     .maybeSingle();
 
   const appUrl =
-    process.env.NEXT_PUBLIC_APP_URL || "https://olos.theupskillinglabs.org";
+    process.env.NEXT_PUBLIC_APP_URL || "https://theupskillinglabs.org";
 
   if (existing) {
     try {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const geologica = Geologica({
 // automatically by Next's metadata file conventions; the blocks below add the
 // text/type/URL tags that pair with them.
 const siteUrl =
-  process.env.NEXT_PUBLIC_APP_URL ?? "https://app.theupskillinglabs.org";
+  process.env.NEXT_PUBLIC_APP_URL ?? "https://olos.theupskillinglabs.org";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const geologica = Geologica({
 // automatically by Next's metadata file conventions; the blocks below add the
 // text/type/URL tags that pair with them.
 const siteUrl =
-  process.env.NEXT_PUBLIC_APP_URL ?? "https://olos.theupskillinglabs.org";
+  process.env.NEXT_PUBLIC_APP_URL ?? "https://theupskillinglabs.org";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),

--- a/docs/PRD-login-and-cycle-onboarding.md
+++ b/docs/PRD-login-and-cycle-onboarding.md
@@ -432,7 +432,7 @@ The copy below is a draft. Final wording should go through whoever owns brand vo
 
 - `preferred_name` (falls back to `first_name` if null)
 - `cycle_name` (only used in the primary variant)
-- `cycle_join_url` (only used in the primary variant; typically `https://olos.theupskillinglabs.org/cycles/{cycle_id}/join`)
+- `cycle_join_url` (only used in the primary variant; typically `https://theupskillinglabs.org/cycles/{cycle_id}/join`)
 
 **Conditional logic:**
 
@@ -472,7 +472,7 @@ The copy below is a draft. Final wording should go through whoever owns brand vo
 
 **Template variables required:**
 
-- `login_url` (typically `https://olos.theupskillinglabs.org/login`)
+- `login_url` (typically `https://theupskillinglabs.org/login`)
 
 **Security notes:**
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -8,7 +8,7 @@ Three environments: **local**, **dev**, and **prod**. Local and dev share the sa
 
 | | Local | Dev | Prod |
 |---|---|---|---|
-| **URL** | `http://localhost:3000` | Vercel preview (auto-deployed from `dev` branch) | `https://olos.theupskillinglabs.org` |
+| **URL** | `http://localhost:3000` | Vercel preview (auto-deployed from `dev` branch) | `https://theupskillinglabs.org` |
 | **Git branch** | any | `dev` | `main` |
 | **Supabase project** | `cethihabtddiujzayaxe` (OLOS-dev) | `cethihabtddiujzayaxe` (OLOS-dev) | `cdbgkgkjnomjnpicaxqe` (OLOS-prod) |
 | **Env file** | `.env.development.local` | Vercel env vars (dev) | Vercel env vars (prod) |
@@ -28,8 +28,8 @@ Sign in at `http://localhost:3000/login` with a Google account that has a row in
 **Dev (Vercel)**
 Open the Vercel preview URL for the `dev` branch. Sign in with Google — same dev Supabase, same participant rows.
 
-**Prod (`olos.theupskillinglabs.org`)**
-Open `https://olos.theupskillinglabs.org/login`. Sign in with Google. Your account must have a row in the *prod* `participants` table — dev data does not carry over.
+**Prod (`theupskillinglabs.org`)**
+Open `https://theupskillinglabs.org/login`. Sign in with Google. Your account must have a row in the *prod* `participants` table — dev data does not carry over.
 
 > If someone can authenticate (Google accepts the login) but lands on `/register`, their email is missing from the `participants` table for that environment. Add the row in Supabase Studio, or send them an invitation from the admin panel.
 
@@ -92,7 +92,7 @@ RESEND_API_KEY=<resend key>
 RESEND_FROM_EMAIL=hq@enroll.theupskillinglabs.org
 
 # App URL
-NEXT_PUBLIC_APP_URL=https://olos.theupskillinglabs.org
+NEXT_PUBLIC_APP_URL=https://theupskillinglabs.org
 ```
 
 Keys are in 1Password (or ask Madhu). Do not commit either file — they are git-ignored.

--- a/docs/legal/CODE_OF_CONDUCT.md
+++ b/docs/legal/CODE_OF_CONDUCT.md
@@ -2,9 +2,6 @@
 
 **Effective date:** July 6, 2026
 
-> **Draft for review.** This Code of Conduct was newly authored and should be reviewed
-> and adopted by The Upskilling Labs' leadership and board before it is treated as final.
-
 The Upskilling Labs is a community built on learning together — openly, in person, and with
 respect. This Code of Conduct sets the expectations for everyone who takes part, so the
 Labs stays a place where anyone can show up, contribute, and belong. It is part of the

--- a/docs/legal/PRIVACY_POLICY.md
+++ b/docs/legal/PRIVACY_POLICY.md
@@ -1,8 +1,9 @@
 # Privacy Policy — The Upskilling Labs (OLOS)
 
-**Effective date:** July 3, 2026
+**Effective date:** July 9, 2026
 
-The Upskilling Labs, Inc. ("The Labs," "we," "us") operates OLOS (Open Labs OS), a platform supporting peer-driven learning cycles and community programs for people navigating career transitions. This Privacy Policy explains what information we collect through OLOS, how we use it, and the choices you have.
+The Upskilling Labs, Inc. ("The Labs," "we," "us") operates
+[theupskillinglabs.org](https://theupskillinglabs.org) and OLOS (Open Labs OS), the platform behind it — supporting peer-driven learning cycles and community programs for people navigating career transitions. This Privacy Policy explains what information we collect, how we use it, and the choices you have. It covers both our public website and the OLOS platform.
 
 This Privacy Policy is part of the Participant Agreement every member accepts at registration, and it applies to all members equally, regardless of role.
 
@@ -10,9 +11,11 @@ This Privacy Policy is part of the Participant Agreement every member accepts at
 
 **Through Google Sign-In:** When you sign in with your Google Account, we receive your name, email address, and profile picture (basic profile scopes only — we do not request access to your Gmail, Drive, Calendar, or other Google data).
 
-**Through registration and program forms:** If you register as a participant, volunteer, or mentor, we may collect your name, email address, ZIP code, current work situation, role or program interests, and any consents you provide during onboarding.
+**Through forms on our site:** When you fill out a form — to register, join a program, volunteer, mentor, partner, donate, subscribe to updates, or contact us — we may collect your name, email address, phone number (if you provide it), ZIP code, current work situation, role or program interests, responses to interest and background questions, and any consents you provide.
 
 **Through your use of the platform:** We keep records of your program enrollments, role assignments (e.g., moderator, mentor), and participation status within cycles and pods.
+
+**Cookies:** We use a strictly necessary cookie to keep you signed in (set by Supabase Auth). We do not use advertising or third-party tracking cookies.
 
 ## 2. How We Use Your Information
 
@@ -20,38 +23,63 @@ We use the information we collect to:
 
 - Create and manage your account and participant profile
 - Match you to relevant cycles, pods, events, or mentorship opportunities
-- Send you programmatic communications (e.g., invitations, onboarding steps, cycle updates) via email
+- Send you communications — invitations, onboarding steps, cycle updates, newsletters, and program announcements — via email
+- Coordinate programming and events with collaborating organizations
 - Operate moderator and admin tools that support program delivery
+- Report to our funders and fiscal sponsor for grant administration and compliance
 - Improve and maintain the platform
 
 We do not sell your personal information, and we do not use it for advertising.
 
-## 3. How We Store and Protect Information
+## 3. How We Share Your Information
+
+We share personal information only as needed to run our programs:
+
+- **Our fiscal sponsor (Superbloom)** — for administrative and grant-management purposes
+- **Funders** — for reporting and compliance
+- **Collaborating organizations** — to coordinate programming and events
+- **Service providers** — the vendors listed in Section 5, who process data on our behalf
+
+We do not sell your personal information.
+
+## 4. How We Store and Protect Information
 
 Your information is stored in a hosted Postgres database (via Supabase) with access controls limiting who on our team can view participant data. Authentication is handled by Google OAuth and Supabase Auth; we do not store your Google password.
 
-## 4. Third-Party Services
+## 5. Third-Party Services
 
-We use the following third-party services to operate OLOS:
+We use the following third-party services to operate The Upskilling Labs:
 
 - **Google** — for account sign-in (OAuth)
 - **Supabase** — for database hosting and authentication infrastructure
-- **Resend** — for transactional and invitation emails sent from `theupskillinglabs.org` domains
+- **Resend** — for transactional, invitation, and program emails sent from `theupskillinglabs.org` domains
+- **Slack** — for community coordination
 
 These providers process data on our behalf and are not authorized to use it for their own purposes.
 
-## 5. Data Retention and Deletion
+## 6. Data Retention and Deletion
 
-We retain participant data for as long as your account is active or as needed to operate our programs. You may request deletion of your account and associated data at any time by contacting us at the address below.
+We retain personal data for as long as your account is active or as needed to operate our programs and meet legal and reporting obligations. You may request deletion of your account and associated data at any time by contacting us at the address below.
 
-## 6. Children's Privacy
+## 7. Your Choices
 
-OLOS is not directed at children under 13, and we do not knowingly collect information from children under 13.
+You may:
 
-## 7. Changes to This Policy
+- Opt out of newsletter and program emails at any time using the "unsubscribe" link in any such email (we will still send essential account and program messages)
+- Request access to, correction of, or deletion of your personal information by contacting us
+
+## 8. Children's Privacy
+
+The Upskilling Labs is not directed to children under 13, and we do not knowingly collect personal information from children under 13.
+
+## 9. Changes to This Policy
 
 We may update this Privacy Policy from time to time. Material changes will be reflected by an updated effective date above.
 
-## 8. Contact Us
+## 10. Contact Us
 
-Questions about this policy or your data can be sent to **hq@theupskillinglabs.org**.
+Questions about this policy or your data can be sent to **hq@theupskillinglabs.org**, or by mail to:
+
+The Upskilling Labs
+712 H St NE PMB 143
+Washington, DC 20002

--- a/docs/marketing-site/pages/privacy-policy.md
+++ b/docs/marketing-site/pages/privacy-policy.md
@@ -2,10 +2,16 @@
 slug: privacy-policy
 title: Privacy Policy
 type: page
-status: published
+status: superseded
 summary: "The Upskilling Labs Effective Date: March 2, 2026"
 source_url: https://theupskillinglabs.org/privacy-policy
 ---
+
+> **Superseded.** This is the legacy Squarespace privacy policy, kept for
+> provenance only. The live, go-forward policy is the OLOS `/privacy` page
+> (source: [`docs/legal/PRIVACY_POLICY.md`](../../legal/PRIVACY_POLICY.md)),
+> which consolidates the platform and this site. Do **not** import or
+> republish this file.
 
 # Privacy Policy
 

--- a/lib/auth/CLAUDE.md
+++ b/lib/auth/CLAUDE.md
@@ -450,12 +450,15 @@ Sequenced — each step depends on the previous:
    `https://<project-ref>.supabase.co/auth/v1/callback`.
 2. **Supabase Studio → Auth → Providers → Google** — paste client_id +
    secret from step 1.
-3. **Supabase Studio → Auth → URL Configuration** — set `Site URL` and
-   add the prod app domain to Redirect URLs
-   (`https://olos.theupskillinglabs.org/api/auth/callback`). The
-   `app.theupskillinglabs.org` subdomain referenced in earlier drafts was
-   never DNS'd; production lives on `olos.theupskillinglabs.org` per the
-   Vercel project's domain configuration.
+3. **Supabase Studio → Auth → URL Configuration** — set `Site URL` to
+   `https://theupskillinglabs.org` and add
+   `https://theupskillinglabs.org/api/auth/callback` to Redirect URLs.
+   Production is moving onto the apex `theupskillinglabs.org` as the legacy
+   Squarespace marketing site is folded into this app; the earlier
+   `olos.theupskillinglabs.org` subdomain and the never-DNS'd
+   `app.theupskillinglabs.org` are both superseded. Leave the
+   `olos.…/api/auth/callback` entry in the allow-list until that subdomain is
+   retired so in-flight sign-ins don't break during cutover.
 4. ✅ **Resend** — verified `enroll.theupskillinglabs.org` (subdomain mode);
    SPF + DKIM + DMARC passing on the 2026-05-08 first prod send. Approved
    sender is `noreply@enroll.theupskillinglabs.org` (in-code default

--- a/scripts/ops/CLAUDE.md
+++ b/scripts/ops/CLAUDE.md
@@ -160,7 +160,7 @@ enrolled.
 | `--limit <n>` | none | cap rows processed (after `--only-email` filter) |
 | `--only-email <addr>` | none | restrict to one address (sanity tests) |
 | `--include-pending` | off | do not skip rows with live pending bulk invite |
-| `--app-url <url>` | env / `https://olos.theupskillinglabs.org` | magic-link host |
+| `--app-url <url>` | env / `https://theupskillinglabs.org` | magic-link host |
 
 ### Test plan (executed for #46)
 

--- a/scripts/ops/send-bulk-invites.ts
+++ b/scripts/ops/send-bulk-invites.ts
@@ -36,7 +36,7 @@ import { createInterface } from "node:readline/promises";
 //               cethihabtddiujzayaxe  IS dev/staging (retains pre-split data)
 // MUST match whatever is currently prod, not historical prod.
 const PROD_PROJECT_REF = "cdbgkgkjnomjnpicaxqe";
-const DEFAULT_APP_URL = "https://olos.theupskillinglabs.org";
+const DEFAULT_APP_URL = "https://theupskillinglabs.org";
 const EMAIL_SUBJECT = "You're invited to The Upskilling Labs";
 const PER_ROW_DELAY_MS = 200;
 


### PR DESCRIPTION
## What

Gets our documents ready for the Google OAuth app-publishing (brand-verification) submission and for promoting olos-dev to prod on the apex `theupskillinglabs.org`, with the legacy Squarespace marketing site folding entirely into this app. No product/behavior change — copy, config fallbacks, and legal docs only.

## Changes

- **Unified privacy policy.** OLOS `/privacy` is now the single, go-forward policy for the whole property (site + platform). Merged the platform disclosures with the marketing site's practices: public-site forms incl. phone + interest/background responses, newsletters/announcements, coordination with collaborating orgs, and a new "How we share" section (fiscal sponsor Superbloom, funders, collaborating orgs, service providers). Added Slack to sub-processors and a postal address to contact. Source of truth (`docs/legal/PRIVACY_POLICY.md`) and the on-site page (`app/(public)/privacy/page.tsx`) kept in lockstep; the legacy Squarespace policy in the marketing corpus is marked `status: superseded` so a future markdown→DB import can't republish a conflicting one.
- **Fixed an inherited inaccuracy.** The legacy "we use no cookies" claim was false for the app (it sets a strictly-necessary Supabase auth session cookie) → replaced with an accurate essential-cookie / no-tracking disclosure.
- **Repointed the prod domain to the apex.** `metadataBase`/OG URL, `NEXT_PUBLIC_APP_URL` example + docs, and the magic-link host fallbacks (`registrations/funnel`, `send-bulk-invites.ts`) now fall back to `https://theupskillinglabs.org` instead of the `olos.*` subdomain. `lib/auth/CLAUDE.md` ops step updated (Supabase Site URL / Redirect URL → apex, with a cutover note to keep the `olos.*` callback allow-listed until retired).
- **Removed draft language.** Dropped the "Draft for review / pending board adoption" banner from the Code of Conduct (source + page comment).
- **Scope disclosure.** Login copy now reads "name, email, and profile picture" to match the policy and the actual Google basic-profile scope.

### For reviewer/legal confirmation (judgment calls while consolidating two policies)

- Children's-privacy age kept at **under 13** (app's existing line + COPPA standard), not the legacy site's "under 18."
- Sub-processors listed as Google / Supabase / Resend / Slack — dropped Google Forms (retired) and **Mailchimp**; add Mailchimp back if newsletters still go through it.
- Kept the fiscal-sponsor (Superbloom) / funders / collaborating-orgs data-sharing from the legacy policy — confirm still accurate.

## Verify

Not run locally — this was authored in a Claude Code web session without `node_modules`; CI will validate. Changes are copy / JSX / string-literal edits with no new dependencies, types, or schema.

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Database

- [x] No schema change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C63KjKSzckStqKZwZ9uLpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01C63KjKSzckStqKZwZ9uLpA)_