### PR TITLE
Reposition the home page around local communities of practice (warm hero)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -137,24 +137,17 @@ export default async function LandingPage() {
           <div className="hero-photo" aria-hidden="true" />
           <div className="hero-tint" aria-hidden="true" />
           <HeroFade>
-            <div
-              className="lbl lbl-teal"
-              style={{ gridColumn: "1 / -1", marginBottom: 14 }}
-            >
-              Local communities of practice — for lifelong upskilling
-            </div>
             <h1 className="t-display">
               Find your people.
               <br />
               Build your edge.
             </h1>
             <div className="hero-cta">
-              <p className="t-lede" style={{ marginBottom: 24, maxWidth: "58ch" }}>
-                The Upskilling Labs is a network of local communities of
-                practice — people who learn by doing, together, and keep
-                leveling up for life. OLOS is the platform that runs it: sign in
-                with Google to join your local lab, form a cohort, and build
-                something real.
+              <p className="t-lede" style={{ marginBottom: 24, maxWidth: "54ch" }}>
+                Nobody gets good at the hard stuff alone. So we help you find
+                your crew — a handful of people near you who meet up for a few
+                months, build something real, and keep each other going. Sign in
+                with Google to jump in.
               </p>
               {signedIn ? (
                 <Link className="btn btn-teal btn-lg" href="/dashboard">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,9 +16,9 @@ import { getRecruitingCycle } from "@/lib/cycle/active";
 import { getPublishedSpotlights } from "@/lib/content/spotlights";
 
 export const metadata = {
-  title: "The Upskilling Labs — a learn-by-doing platform for career changers",
+  title: "The Upskilling Labs — local communities of practice for lifelong upskilling",
   description:
-    "The Upskilling Labs runs OLOS — a free platform where people changing careers learn by doing. Join a twelve-week Build Cycle, form a pod, and ship a real project with people who notice.",
+    "The Upskilling Labs is a network of local communities of practice where people learn by doing and keep leveling up for life. OLOS is the platform that runs them — sign in to join your local lab, form a cohort, and build something real.",
 };
 
 // Auth-aware nav + live content tables — always rendered per request.
@@ -141,7 +141,7 @@ export default async function LandingPage() {
               className="lbl lbl-teal"
               style={{ gridColumn: "1 / -1", marginBottom: 14 }}
             >
-              A free platform for career changers
+              Local communities of practice — for lifelong upskilling
             </div>
             <h1 className="t-display">
               Find your people.
@@ -149,10 +149,12 @@ export default async function LandingPage() {
               Build your edge.
             </h1>
             <div className="hero-cta">
-              <p className="t-lede" style={{ marginBottom: 24, maxWidth: "56ch" }}>
-                The Upskilling Labs is an online platform where people changing
-                careers learn by doing — join a twelve-week build cycle, form a
-                small team, and ship a real project with people who notice.
+              <p className="t-lede" style={{ marginBottom: 24, maxWidth: "58ch" }}>
+                The Upskilling Labs is a network of local communities of
+                practice — people who learn by doing, together, and keep
+                leveling up for life. OLOS is the platform that runs it: sign in
+                with Google to join your local lab, form a cohort, and build
+                something real.
               </p>
               {signedIn ? (
                 <Link className="btn btn-teal btn-lg" href="/dashboard">
@@ -376,7 +378,7 @@ export default async function LandingPage() {
         <div className="container">
           <SectionHead
             eyebrow="What this is"
-            heading="A learning platform for people changing careers"
+            heading="Local communities of practice, powered by OLOS"
           />
           <div
             style={{
@@ -388,11 +390,13 @@ export default async function LandingPage() {
           >
             <div>
               <p className="t-lede" style={{ marginBottom: 16, maxWidth: "60ch" }}>
-                The Upskilling Labs runs OLOS (Open Labs OS) — a platform where
-                people navigating career transitions learn by doing. You join a
-                twelve-week Build Cycle, form a small pod, ship one real
-                project, drop into weekly workshops, and keep a Learning Log,
-                alongside people who notice your work.
+                The Upskilling Labs is a network of local communities of
+                practice — people navigating career change who learn by doing
+                and keep leveling up for life. OLOS (Open Labs OS) is the
+                platform that runs it: you sign in to join your local lab, form
+                a cohort in a twelve-week Build Cycle, ship a real project, drop
+                into workshops, and keep a Learning Log — alongside people who
+                notice your work.
               </p>
               <p className="t-body" style={{ maxWidth: "60ch" }}>
                 Membership is free. Browse cycles, workshops, the Learning


### PR DESCRIPTION
## What

Reposition the home page so it tells the true story: The Upskilling Labs is a network of **local communities of practice** for lifelong learning, and **OLOS is the platform that runs them** — not "an online platform." The hero speaks in plain, human language (no jargon); the precise "communities of practice / powered by OLOS" wording lives in the page title and the bottom section. Throughout, the app's purpose and the Google sign-in stay legible for OAuth verification.

## Changes

- **Hero:** warm, jargon-free lede — "Nobody gets good at the hard stuff alone. So we help you find your crew — a handful of people near you who meet up for a few months, build something real, and keep each other going. Sign in with Google to jump in." No eyebrow; keeps the "Find your people. Build your edge." headline.
- **Title + description:** reframed to local communities of practice for lifelong upskilling.
- **Bottom "What this is" section:** heading → "Local communities of practice, powered by OLOS"; opening paragraph reframed, keeping the concrete detail (local lab, cohort, Build Cycle, project, workshops, Learning Log) and the unchanged Google data-use callout.

## Verify

- [x] `npm run lint` passes (0 errors; pre-existing warnings only)
- [x] `npm run test` passes (243 tests across 34 files)
- [x] `npm run build` passes
- Verified on the Vercel preview (`curl`): warm hero live and eyebrow removed; "Sign in with Google to jump in" present; new title live; bottom "powered by OLOS" heading and the Google data-use callout intact.

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzyZtSnLqHN9GG8z6ZJnE1)_