### PR TITLE
Describe the app's purpose and Google data use on the home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,8 @@ import { getPublishedSpotlights } from "@/lib/content/spotlights";
 
 export const metadata = {
   title: "The Upskilling Labs",
-  description: "Find your people. Build your edge.",
+  description:
+    "The Upskilling Labs runs OLOS — a free platform where people changing careers learn by doing. Join a twelve-week Build Cycle, form a pod, and ship a real project with people who notice.",
 };
 
 // Auth-aware nav + live content tables — always rendered per request.
@@ -166,9 +167,62 @@ export default async function LandingPage() {
         </div>
       </div>
 
+      {/* ── What this is ── A plain-language description of the platform and
+          why we ask you to sign in with Google. Placed first so anyone — and
+          Google's OAuth reviewers — can see the app's purpose and its data
+          use without logging in. */}
+      <section className="section s-white sec-after-hero" id="sec-about">
+        <div className="container">
+          <SectionHead
+            eyebrow="What this is"
+            heading="A learning platform for people changing careers"
+          />
+          <div
+            style={{
+              display: "grid",
+              gap: 32,
+              gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
+              alignItems: "start",
+            }}
+          >
+            <div>
+              <p className="t-lede" style={{ marginBottom: 16, maxWidth: "60ch" }}>
+                The Upskilling Labs runs OLOS (Open Labs OS) — a platform where
+                people navigating career transitions learn by doing. You join a
+                twelve-week Build Cycle, form a small pod, ship one real
+                project, drop into weekly workshops, and keep a Learning Log,
+                alongside people who notice your work.
+              </p>
+              <p className="t-body" style={{ maxWidth: "60ch" }}>
+                Membership is free. Browse cycles, workshops, the Learning
+                Library, and local labs below — no account needed. You only sign
+                in when you&rsquo;re ready to join.
+              </p>
+            </div>
+            <div className="lcard" style={{ padding: 28 }}>
+              <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
+                Signing in
+              </div>
+              <h3 className="t-h3" style={{ marginBottom: 10 }}>
+                Why we ask for your Google account
+              </h3>
+              <p className="t-body" style={{ marginBottom: 14 }}>
+                You create your member account by signing in with Google. We use
+                only your name, email address, and profile picture — to set up
+                your profile and keep you signed in. We never request access to
+                your Gmail, Drive, or Calendar.
+              </p>
+              <Link className="see" href="/privacy">
+                How we handle your data →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* ── Upskiller Spotlights (onboarding-proto #sec-stories) ── */}
       {spotlights.length > 0 && (
-        <section className="section s-white sec-after-hero" id="sec-stories">
+        <section className="section s-white" id="sec-stories">
           <div className="story-bleed">
             <div className="story-row">
               {spotlights.slice(0, 6).map((s) => (
@@ -240,10 +294,7 @@ export default async function LandingPage() {
       )}
 
       {/* ── Cycles ── */}
-      <section
-        className={`section s-white${spotlights.length > 0 ? "" : " sec-after-hero"}`}
-        id="sec-cycles"
-      >
+      <section className="section s-white" id="sec-cycles">
         <div className="container">
           <SectionHead
             eyebrow="Build Cycles · 4 a year"


### PR DESCRIPTION
## What

Google's OAuth app verification flagged the home page for not explaining the purpose of the application or why it requests user data. This adds a plain-language section to the landing page so reviewers (and anyone) can see the app's functionality and its data use **without logging in**.

## Changes

- Add a **"What this is"** section as the first content section after the hero in `app/page.tsx`:
  - Describes what the platform does — The Upskilling Labs runs OLOS, where people changing careers join a twelve-week Build Cycle, form a pod, ship a real project, attend workshops, and keep a Learning Log.
  - A **"Signing in"** callout explaining, with transparency, why we request a Google account: name, email address, and profile picture only — used to create the member profile and keep you signed in, never Gmail/Drive/Calendar — with a link to the Privacy Policy.
- Move the `sec-after-hero` top-spacing onto this new first section (dropped from the spotlights/cycles sections, which are no longer first).
- Make the page `metadata.description` actually describe the app.

The landing page is an async **server component**, so this content is in the raw server-rendered HTML — visible without JavaScript or login, which is what Google's reviewers check.

## Verify

- [x] `npm run lint` passes (0 errors; pre-existing warnings only, none in the changed file)
- [x] `npm run test` passes (239 tests across 33 files)
- [x] `npm run build` passes (`/` server-rendered on demand)
- Verified on the Vercel preview deployment (plain `curl`, no JS): the homepage serves the new app description, the Google data-use callout ("name, email address, and profile picture", "never request access to your Gmail, Drive, or Calendar"), and **2** Privacy Policy links (footer + new callout) in server-rendered HTML.

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1)_