### PR TITLE
Link Privacy Policy & Terms at the Google sign-in consent point

### DIFF
--- a/app/(auth)/login/login-card.tsx
+++ b/app/(auth)/login/login-card.tsx
@@ -132,10 +132,35 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
   );
 
   const finePrint = (
-    <p className="t-small">
-      We only access your name, email, and profile picture. Already a member?
-      Same door — Google signs you in either way.
-    </p>
+    <>
+      <p className="t-small">
+        We only access your name, email, and profile picture. Already a member?
+        Same door — Google signs you in either way.
+      </p>
+      <p className="t-small" style={{ marginTop: 8 }}>
+        By continuing, you agree to our{" "}
+        <a
+          className="see"
+          href="/terms"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ textDecoration: "underline" }}
+        >
+          Terms of Service
+        </a>{" "}
+        and{" "}
+        <a
+          className="see"
+          href="/privacy"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ textDecoration: "underline" }}
+        >
+          Privacy Policy
+        </a>
+        .
+      </p>
+    </>
   );
 
   if (inModal) {


### PR DESCRIPTION
## What

Makes the app ready for Google OAuth app verification by surfacing the Privacy Policy and Terms of Service links at the point of consent. Google's reviewers navigate the sign-in flow, and the Google sign-in card — the actual OAuth consent entry point — previously described the data accessed but linked neither policy.

_The `/privacy` and `/terms` pages themselves already existed, are in the auth proxy's public allowlist (load without login), and are linked from the site footer and the registration funnel — so no new pages were needed. The remaining step lives outside this repo: pasting these URLs into the OAuth consent screen config in Google Cloud Console on a verified domain._

## Changes

- Add a "By continuing, you agree to our **Terms of Service** and **Privacy Policy**" line beneath the Continue-with-Google button in `app/(auth)/login/login-card.tsx`. This card renders both the full `/login` page **and** the intercepted auth modal (`app/@authmodal/(.)login`), so both consent surfaces now link the policies.
- Links open in a new tab (`target="_blank" rel="noopener noreferrer"`) so the sign-in flow isn't interrupted, and are underlined so they read as links against the design system's `color: inherit` anchors.

## Verify

- [x] `npm run lint` passes (0 errors; pre-existing warnings only, none in the changed file)
- [x] `npm run test` passes (239 tests across 33 files)
- [x] `npm run build` passes (`/login` static, `/privacy` & `/terms` dynamic)
- Ran the dev server: `/privacy`, `/terms`, and `/login` all return **200** while unauthenticated; confirmed the rendered `/login` HTML now contains both links.

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1)_