### PR TITLE
Lead the home-page hero with what the platform is (Google verification)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,7 @@ import { getRecruitingCycle } from "@/lib/cycle/active";
 import { getPublishedSpotlights } from "@/lib/content/spotlights";
 
 export const metadata = {
-  title: "The Upskilling Labs",
+  title: "The Upskilling Labs — a learn-by-doing platform for career changers",
   description:
     "The Upskilling Labs runs OLOS — a free platform where people changing careers learn by doing. Join a twelve-week Build Cycle, form a pod, and ship a real project with people who notice.",
 };
@@ -137,16 +137,22 @@ export default async function LandingPage() {
           <div className="hero-photo" aria-hidden="true" />
           <div className="hero-tint" aria-hidden="true" />
           <HeroFade>
+            <div
+              className="lbl lbl-teal"
+              style={{ gridColumn: "1 / -1", marginBottom: 14 }}
+            >
+              A free platform for career changers
+            </div>
             <h1 className="t-display">
               Find your people.
               <br />
               Build your edge.
             </h1>
             <div className="hero-cta">
-              <p className="t-lede" style={{ marginBottom: 24, maxWidth: "52ch" }}>
-                The Labs isn’t a class you sit through. It’s where you practice
-                becoming the person you want to be — on real problems, with
-                people who notice.
+              <p className="t-lede" style={{ marginBottom: 24, maxWidth: "56ch" }}>
+                The Upskilling Labs is an online platform where people changing
+                careers learn by doing — join a twelve-week build cycle, form a
+                small team, and ship a real project with people who notice.
               </p>
               {signedIn ? (
                 <Link className="btn btn-teal btn-lg" href="/dashboard">


### PR DESCRIPTION
## What

Google's OAuth verification kept failing with "your page doesn't explain the purpose of your app." The top of the page read as a movement (brand-name title, an emotional H1) while the actual purpose description sat at the very bottom, where a reviewer never scrolls. This makes the **hero** carry the purpose, above the fold.

## Changes

- Add a clarity **kicker** above the hero headline — "A free platform for career changers" — spanning the full hero grid row (`grid-column: 1 / -1`).
- Rewrite the hero **lede** to lead with what it is: "The Upskilling Labs is an online platform where people changing careers learn by doing — join a twelve-week build cycle, form a small team, and ship a real project with people who notice." Keeps the "Find your people. Build your edge." headline.
- Give the home page a descriptive **`<title>`**: "The Upskilling Labs — a learn-by-doing platform for career changers".
- The detailed "What this is" + Google-data-use block stays at the bottom.

## Verify

- [x] `npm run lint` passes (0 errors; pre-existing warnings only)
- [x] `npm run test` passes (243 tests across 34 files)
- [x] `npm run build` passes
- On the branch preview (`curl`): kicker → headline → lede DOM order confirmed; the kicker carries `grid-column: 1 / -1` (a full-width row above the headline on desktop, stacks first on mobile); the new `<title>` is live. (A pixel screenshot wasn't possible — the agent proxy resets Playwright's bundled Chromium — so layout was confirmed via the CSS grid rules + DOM order.)

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1)_