### PR TITLE
Release: promote dev → main (production cutover)

### DIFF
--- a/app/(dashboard)/admin/access/page.tsx
+++ b/app/(dashboard)/admin/access/page.tsx
@@ -295,7 +295,7 @@ export default async function AccessConsolePage() {
       })}
 
       {((byRole["staff"]?.length ?? 0) + (byRole["tester"]?.length ?? 0)) > 0 &&
-        section("Staff & testers", [...(byRole["staff"] ?? []), ...(byRole["tester"] ?? [])], {
+        section("Core contributors & testers", [...(byRole["staff"] ?? []), ...(byRole["tester"] ?? [])], {
           empty: "None.",
         })}
 

--- a/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
@@ -289,7 +289,7 @@ export default async function AdminCycleDetailPage({
     <div className="space-y-10">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <StatCard
-          label={isOrg ? "Staff" : "Enrolled"}
+          label={isOrg ? "Core contributors" : "Enrolled"}
           value={participants.length}
         />
         <StatCard
@@ -453,7 +453,7 @@ export default async function AdminCycleDetailPage({
     <div className="space-y-10">
       <section>
         <h2 className="mb-4 t-h3 text-ink">
-          {isOrg ? "Staff" : "Participants"} ({participants.length})
+          {isOrg ? "Core contributors" : "Participants"} ({participants.length})
         </h2>
         <ParticipantsTable
           participants={participants}
@@ -531,7 +531,7 @@ export default async function AdminCycleDetailPage({
         formation={formation}
         people={people}
         dev={dev}
-        labels={isOrg ? { formation: "Workstreams", people: "Staff" } : undefined}
+        labels={isOrg ? { formation: "Workstreams", people: "Core contributors" } : undefined}
       />
     </div>
   );

--- a/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
@@ -223,25 +223,46 @@ export default async function AdminCycleDetailPage({
   // cycles for the copy-roster dropdown.
   let workstreamRows: WorkstreamAdminRow[] = [];
   let priorOrgCycles: PriorOrgCycleOption[] = [];
+  let orgParticipantOptions: { participant_id: number; name: string; email?: string }[] = [];
   if (isOrg) {
-    const [{ data: workstreamsData }, { data: runPods }, { data: priorCycles }] =
-      await Promise.all([
-        serviceClient
-          .from("workstreams")
-          .select("id, name, description, status")
-          .order("name"),
-        serviceClient
-          .from("pods")
-          .select("id, name, workstream_id")
-          .eq("cycle_id", cycleId)
-          .not("workstream_id", "is", null),
-        serviceClient
-          .from("cycles")
-          .select("id, name")
-          .eq("mode", "org")
-          .neq("id", cycleId)
-          .order("start_date", { ascending: false }),
-      ]);
+    const [
+      { data: workstreamsData },
+      { data: runPods },
+      { data: priorCycles },
+      { data: allParticipants },
+    ] = await Promise.all([
+      serviceClient
+        .from("workstreams")
+        .select("id, name, description, status")
+        .order("name"),
+      serviceClient
+        .from("pods")
+        .select("id, name, workstream_id")
+        .eq("cycle_id", cycleId)
+        .not("workstream_id", "is", null),
+      serviceClient
+        .from("cycles")
+        .select("id, name")
+        .eq("mode", "org")
+        .neq("id", cycleId)
+        .order("start_date", { ascending: false }),
+      // Org runs are invite-only and cross-lab: the add-member and co-lead
+      // pickers draw from EVERY registered participant, not just this
+      // cycle's enrollees (which is empty on a fresh org cycle — the
+      // chicken-and-egg the email-invite flow can't solve for people who
+      // already have accounts).
+      serviceClient
+        .from("participants")
+        .select("id, first_name, last_name, preferred_name, email")
+        .order("last_name"),
+    ]);
+    orgParticipantOptions = (allParticipants ?? []).map((p) => ({
+      participant_id: p.id,
+      name: p.preferred_name
+        ? `${p.preferred_name} ${p.last_name}`
+        : `${p.first_name} ${p.last_name}`,
+      email: p.email,
+    }));
 
     const runByWorkstream = new Map<number, { pod_id: number; name: string | null }>();
     for (const run of runPods ?? []) {
@@ -421,7 +442,7 @@ export default async function AdminCycleDetailPage({
         <PodsTable
           cycleId={cycle.id}
           pods={podAdminRows}
-          participants={participantOptions}
+          participants={isOrg ? orgParticipantOptions : participantOptions}
           mode={cycle.mode}
         />
       </section>

--- a/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
@@ -18,7 +18,7 @@ export default function ParticipantsTable({
   cycleId,
   mode,
 }: Props) {
-  // Org staff are invite-only: enrollments never go through the activation
+  // Org core contributors are invite-only: enrollments never go through the activation
   // pipeline the reconciler + stuck-inactive tooling exist for, so those
   // affordances only render for participant cycles.
   const isOrg = mode === "org";
@@ -87,7 +87,7 @@ export default function ParticipantsTable({
     return (
       <p className="text-sm text-meta">
         {isOrg
-          ? "No staff enrolled yet — invite co-leads and members from the Organization page."
+          ? "No core contributors enrolled yet — invite co-leads and members from the Organization page, or add registered members from the Workstreams tab."
           : "No participants enrolled."}
       </p>
     );

--- a/app/(dashboard)/admin/cycles/[cycle_id]/pods-table.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/pods-table.tsx
@@ -32,7 +32,7 @@ export type PodAdminRow = {
   /** Existing projects for this pod — gates the Finalize-projects action. */
   projectCount: number;
 };
-type ParticipantOption = { participant_id: number; name: string };
+type ParticipantOption = { participant_id: number; name: string; email?: string };
 
 const POD_STATUS_VARIANT: Record<string, "active" | "forming" | "inactive"> = {
   active: "active",
@@ -159,12 +159,26 @@ function PodManagePanel({
   mode?: string | null;
 }) {
   const router = useRouter();
+  const isOrg = mode === "org";
   const [busy, setBusy] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [selectedId, setSelectedId] = React.useState("");
+  const [roleValue, setRoleValue] = React.useState<"member" | "co_lead">("member");
+  const [search, setSearch] = React.useState("");
 
   const memberIds = new Set(pod.members.map((m) => m.participant_id));
   const addable = participants.filter((p) => !memberIds.has(p.participant_id));
+  // Org runs draw from the FULL registered-participant list (it can be
+  // hundreds of people), so offer a client-side name/email filter — the
+  // people-table.tsx idiom. Open cycles keep the short enrolled-only list.
+  const q = search.trim().toLowerCase();
+  const filteredAddable = q
+    ? addable.filter(
+        (p) =>
+          p.name.toLowerCase().includes(q) ||
+          (p.email ?? "").toLowerCase().includes(q),
+      )
+    : addable;
 
   async function call(
     url: string,
@@ -220,8 +234,13 @@ function PodManagePanel({
     if (!selectedId) return;
     call(`/api/admin/pods/${pod.id}/memberships`, "POST", {
       participant_id: parseInt(selectedId, 10),
+      // Org runs require the role pairing (co-lead also writes the
+      // moderator assignment server-side); other pods reject pod_role.
+      ...(isOrg ? { pod_role: roleValue } : {}),
     });
     setSelectedId("");
+    setSearch("");
+    setRoleValue("member");
   };
 
   const removeMember = (participantId: number) => {
@@ -311,28 +330,58 @@ function PodManagePanel({
         </div>
 
         {addable.length > 0 && (
-          <div className="mt-4 flex items-center gap-2">
-            <select
-              value={selectedId}
-              onChange={(e) => setSelectedId(e.target.value)}
-              aria-label="Add participant to pod"
-              className="flex-1 rounded-card border border-ink/10 bg-white px-2 py-1.5 text-base text-ink transition-colors duration-150 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal"
-            >
-              <option value="">Add participant…</option>
-              {addable.map((p) => (
-                <option key={p.participant_id} value={p.participant_id}>
-                  {p.name}
+          <div className="mt-4 space-y-2">
+            {isOrg && (
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search members by name or email…"
+                aria-label="Search registered members"
+                className="w-full rounded-card border border-ink/10 bg-white px-2 py-1.5 text-base text-ink transition-colors duration-150 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal"
+              />
+            )}
+            <div className="flex items-center gap-2">
+              <select
+                value={selectedId}
+                onChange={(e) => setSelectedId(e.target.value)}
+                aria-label="Add participant to pod"
+                className="flex-1 rounded-card border border-ink/10 bg-white px-2 py-1.5 text-base text-ink transition-colors duration-150 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal"
+              >
+                <option value="">
+                  {isOrg ? "Add core contributor…" : "Add participant…"}
                 </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              onClick={addMember}
-              disabled={!selectedId || busy}
-              className="rounded-card bg-teal/10 px-3 py-1.5 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
-            >
-              {busy ? "…" : "Add"}
-            </button>
+                {filteredAddable.map((p) => (
+                  <option key={p.participant_id} value={p.participant_id}>
+                    {p.email ? `${p.name} — ${p.email}` : p.name}
+                  </option>
+                ))}
+              </select>
+              {isOrg && (
+                <select
+                  value={roleValue}
+                  onChange={(e) =>
+                    setRoleValue(e.target.value === "co_lead" ? "co_lead" : "member")
+                  }
+                  aria-label="Role for the new core contributor"
+                  className="rounded-card border border-ink/10 bg-white px-2 py-1.5 text-base text-ink transition-colors duration-150 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal"
+                >
+                  <option value="member">Member</option>
+                  <option value="co_lead">Co-lead</option>
+                </select>
+              )}
+              <button
+                type="button"
+                onClick={addMember}
+                disabled={!selectedId || busy}
+                className="rounded-card bg-teal/10 px-3 py-1.5 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+              >
+                {busy ? "…" : "Add"}
+              </button>
+            </div>
+            {isOrg && q && filteredAddable.length === 0 && (
+              <p className="text-xs text-meta">No registered members match that search.</p>
+            )}
           </div>
         )}
       </section>

--- a/app/(dashboard)/admin/org/page.tsx
+++ b/app/(dashboard)/admin/org/page.tsx
@@ -309,7 +309,8 @@ export default async function AdminOrgPage() {
           <p className="text-sm text-meta">No current organization cycle.</p>
         ) : staffRows.length === 0 ? (
           <p className="text-sm text-meta">
-            No staff on runs yet — invite co-leads and members.
+            No core contributors on runs yet — invite them by email, or add
+            already-registered members from the cycle&rsquo;s Workstreams tab.
           </p>
         ) : (
           <DataTable<StaffRow>
@@ -348,12 +349,20 @@ export default async function AdminOrgPage() {
         )}
       </section>
 
-      <div>
+      <div className="flex items-center gap-6">
+        {rosterCycle && (
+          <Link
+            href={`/admin/cycles/${rosterCycle.id}?tab=formation`}
+            className="text-sm font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:text-ink"
+          >
+            Add core contributors &rarr;
+          </Link>
+        )}
         <Link
           href="/admin/people?tab=invitations"
           className="text-sm font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:text-ink"
         >
-          Invite staff &rarr;
+          Invite core contributors &rarr;
         </Link>
       </div>
     </div>

--- a/app/(dashboard)/admin/org/page.tsx
+++ b/app/(dashboard)/admin/org/page.tsx
@@ -14,7 +14,7 @@ import WorkstreamsDirectory, {
  * /admin/cycles/[id] drill-down. Three sections top to bottom: the org
  * cycle list (current cards + a collapsed past list), the workstream
  * directory (durable, cross-cycle — create/edit/status live in
- * workstreams-directory.tsx), and a staff roster scoped to the current org
+ * workstreams-directory.tsx), and a core-contributor roster scoped to the current org
  * cycle — the active one if it exists, else the most recent draft/upcoming
  * (so the roster is usable while the quarter is being set up).
  */
@@ -43,7 +43,7 @@ type EmbeddedParticipant = {
   email: string;
 };
 
-type StaffRow = {
+type ContributorRow = {
   participant_id: number;
   name: string;
   email: string;
@@ -69,7 +69,7 @@ export default async function AdminOrgPage() {
   const current = cycles.filter((c) => CURRENT_STATUSES.has(c.status));
   const past = cycles.filter((c) => !CURRENT_STATUSES.has(c.status));
   // Active wins; otherwise fall back to the most recent draft/upcoming so
-  // the directory's run column + staff roster aren't empty during setup.
+  // the directory's run column + core-contributor roster aren't empty during setup.
   const rosterCycle =
     current.find((c) => c.status === "active") ?? current[0] ?? null;
   const currentCycleIds = current.map((c) => c.id);
@@ -95,11 +95,11 @@ export default async function AdminOrgPage() {
         .order("name"),
     ]);
 
-  // Staff + runs counts per current cycle, for the "Org cycles" cards.
-  const staffCountByCycle: Record<number, number> = {};
+  // Core-contributor + runs counts per current cycle, for the "Org cycles" cards.
+  const contributorCountByCycle: Record<number, number> = {};
   for (const e of enrollmentRows ?? []) {
     if (e.status !== "active") continue;
-    staffCountByCycle[e.cycle_id] = (staffCountByCycle[e.cycle_id] ?? 0) + 1;
+    contributorCountByCycle[e.cycle_id] = (contributorCountByCycle[e.cycle_id] ?? 0) + 1;
   }
   const runsCountByCycle: Record<number, number> = {};
   for (const r of (runPodRows ?? []) as RunPodRow[]) {
@@ -107,7 +107,7 @@ export default async function AdminOrgPage() {
   }
 
   // The roster cycle's runs feed both the workstream directory's
-  // "current run" cell and the staff roster below — everything else on
+  // "current run" cell and the core-contributor roster below — everything else on
   // this page is cross-cycle or per-card.
   const activeRuns = rosterCycle
     ? ((runPodRows ?? []) as RunPodRow[]).filter((r) => r.cycle_id === rosterCycle.id)
@@ -160,20 +160,20 @@ export default async function AdminOrgPage() {
     workstreamNameById[w.id] = w.name;
   }
 
-  const staffMap = new Map<number, StaffRow>();
+  const contributorMap = new Map<number, ContributorRow>();
   for (const m of membershipRows ?? []) {
     const p = one(
       m.participants as EmbeddedParticipant | EmbeddedParticipant[] | null
     );
     const workstreamId = workstreamIdByPod[m.pod_id];
     const workstreamName = workstreamId != null ? workstreamNameById[workstreamId] : undefined;
-    const existing = staffMap.get(m.participant_id);
+    const existing = contributorMap.get(m.participant_id);
     if (existing) {
       if (workstreamName && !existing.workstreams.includes(workstreamName)) {
         existing.workstreams.push(workstreamName);
       }
     } else {
-      staffMap.set(m.participant_id, {
+      contributorMap.set(m.participant_id, {
         participant_id: m.participant_id,
         name: participantName(p),
         email: p?.email ?? "",
@@ -183,7 +183,7 @@ export default async function AdminOrgPage() {
     }
   }
 
-  const staffRows = Array.from(staffMap.values()).sort((a, b) => {
+  const contributorRows = Array.from(contributorMap.values()).sort((a, b) => {
     if (a.is_co_lead !== b.is_co_lead) return a.is_co_lead ? -1 : 1;
     return a.name.localeCompare(b.name);
   });
@@ -213,7 +213,7 @@ export default async function AdminOrgPage() {
         <div>
           <h1 className="t-h1 text-ink">Organization</h1>
           <p className="mt-1 text-sm text-meta">
-            The Labs&rsquo; own quarterly cycle — workstreams, staff, and runs.
+            The Labs&rsquo; own quarterly cycle — workstreams, core contributors, and runs.
           </p>
         </div>
         <CreateCycleForm fixedMode="org" />
@@ -245,7 +245,7 @@ export default async function AdminOrgPage() {
                   {new Date(cycle.end_date).toLocaleDateString()}
                 </p>
                 <div className="mt-3 flex items-center gap-4 text-xs text-meta tabular-nums">
-                  <span>{staffCountByCycle[cycle.id] ?? 0} staff</span>
+                  <span>{contributorCountByCycle[cycle.id] ?? 0} core contributor{(contributorCountByCycle[cycle.id] ?? 0) === 1 ? "" : "s"}</span>
                   <span>{runsCountByCycle[cycle.id] ?? 0} runs</span>
                 </div>
                 <Link
@@ -298,7 +298,7 @@ export default async function AdminOrgPage() {
 
       <section className="mb-10">
         <h2 className="mb-4 t-h3 text-ink">
-          Staff
+          Core contributors
           {rosterCycle && (
             <span className="ml-2 text-sm font-normal text-meta">
               {rosterCycle.name}
@@ -307,14 +307,14 @@ export default async function AdminOrgPage() {
         </h2>
         {!rosterCycle ? (
           <p className="text-sm text-meta">No current organization cycle.</p>
-        ) : staffRows.length === 0 ? (
+        ) : contributorRows.length === 0 ? (
           <p className="text-sm text-meta">
             No core contributors on runs yet — invite them by email, or add
             already-registered members from the cycle&rsquo;s Workstreams tab.
           </p>
         ) : (
-          <DataTable<StaffRow>
-            rows={staffRows}
+          <DataTable<ContributorRow>
+            rows={contributorRows}
             rowKey={(row) => row.participant_id}
             columns={[
               {

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -15,7 +15,7 @@ type CycleListRow = {
 };
 
 /** Shared column set for both cycle sections (P-1) — the headcount column's
-    header ("Participants" vs. "Staff") and cell noun ("enrolled" vs. "staff")
+    header ("Participants" vs. "Core contributors") and cell noun ("enrolled" vs. "core contributors")
     differ per section. labNameById (non-null once any lab cycle exists) adds
     a Lab column so the global list stays legible across streams. */
 function cycleColumns(
@@ -157,7 +157,7 @@ export default async function AdminPage() {
             rows={orgCycles}
             rowKey={(cycle) => cycle.id}
             empty="No organization cycles yet."
-            columns={cycleColumns(countsByCycle, "Staff", "staff", labNameById)}
+            columns={cycleColumns(countsByCycle, "Core contributors", "core contributors", labNameById)}
           />
         </section>
       )}

--- a/app/(dashboard)/admin/participants/[participant_id]/permissions/page.tsx
+++ b/app/(dashboard)/admin/participants/[participant_id]/permissions/page.tsx
@@ -19,7 +19,7 @@ export default async function ParticipantPermissionsPage({
 
   const [{ data: participant }, { data: permRows }, { data: roleRows }, { data: modAssignments }] =
     await Promise.all([
-      serviceClient.from("participants").select("id, first_name, last_name, preferred_name, email, is_test").eq("id", participantId).single(),
+      serviceClient.from("participants").select("id, first_name, last_name, preferred_name, email, is_test, is_staff").eq("id", participantId).single(),
       serviceClient.from("participant_permissions").select("permission").eq("participant_id", participantId).is("revoked_at", null),
       serviceClient.from("user_roles").select("role").eq("participant_id", participantId).is("revoked_at", null),
       serviceClient.from("moderator_assignments").select("pod_id, pods (name, cycle_id, cycles (name))").eq("participant_id", participantId).is("removed_at", null),
@@ -96,6 +96,7 @@ export default async function ParticipantPermissionsPage({
         canManageRoles={canManageRoles}
         podAssignments={podAssignments}
         initialIsTest={!!participant.is_test}
+        initialIsStaff={!!participant.is_staff}
       />
     </div>
   );

--- a/app/(dashboard)/admin/people/participant-sheet.tsx
+++ b/app/(dashboard)/admin/people/participant-sheet.tsx
@@ -110,7 +110,7 @@ export default function ParticipantSheet({
               {person.is_staff && (
                 <span className={`${ORG_CHIP_CLASS} px-2.5`}>
                   <OrgDot />
-                  staff
+                  core contributor
                 </span>
               )}
               {person.roles.length === 0 && !person.is_test && !person.is_staff && (
@@ -201,6 +201,7 @@ export default function ParticipantSheet({
               canManageRoles={canManageRoles}
               podAssignments={podAssignments}
               initialIsTest={person.is_test}
+              initialIsStaff={person.is_staff}
             />
           ) : null}
         </div>

--- a/app/(dashboard)/admin/people/people-table.tsx
+++ b/app/(dashboard)/admin/people/people-table.tsx
@@ -127,7 +127,7 @@ export default function PeopleTable({
                   {p.is_staff && (
                     <span className={`${ORG_CHIP_CLASS} px-2.5`}>
                       <OrgDot />
-                      staff
+                      core contributor
                     </span>
                   )}
                   {roles.length === 0 && !p.is_test && !p.is_staff && (

--- a/app/(dashboard)/admin/people/permissions-editor.tsx
+++ b/app/(dashboard)/admin/people/permissions-editor.tsx
@@ -24,12 +24,14 @@ export default function PermissionsEditor({
   canManageRoles,
   podAssignments,
   initialIsTest,
+  initialIsStaff = false,
 }: {
   participantId: number;
   initialPermissions: Permission[];
   canManageRoles: boolean;
   podAssignments: { pod_id: number; pod_name: string; cycle_name: string }[];
   initialIsTest: boolean;
+  initialIsStaff?: boolean;
 }) {
   const [permissions, setPermissions] = useState<Set<Permission>>(
     new Set(initialPermissions)
@@ -39,6 +41,8 @@ export default function PermissionsEditor({
   const [error, setError] = useState<string | null>(null);
   const [isTest, setIsTest] = useState(initialIsTest);
   const [testerBusy, setTesterBusy] = useState(false);
+  const [isStaff, setIsStaff] = useState(initialIsStaff);
+  const [staffBusy, setStaffBusy] = useState(false);
 
   async function toggleTester() {
     setTesterBusy(true);
@@ -55,6 +59,24 @@ export default function PermissionsEditor({
     } else {
       const data = await res.json().catch(() => null);
       setError(data?.error ?? "Failed to update tester status");
+    }
+  }
+
+  async function toggleStaff() {
+    setStaffBusy(true);
+    setError(null);
+    const res = await fetch("/api/admin/staff-flag", {
+      method: isStaff ? "DELETE" : "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ participant_id: participantId }),
+    });
+    setStaffBusy(false);
+    if (res.ok) {
+      const data = await res.json();
+      setIsStaff(!!data.core_contributor);
+    } else {
+      const data = await res.json().catch(() => null);
+      setError(data?.error ?? "Failed to update core-contributor status");
     }
   }
 
@@ -186,6 +208,30 @@ export default function PermissionsEditor({
             onChange={toggleTester}
             busy={testerBusy}
             label="Tester account"
+          />
+        </div>
+      </section>
+
+      {/* Core-contributor flag (participants.is_staff, migration 00041) —
+          a visibility flag, never a permission. */}
+      <section>
+        <h2 className="lbl mb-3">Core Contributor</h2>
+        <div className="flex items-center justify-between rounded-card border border-dashed border-ink/20 bg-paper px-4 py-3">
+          <div className="pr-4">
+            <span className="text-sm font-semibold text-ink">
+              Organization insider
+            </span>
+            <p className="mt-0.5 text-xs text-meta">
+              Marks this account as one of the Labs&rsquo; own. Hidden from the
+              community directory, follow suggestions, and public profiles;
+              excluded from pod health math. Grants no permissions.
+            </p>
+          </div>
+          <ToggleSwitch
+            checked={isStaff}
+            onChange={toggleStaff}
+            busy={staffBusy}
+            label="Core contributor"
           />
         </div>
       </section>

--- a/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
@@ -196,8 +196,8 @@ export function RosterTable({
               className="text-teal-deep transition-colors hover:text-ink focus-visible:underline"
             >
               {showStaffTest
-                ? "Hide staff & test accounts"
-                : "Show staff & test accounts"}
+                ? "Hide core contributor & test accounts"
+                : "Show core contributor & test accounts"}
             </button>
           )}
         </div>

--- a/app/api/admin/pods/[pod_id]/memberships/route.ts
+++ b/app/api/admin/pods/[pod_id]/memberships/route.ts
@@ -6,9 +6,11 @@ import { parseIntParam } from "@/lib/api/params";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { adminAddPodMembershipSchema } from "@/lib/validations/admin-pod-membership";
 import {
+  ensureActivePodMembership,
   reconcileEnrollmentActivation,
   reconcilePodMembers,
 } from "@/lib/enrollment/reconciler";
+import { grantRole } from "@/lib/auth/grants";
 import { createServiceClient } from "@/lib/supabase/server";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 
@@ -76,7 +78,7 @@ export const POST = withAuth(
 
     const body = await parseBody(request, adminAddPodMembershipSchema);
     if (isErrorResponse(body)) return body;
-    const { participant_id } = body;
+    const { participant_id, pod_role } = body;
 
     const client = createServiceClient();
 
@@ -110,6 +112,23 @@ export const POST = withAuth(
     // cross-lab by design) and NULL-lab/HQ pods are exempt, matching the DB
     // fence. Re-tag the member's lab or the pod's lab to override.
     const podMode = ((pod.cycles as unknown) as { mode: string } | null)?.mode;
+
+    // pod_role pairs with org workstream runs only — same contract as
+    // POST /api/invitations (co-lead/member are org concepts; an org add
+    // without a role would be ambiguous about the moderator_assignments row).
+    if (pod_role && podMode !== "org") {
+      return NextResponse.json(
+        { error: "Co-lead/member roles apply only to organization workstreams." },
+        { status: 400 }
+      );
+    }
+    if (!pod_role && podMode === "org") {
+      return NextResponse.json(
+        { error: "Organization workstream adds need a pod role (co-lead or member)." },
+        { status: 400 }
+      );
+    }
+
     if (
       pod.lab_id !== null &&
       podMode === "open" &&
@@ -204,8 +223,47 @@ export const POST = withAuth(
         .update({ status: "active" })
         .eq("id", podId);
       await reconcilePodMembers(podId);
+    } else if (podMode === "org") {
+      // Org runs charter as status:'active', so the forming→active branch
+      // never fires — and reconcileEnrollmentActivation returns without
+      // mutating when no cycle_enrollments row exists, which is exactly the
+      // fresh-org-add case. ensureActivePodMembership (the primitive invite
+      // fulfillment uses) is idempotent against the membership row created
+      // above and upserts the active enrollment + seeds follows, keeping the
+      // org roster (pod_memberships) and the Core Contributors tab / counts
+      // (cycle_enrollments) in agreement.
+      await ensureActivePodMembership(participant_id, podId, pod.cycle_id);
     } else {
       await reconcileEnrollmentActivation(participant_id, pod.cycle_id);
+    }
+
+    if (podMode === "org" && pod_role === "co_lead") {
+      // Mirrors the org block of POST /api/pods/[pod_id]/moderators: record
+      // the role through grants.ts FIRST so participant_roles carries
+      // granted_by provenance (the moderator_assignments sync trigger then
+      // no-ops on the row this created).
+      const grant = await grantRole(client, {
+        participantId: participant_id,
+        role: "poderator",
+        scope: { podId, cycleId: pod.cycle_id },
+        actor: auth.user,
+        scopeAuthorized: true,
+        note: "org co-lead added by admin",
+      });
+      if (!grant.ok) {
+        // Membership stands as a plain member; the admin can retry the
+        // co-lead promotion via the Assign co-lead control.
+        return NextResponse.json({ error: grant.error }, { status: grant.status });
+      }
+      // Upsert (fulfillment's shape, lib/auth/invitations.ts) rather than a
+      // bare insert — a prior assignment row may exist from an earlier stint.
+      const { error: assignError } = await client
+        .from("moderator_assignments")
+        .upsert(
+          { participant_id, pod_id: podId, cycle_id: pod.cycle_id },
+          { onConflict: "participant_id,pod_id,cycle_id", ignoreDuplicates: true }
+        );
+      if (assignError) return dbError(assignError);
     }
 
     return NextResponse.json(

--- a/app/api/admin/staff-flag/route.ts
+++ b/app/api/admin/staff-flag/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse, NextRequest } from "next/server";
+import { z } from "zod";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import type { AuthenticatedRequest } from "@/lib/auth/middleware";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { dbError } from "@/lib/api/errors";
+import { createServiceClient } from "@/lib/supabase/server";
+
+// Set / clear the core-contributor flag (participants.is_staff, migration
+// 00041 — the column keeps its historical name; the UI says "core
+// contributor"). A visibility flag, never a permission: it hides the
+// account from the community directory, follow suggestions, and public
+// profiles, and excludes it from pod health math. Closes 00041's noted
+// follow-up ("an admin UI control can follow") — until now the flag was
+// settable only via SQL/entity explorer. Unlike testers there is no
+// email-keyed side table: the flag does not need to survive a reset.
+
+const staffFlagSchema = z.object({ participant_id: z.number().int() }).strict();
+
+async function setFlag(request: NextRequest, isStaff: boolean) {
+  const body = await parseBody(request, staffFlagSchema);
+  if (isErrorResponse(body)) return body;
+
+  const service = createServiceClient();
+  const { data: participant } = await service
+    .from("participants")
+    .select("id")
+    .eq("id", body.participant_id)
+    .maybeSingle();
+  if (!participant) {
+    return NextResponse.json({ error: "Participant not found" }, { status: 404 });
+  }
+
+  const { error: flagError } = await service
+    .from("participants")
+    .update({ is_staff: isStaff })
+    .eq("id", participant.id);
+  if (flagError) return dbError(flagError, "staff-flag");
+
+  return NextResponse.json({ core_contributor: isStaff });
+}
+
+export const POST = withAdminAuth(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async (request: NextRequest, _auth: AuthenticatedRequest) => setFlag(request, true)
+);
+
+export const DELETE = withAdminAuth(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async (request: NextRequest, _auth: AuthenticatedRequest) => setFlag(request, false)
+);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -167,62 +167,9 @@ export default async function LandingPage() {
         </div>
       </div>
 
-      {/* ── What this is ── A plain-language description of the platform and
-          why we ask you to sign in with Google. Placed first so anyone — and
-          Google's OAuth reviewers — can see the app's purpose and its data
-          use without logging in. */}
-      <section className="section s-white sec-after-hero" id="sec-about">
-        <div className="container">
-          <SectionHead
-            eyebrow="What this is"
-            heading="A learning platform for people changing careers"
-          />
-          <div
-            style={{
-              display: "grid",
-              gap: 32,
-              gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
-              alignItems: "start",
-            }}
-          >
-            <div>
-              <p className="t-lede" style={{ marginBottom: 16, maxWidth: "60ch" }}>
-                The Upskilling Labs runs OLOS (Open Labs OS) — a platform where
-                people navigating career transitions learn by doing. You join a
-                twelve-week Build Cycle, form a small pod, ship one real
-                project, drop into weekly workshops, and keep a Learning Log,
-                alongside people who notice your work.
-              </p>
-              <p className="t-body" style={{ maxWidth: "60ch" }}>
-                Membership is free. Browse cycles, workshops, the Learning
-                Library, and local labs below — no account needed. You only sign
-                in when you&rsquo;re ready to join.
-              </p>
-            </div>
-            <div className="lcard" style={{ padding: 28 }}>
-              <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
-                Signing in
-              </div>
-              <h3 className="t-h3" style={{ marginBottom: 10 }}>
-                Why we ask for your Google account
-              </h3>
-              <p className="t-body" style={{ marginBottom: 14 }}>
-                You create your member account by signing in with Google. We use
-                only your name, email address, and profile picture — to set up
-                your profile and keep you signed in. We never request access to
-                your Gmail, Drive, or Calendar.
-              </p>
-              <Link className="see" href="/privacy">
-                How we handle your data →
-              </Link>
-            </div>
-          </div>
-        </div>
-      </section>
-
       {/* ── Upskiller Spotlights (onboarding-proto #sec-stories) ── */}
       {spotlights.length > 0 && (
-        <section className="section s-white" id="sec-stories">
+        <section className="section s-white sec-after-hero" id="sec-stories">
           <div className="story-bleed">
             <div className="story-row">
               {spotlights.slice(0, 6).map((s) => (
@@ -294,7 +241,10 @@ export default async function LandingPage() {
       )}
 
       {/* ── Cycles ── */}
-      <section className="section s-white" id="sec-cycles">
+      <section
+        className={`section s-white${spotlights.length > 0 ? "" : " sec-after-hero"}`}
+        id="sec-cycles"
+      >
         <div className="container">
           <SectionHead
             eyebrow="Build Cycles · 4 a year"
@@ -409,6 +359,59 @@ export default async function LandingPage() {
             seeLabel="All cities →"
           />
           <MetroSearch metros={metros} initial={landingLabs} signedIn={signedIn} />
+        </div>
+      </section>
+
+      {/* ── What this is ── A plain-language description of the platform and
+          why we ask you to sign in with Google. Kept as the last section above
+          the footer so anyone — and Google's OAuth reviewers — can see the
+          app's purpose and its data use without logging in. */}
+      <section className="section s-white" id="sec-about">
+        <div className="container">
+          <SectionHead
+            eyebrow="What this is"
+            heading="A learning platform for people changing careers"
+          />
+          <div
+            style={{
+              display: "grid",
+              gap: 32,
+              gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
+              alignItems: "start",
+            }}
+          >
+            <div>
+              <p className="t-lede" style={{ marginBottom: 16, maxWidth: "60ch" }}>
+                The Upskilling Labs runs OLOS (Open Labs OS) — a platform where
+                people navigating career transitions learn by doing. You join a
+                twelve-week Build Cycle, form a small pod, ship one real
+                project, drop into weekly workshops, and keep a Learning Log,
+                alongside people who notice your work.
+              </p>
+              <p className="t-body" style={{ maxWidth: "60ch" }}>
+                Membership is free. Browse cycles, workshops, the Learning
+                Library, and local labs above — no account needed. You only sign
+                in when you&rsquo;re ready to join.
+              </p>
+            </div>
+            <div className="lcard" style={{ padding: 28 }}>
+              <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
+                Signing in
+              </div>
+              <h3 className="t-h3" style={{ marginBottom: 10 }}>
+                Why we ask for your Google account
+              </h3>
+              <p className="t-body" style={{ marginBottom: 14 }}>
+                You create your member account by signing in with Google. We use
+                only your name, email address, and profile picture — to set up
+                your profile and keep you signed in. We never request access to
+                your Gmail, Drive, or Calendar.
+              </p>
+              <Link className="see" href="/privacy">
+                How we handle your data →
+              </Link>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,8 @@ import { getPublishedSpotlights } from "@/lib/content/spotlights";
 
 export const metadata = {
   title: "The Upskilling Labs",
-  description: "Find your people. Build your edge.",
+  description:
+    "The Upskilling Labs runs OLOS — a free platform where people changing careers learn by doing. Join a twelve-week Build Cycle, form a pod, and ship a real project with people who notice.",
 };
 
 // Auth-aware nav + live content tables — always rendered per request.
@@ -166,9 +167,62 @@ export default async function LandingPage() {
         </div>
       </div>
 
+      {/* ── What this is ── A plain-language description of the platform and
+          why we ask you to sign in with Google. Placed first so anyone — and
+          Google's OAuth reviewers — can see the app's purpose and its data
+          use without logging in. */}
+      <section className="section s-white sec-after-hero" id="sec-about">
+        <div className="container">
+          <SectionHead
+            eyebrow="What this is"
+            heading="A learning platform for people changing careers"
+          />
+          <div
+            style={{
+              display: "grid",
+              gap: 32,
+              gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
+              alignItems: "start",
+            }}
+          >
+            <div>
+              <p className="t-lede" style={{ marginBottom: 16, maxWidth: "60ch" }}>
+                The Upskilling Labs runs OLOS (Open Labs OS) — a platform where
+                people navigating career transitions learn by doing. You join a
+                twelve-week Build Cycle, form a small pod, ship one real
+                project, drop into weekly workshops, and keep a Learning Log,
+                alongside people who notice your work.
+              </p>
+              <p className="t-body" style={{ maxWidth: "60ch" }}>
+                Membership is free. Browse cycles, workshops, the Learning
+                Library, and local labs below — no account needed. You only sign
+                in when you&rsquo;re ready to join.
+              </p>
+            </div>
+            <div className="lcard" style={{ padding: 28 }}>
+              <div className="lbl lbl-teal" style={{ marginBottom: 8 }}>
+                Signing in
+              </div>
+              <h3 className="t-h3" style={{ marginBottom: 10 }}>
+                Why we ask for your Google account
+              </h3>
+              <p className="t-body" style={{ marginBottom: 14 }}>
+                You create your member account by signing in with Google. We use
+                only your name, email address, and profile picture — to set up
+                your profile and keep you signed in. We never request access to
+                your Gmail, Drive, or Calendar.
+              </p>
+              <Link className="see" href="/privacy">
+                How we handle your data →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* ── Upskiller Spotlights (onboarding-proto #sec-stories) ── */}
       {spotlights.length > 0 && (
-        <section className="section s-white sec-after-hero" id="sec-stories">
+        <section className="section s-white" id="sec-stories">
           <div className="story-bleed">
             <div className="story-row">
               {spotlights.slice(0, 6).map((s) => (
@@ -240,10 +294,7 @@ export default async function LandingPage() {
       )}
 
       {/* ── Cycles ── */}
-      <section
-        className={`section s-white${spotlights.length > 0 ? "" : " sec-after-hero"}`}
-        id="sec-cycles"
-      >
+      <section className="section s-white" id="sec-cycles">
         <div className="container">
           <SectionHead
             eyebrow="Build Cycles · 4 a year"

--- a/lib/enrollment/reconciler.test.ts
+++ b/lib/enrollment/reconciler.test.ts
@@ -213,7 +213,13 @@ describe("ensureActivePodMembership", () => {
   });
 
   it("no-ops the membership write when already active, but still seeds the enrollment", async () => {
+    // The admin add-member route (POST /api/admin/pods/[pod_id]/memberships)
+    // depends on this branch: it inserts the membership itself, then calls
+    // this helper for org runs — the helper must tolerate the row it didn't
+    // create and still seed + reconcile the enrollment.
     state.membershipRow = { id: 99, inactive_at: null };
+    state.enrollment = { id: 20, status: "inactive" };
+    state.memberships = [activePod];
 
     await ensureActivePodMembership(7, 6, 2);
 
@@ -224,5 +230,7 @@ describe("ensureActivePodMembership", () => {
       cycle_id: 2,
       status: "active",
     });
+    // Reconcile still runs after the (skipped) membership write.
+    expect(state.updates[0]).toMatchObject({ status: "active", inactive_date: null });
   });
 });

--- a/lib/validations/admin-pod-membership.test.ts
+++ b/lib/validations/admin-pod-membership.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { adminAddPodMembershipSchema } from "./admin-pod-membership";
+
+/* Pins the admin add-member body contract. pod_role's pairing with the
+   pod's cycle mode (required on org runs, rejected elsewhere) lives in the
+   route, not here — the schema only vouches for shape. */
+
+describe("adminAddPodMembershipSchema", () => {
+  it("accepts a bare participant_id (participant-cycle pods)", () => {
+    const parsed = adminAddPodMembershipSchema.parse({ participant_id: 7 });
+    expect(parsed).toEqual({ participant_id: 7 });
+  });
+
+  it("accepts pod_role 'member' and 'co_lead' (org workstream runs)", () => {
+    expect(
+      adminAddPodMembershipSchema.parse({ participant_id: 7, pod_role: "member" })
+    ).toEqual({ participant_id: 7, pod_role: "member" });
+    expect(
+      adminAddPodMembershipSchema.parse({ participant_id: 7, pod_role: "co_lead" })
+    ).toEqual({ participant_id: 7, pod_role: "co_lead" });
+  });
+
+  it("rejects unknown pod_role values", () => {
+    expect(
+      adminAddPodMembershipSchema.safeParse({ participant_id: 7, pod_role: "owner" })
+        .success
+    ).toBe(false);
+    expect(
+      adminAddPodMembershipSchema.safeParse({ participant_id: 7, pod_role: "poderator" })
+        .success
+    ).toBe(false);
+  });
+
+  it("rejects a missing or non-positive participant_id", () => {
+    expect(adminAddPodMembershipSchema.safeParse({}).success).toBe(false);
+    expect(
+      adminAddPodMembershipSchema.safeParse({ participant_id: 0 }).success
+    ).toBe(false);
+    expect(
+      adminAddPodMembershipSchema.safeParse({ participant_id: -3 }).success
+    ).toBe(false);
+    expect(
+      adminAddPodMembershipSchema.safeParse({ participant_id: 1.5 }).success
+    ).toBe(false);
+  });
+});

--- a/lib/validations/admin-pod-membership.ts
+++ b/lib/validations/admin-pod-membership.ts
@@ -3,9 +3,13 @@ import { z } from "zod";
 /**
  * Body schema for POST /api/admin/pods/[pod_id]/memberships.
  * The admin supplies a participant_id; pod_id comes from the route param.
+ * pod_role is required for organization workstream runs and rejected
+ * elsewhere (same contract as POST /api/invitations) — the route enforces
+ * that pairing because it depends on the pod's cycle mode.
  */
 export const adminAddPodMembershipSchema = z.object({
   participant_id: z.number().int().positive(),
+  pod_role: z.enum(["co_lead", "member"]).optional(),
 });
 
 export type AdminAddPodMembership = z.infer<typeof adminAddPodMembershipSchema>;


### PR DESCRIPTION
## What

Production cutover — promote all of `dev` to `main`. Vercel deploys `main` to production (`theupskillinglabs.org`).

## Included in this release (dev not yet in main)

- **Home page describes the app's purpose & Google data use** (#217, #218) — a "What this is" section (platform description + a "Signing in" callout explaining the Google account data we use, linking the Privacy Policy), positioned as the last section above the footer. Needed for Google OAuth app verification.
- **Org / Core-Contributor admin work** — admin add-member endpoint understands org runs (pod_role + enrollment fix), a global participant picker for org runs, `staff` → "Core Contributor" rename + admin flag toggle, and related admin/permissions UI updates.

## Verify

- All changes were merged to `dev` with CI green (lint / test / build) and deployed to the dev preview.
- No database migrations in this delta (no `supabase/migrations/` changes).

## Database

- [x] No schema change in this release delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1)_