### PR TITLE
fix(problems+voting): correct vote budgets, allow stacking, harden config reads, scroll reset

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
@@ -23,11 +23,14 @@ export default async function ProposePage({
 
   // Check if window is open
   const serviceClient = createServiceClient();
+  // maybeSingle: a cycle with no cycle_config row is a real production state
+  // (config is seeded by hand) — .single() would error and read as a generic
+  // "closed" message with no hint at the actual problem.
   const { data: config } = await serviceClient
     .from("cycle_config")
     .select("problem_statement_open, problem_statement_close")
     .eq("cycle_id", cycleId)
-    .single();
+    .maybeSingle();
 
   const now = new Date();
   const isOpen =
@@ -84,7 +87,9 @@ export default async function ProposePage({
       ) : (
         <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
-            Problem statement submission is not currently open.
+            {config
+              ? "Problem statement submission is not currently open."
+              : "This cycle isn't fully configured yet — the submission window hasn't been scheduled. If you expected it to be open, let an organizer know."}
           </p>
           {config?.problem_statement_open &&
             now < new Date(config.problem_statement_open) && (

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -103,6 +103,14 @@ export default function ProposeForm({
     }
   }
 
+  // Step changes reset the scroll position — the nav buttons sit at the
+  // bottom of a long step, so without this the next (often shorter) step
+  // renders with the viewport still parked at the footer.
+  function goToStep(next: Step) {
+    setStep(next);
+    window.scrollTo({ top: 0 });
+  }
+
   async function handleSubmit() {
     setError("");
     setSubmitting(true);
@@ -667,7 +675,7 @@ export default function ProposeForm({
         <div>
           {step > 1 && (
             <button
-              onClick={() => setStep((step - 1) as Step)}
+              onClick={() => goToStep((step - 1) as Step)}
               className="btn btn-ghost btn-sm"
             >
               Back
@@ -677,7 +685,7 @@ export default function ProposeForm({
         <div className="flex items-center gap-3">
           {step < 6 ? (
             <button
-              onClick={() => setStep((step + 1) as Step)}
+              onClick={() => goToStep((step + 1) as Step)}
               disabled={!canAdvance()}
               className="btn btn-teal btn-sm"
             >

--- a/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
@@ -21,13 +21,14 @@ export default async function VotePage({
 
   if (!cycle) notFound();
 
-  // Check if window is open
+  // Check if window is open. maybeSingle: a cycle without a cycle_config row
+  // must degrade to the explicit "not configured" message, not a query error.
   const serviceClient = createServiceClient();
   const { data: config } = await serviceClient
     .from("cycle_config")
     .select("voting_open, voting_close, submitter_votes, non_submitter_votes")
     .eq("cycle_id", cycleId)
-    .single();
+    .maybeSingle();
 
   const now = new Date();
   const isOpen =
@@ -35,6 +36,34 @@ export default async function VotePage({
     config?.voting_close &&
     now >= new Date(config.voting_open) &&
     now <= new Date(config.voting_close);
+
+  // Whether the viewer submitted a proposal in this cycle decides their vote
+  // budget (cycle_config.submitter_votes vs non_submitter_votes). The API
+  // (app/api/votes/route.ts) makes the same determination when a vote is
+  // cast; resolving it here too lets the ballot show the right budget from
+  // the first render instead of defaulting to the non-submitter value.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let isSubmitter = false;
+  if (user) {
+    const { data: participant } = await supabase
+      .from("participants")
+      .select("id")
+      .eq("auth_user_id", user.id)
+      .maybeSingle();
+    if (participant) {
+      const { data: submission } = await supabase
+        .from("problem_statements")
+        .select("id")
+        .eq("cycle_id", cycleId)
+        .eq("participant_id", participant.id)
+        .limit(1)
+        .maybeSingle();
+      isSubmitter = !!submission;
+    }
+  }
 
   return (
     <div>
@@ -57,12 +86,17 @@ export default async function VotePage({
       {isOpen ? (
         <VoteBallot
           cycleId={cycleId}
+          isSubmitter={isSubmitter}
           submitterBudget={config?.submitter_votes ?? 0}
           nonSubmitterBudget={config?.non_submitter_votes ?? 0}
         />
       ) : (
         <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
-          <p className="text-charcoal">Voting is not currently open.</p>
+          <p className="text-charcoal">
+            {config
+              ? "Voting is not currently open."
+              : "This cycle isn't fully configured yet — the voting window hasn't been scheduled. If you expected it to be open, let an organizer know."}
+          </p>
           {config?.voting_open && now < new Date(config.voting_open) && (
             <p className="mt-2 text-sm text-meta tabular-nums">
               Opens{" "}

--- a/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
@@ -29,10 +29,12 @@ interface Tally {
 
 export default function VoteBallot({
   cycleId,
+  isSubmitter,
   submitterBudget,
   nonSubmitterBudget,
 }: {
   cycleId: number;
+  isSubmitter: boolean;
   submitterBudget: number;
   nonSubmitterBudget: number;
 }) {
@@ -40,7 +42,12 @@ export default function VoteBallot({
   const [tallies, setTallies] = useState<Tally[]>([]);
   const [pendingVotes, setPendingVotes] = useState<Record<number, number>>({});
   const [totalUsed, setTotalUsed] = useState(0);
-  const [budget, setBudget] = useState(nonSubmitterBudget);
+  // The server decides which budget applies (page.tsx resolves isSubmitter);
+  // defaulting to nonSubmitterBudget here was the bug that showed submitters
+  // 1 vote instead of their configured allowance.
+  const [budget, setBudget] = useState(
+    isSubmitter ? submitterBudget : nonSubmitterBudget
+  );
   const [submitting, setSubmitting] = useState<number | null>(null);
   const [error, setError] = useState("");
   const [successId, setSuccessId] = useState<number | null>(null);
@@ -54,6 +61,16 @@ export default function VoteBallot({
     ]).then(([stmts, voteData]) => {
       if (Array.isArray(stmts)) setStatements(stmts);
       if (voteData?.tallies) setTallies(voteData.tallies);
+      // Votes cast in earlier sessions count against the budget — without
+      // this, "votes remaining" reads as the full budget after a reload.
+      if (Array.isArray(voteData?.my_votes)) {
+        setTotalUsed(
+          voteData.my_votes.reduce(
+            (sum: number, v: { vote_count: number }) => sum + v.vote_count,
+            0
+          )
+        );
+      }
       setLoading(false);
     });
   }, [cycleId]);
@@ -158,8 +175,14 @@ export default function VoteBallot({
           <p className="text-xs text-meta tabular-nums">votes remaining</p>
         </div>
         <div className="text-right text-xs text-meta tabular-nums">
-          <p>Submitters get {submitterBudget} votes</p>
-          <p>Non-submitters get {nonSubmitterBudget} votes</p>
+          <p className="font-semibold text-charcoal">
+            You have {budget} vote{budget !== 1 ? "s" : ""} this cycle
+            {isSubmitter ? " (you submitted a proposal)" : ""}
+          </p>
+          <p>
+            Submitters get {submitterBudget} · non-submitters get{" "}
+            {nonSubmitterBudget}. Stack votes on one problem or spread them out.
+          </p>
         </div>
       </div>
 

--- a/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
@@ -40,14 +40,19 @@ export default function VoteBallot({
 }) {
   const [statements, setStatements] = useState<ProblemStatement[]>([]);
   const [tallies, setTallies] = useState<Tally[]>([]);
-  const [pendingVotes, setPendingVotes] = useState<Record<number, number>>({});
+  // The viewer's own allocation per statement (committed). Drives the
+  // "Your votes: N" display and seeds the stepper when editing.
+  const [myVotes, setMyVotes] = useState<Record<number, number>>({});
+  // Which card's stepper is open, and the uncommitted stepper value per card.
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [draft, setDraft] = useState<Record<number, number>>({});
   const [totalUsed, setTotalUsed] = useState(0);
   // The server decides which budget applies (page.tsx resolves isSubmitter);
   // defaulting to nonSubmitterBudget here was the bug that showed submitters
   // 1 vote instead of their configured allowance.
-  const [budget, setBudget] = useState(
-    isSubmitter ? submitterBudget : nonSubmitterBudget
-  );
+  // Budget is fixed for the cycle (server resolves submitter vs non-submitter);
+  // only totalUsed changes as votes are cast.
+  const budget = isSubmitter ? submitterBudget : nonSubmitterBudget;
   const [submitting, setSubmitting] = useState<number | null>(null);
   const [error, setError] = useState("");
   const [successId, setSuccessId] = useState<number | null>(null);
@@ -61,15 +66,21 @@ export default function VoteBallot({
     ]).then(([stmts, voteData]) => {
       if (Array.isArray(stmts)) setStatements(stmts);
       if (voteData?.tallies) setTallies(voteData.tallies);
-      // Votes cast in earlier sessions count against the budget — without
-      // this, "votes remaining" reads as the full budget after a reload.
+      // Votes cast in earlier sessions count against the budget and are shown
+      // per card — without this, "votes remaining" reads as the full budget
+      // after a reload and there's no visibility into prior allocation.
       if (Array.isArray(voteData?.my_votes)) {
-        setTotalUsed(
-          voteData.my_votes.reduce(
-            (sum: number, v: { vote_count: number }) => sum + v.vote_count,
-            0
-          )
-        );
+        const mine: Record<number, number> = {};
+        let used = 0;
+        for (const v of voteData.my_votes as {
+          problem_statement_id: number;
+          vote_count: number;
+        }[]) {
+          mine[v.problem_statement_id] = v.vote_count;
+          used += v.vote_count;
+        }
+        setMyVotes(mine);
+        setTotalUsed(used);
       }
       setLoading(false);
     });
@@ -81,9 +92,15 @@ export default function VoteBallot({
     );
   }
 
-  async function castVote(problemStatementId: number) {
-    const voteCount = pendingVotes[problemStatementId];
-    if (!voteCount || voteCount < 1) return;
+  // Set-absolute: submits the desired total for a statement (0 removes it).
+  // The stepper/edit UI collects the target count; the server clamps it to the
+  // budget and this reconciles local state from the returned votes_remaining.
+  async function setVotes(problemStatementId: number, count: number) {
+    const prev = myVotes[problemStatementId] ?? 0;
+    if (count === prev) {
+      setEditingId(null);
+      return;
+    }
 
     setError("");
     setSuccessId(null);
@@ -91,44 +108,69 @@ export default function VoteBallot({
 
     try {
       const res = await fetch("/api/votes", {
-        method: "POST",
+        method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           cycle_id: cycleId,
           problem_statement_id: problemStatementId,
-          vote_count: voteCount,
+          vote_count: count,
         }),
       });
 
       if (!res.ok) {
         const body = await res.json();
-        setError(body.error || "Failed to cast vote");
+        setError(body.error || "Failed to update votes");
         return;
       }
 
       const result = await res.json();
       setSuccessId(problemStatementId);
-      setTotalUsed((prev) => prev + voteCount);
+
+      setMyVotes((m) => {
+        const next = { ...m };
+        if (count === 0) delete next[problemStatementId];
+        else next[problemStatementId] = count;
+        return next;
+      });
+
+      // Budget is constant for the cycle; trust the server's votes_remaining as
+      // the source of truth for how many votes are now used.
       if (result.votes_remaining !== undefined) {
-        setBudget(result.votes_remaining + totalUsed + voteCount);
+        setTotalUsed(budget - result.votes_remaining);
+      } else {
+        setTotalUsed((t) => t - prev + count);
       }
-      setTallies((prev) => {
-        const existing = prev.find(
+
+      // Adjust the community tally by the delta (removal lowers it).
+      const delta = count - prev;
+      setTallies((prevT) => {
+        const existing = prevT.find(
           (t) => t.problem_statement_id === problemStatementId
         );
         if (existing) {
-          return prev.map((t) =>
-            t.problem_statement_id === problemStatementId
-              ? { ...t, total_votes: t.total_votes + voteCount }
-              : t
-          );
+          return prevT
+            .map((t) =>
+              t.problem_statement_id === problemStatementId
+                ? { ...t, total_votes: Math.max(0, t.total_votes + delta) }
+                : t
+            )
+            .filter((t) => t.total_votes > 0);
         }
-        return [
-          ...prev,
-          { problem_statement_id: problemStatementId, total_votes: voteCount },
-        ];
+        if (delta > 0) {
+          return [
+            ...prevT,
+            { problem_statement_id: problemStatementId, total_votes: delta },
+          ];
+        }
+        return prevT;
       });
-      setPendingVotes((prev) => ({ ...prev, [problemStatementId]: 0 }));
+
+      setEditingId(null);
+      setDraft((d) => {
+        const next = { ...d };
+        delete next[problemStatementId];
+        return next;
+      });
     } catch {
       setError("Network error. Try again.");
     } finally {
@@ -175,10 +217,16 @@ export default function VoteBallot({
           <p className="text-xs text-meta tabular-nums">votes remaining</p>
         </div>
         <div className="text-right text-xs text-meta tabular-nums">
-          <p className="font-semibold text-charcoal">
-            You have {budget} vote{budget !== 1 ? "s" : ""} this cycle
-            {isSubmitter ? " (you submitted a proposal)" : ""}
-          </p>
+          {remaining <= 0 ? (
+            <p className="font-semibold text-charcoal">
+              You&rsquo;ve used all of your votes for this cycle.
+            </p>
+          ) : (
+            <p className="font-semibold text-charcoal">
+              You have {budget} vote{budget !== 1 ? "s" : ""} this cycle
+              {isSubmitter ? " (you submitted a proposal)" : ""}
+            </p>
+          )}
           <p>
             Submitters get {submitterBudget} · non-submitters get{" "}
             {nonSubmitterBudget}. Stack votes on one problem or spread them out.
@@ -201,6 +249,15 @@ export default function VoteBallot({
           const pd = stmt.proposal_data;
           const isExpanded = expandedId === stmt.id;
           const hasDetails = pd?.problem || pd?.voter_context;
+
+          const mine = myVotes[stmt.id] ?? 0;
+          // Zero-state cards show the stepper directly so votes can be added;
+          // cards you've voted on rest at "Your votes: N" until you hit Edit.
+          const isEditing = editingId === stmt.id || mine === 0;
+          // Freeing this card's current allocation is available headroom, so
+          // the stepper can range up to mine + remaining.
+          const maxSettable = mine + remaining;
+          const draftValue = draft[stmt.id] ?? mine;
 
           return (
             <div
@@ -299,40 +356,93 @@ export default function VoteBallot({
                   <span className="text-xs font-medium text-meta tabular-nums">
                     {getTallyFor(stmt.id)} vote
                     {getTallyFor(stmt.id) !== 1 ? "s" : ""}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="number"
-                      min={1}
-                      max={remaining}
-                      value={pendingVotes[stmt.id] || ""}
-                      onChange={(e) =>
-                        setPendingVotes((prev) => ({
-                          ...prev,
-                          [stmt.id]: parseInt(e.target.value, 10) || 0,
-                        }))
-                      }
-                      placeholder="0"
-                      aria-label="Vote count"
-                      className="w-16 rounded-card border border-ink/10 bg-white px-2 py-1 text-center text-base tabular-nums text-ink placeholder:text-meta-soft transition-colors duration-150 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal"
-                    />
-                    <button
-                      onClick={() => castVote(stmt.id)}
-                      disabled={
-                        submitting !== null ||
-                        !pendingVotes[stmt.id] ||
-                        pendingVotes[stmt.id] < 1
-                      }
-                      className="rounded-card bg-teal/10 px-3 py-2 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
-                    >
-                      {submitting === stmt.id ? "..." : "Vote"}
-                    </button>
-                    {successId === stmt.id && (
-                      <span className="text-xs font-medium text-teal-deep">
-                        Voted
+                    {mine > 0 && (
+                      <span className="ml-2 font-semibold text-teal-deep">
+                        · you: {mine}
                       </span>
                     )}
-                  </div>
+                  </span>
+                  {isEditing ? (
+                    <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-1">
+                        <button
+                          type="button"
+                          aria-label="Remove one vote"
+                          onClick={() =>
+                            setDraft((prev) => ({
+                              ...prev,
+                              [stmt.id]: Math.max(0, draftValue - 1),
+                            }))
+                          }
+                          disabled={submitting !== null || draftValue <= 0}
+                          className="flex h-8 w-8 items-center justify-center rounded-card border border-ink/10 bg-white text-lg leading-none text-ink transition-colors duration-150 hover:border-ink/20 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+                        >
+                          −
+                        </button>
+                        <span className="w-8 text-center text-base font-semibold tabular-nums text-ink">
+                          {draftValue}
+                        </span>
+                        <button
+                          type="button"
+                          aria-label="Add one vote"
+                          onClick={() =>
+                            setDraft((prev) => ({
+                              ...prev,
+                              [stmt.id]: Math.min(maxSettable, draftValue + 1),
+                            }))
+                          }
+                          disabled={submitting !== null || draftValue >= maxSettable}
+                          className="flex h-8 w-8 items-center justify-center rounded-card border border-ink/10 bg-white text-lg leading-none text-ink transition-colors duration-150 hover:border-ink/20 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+                        >
+                          +
+                        </button>
+                      </div>
+                      <button
+                        onClick={() => setVotes(stmt.id, draftValue)}
+                        disabled={submitting !== null || draftValue === mine}
+                        className="rounded-card bg-teal/10 px-3 py-2 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+                      >
+                        {submitting === stmt.id ? "..." : mine > 0 ? "Save" : "Vote"}
+                      </button>
+                      {mine > 0 && (
+                        <button
+                          onClick={() => {
+                            setEditingId(null);
+                            setDraft((prev) => {
+                              const next = { ...prev };
+                              delete next[stmt.id];
+                              return next;
+                            });
+                          }}
+                          disabled={submitting !== null}
+                          className="text-xs font-medium text-meta transition-colors duration-150 hover:text-charcoal disabled:opacity-40"
+                        >
+                          Cancel
+                        </button>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-semibold tabular-nums text-charcoal">
+                        Your votes: {mine}
+                      </span>
+                      <button
+                        onClick={() => {
+                          setEditingId(stmt.id);
+                          setDraft((prev) => ({ ...prev, [stmt.id]: mine }));
+                        }}
+                        disabled={submitting !== null}
+                        className="rounded-card bg-teal/10 px-3 py-2 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+                      >
+                        Edit
+                      </button>
+                      {successId === stmt.id && (
+                        <span className="text-xs font-medium text-teal-deep">
+                          Saved
+                        </span>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/app/api/votes/[cycle_id]/route.ts
+++ b/app/api/votes/[cycle_id]/route.ts
@@ -36,6 +36,17 @@ export const GET = withAuth(
 
     const result: Record<string, unknown> = { tallies };
 
+    // The caller's own allocations — lets the ballot compute a correct
+    // remaining budget on load (votes rows were already fetched above).
+    if (auth.user.participantId) {
+      result.my_votes = (votes || [])
+        .filter((v) => v.voter_id === auth.user.participantId)
+        .map((v) => ({
+          problem_statement_id: v.problem_statement_id,
+          vote_count: v.vote_count,
+        }));
+    }
+
     // Voter-level detail — admin only
     if (isAdmin(auth.user)) {
       result.votes = votes;

--- a/app/api/votes/route.ts
+++ b/app/api/votes/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { createServiceClient } from "@/lib/supabase/server";
 import { withAuth } from "@/lib/auth/middleware";
 import { isEnrolledParticipant, isActiveParticipant } from "@/lib/auth/roles";
 import { isCurrentlyRevoked } from "@/lib/enrollment/revocation";
@@ -100,7 +101,7 @@ export const POST = withAuth(
     // Check total allocated votes
     const { data: existingVotes } = await auth.supabase
       .from("votes")
-      .select("vote_count")
+      .select("id, problem_statement_id, vote_count")
       .eq("cycle_id", cycle_id)
       .eq("voter_id", voter_id);
 
@@ -118,14 +119,38 @@ export const POST = withAuth(
       );
     }
 
-    const { data, error } = await auth.supabase
-      .from("votes")
-      .insert({ cycle_id, voter_id, problem_statement_id, vote_count })
-      .select("id, created_at")
-      .single();
+    // Stacking: voters may add votes to a problem they already voted on.
+    // UNIQUE(voter_id, problem_statement_id, cycle_id) means one row per
+    // (voter, problem) — an existing row is incremented rather than
+    // duplicated. votes has no UPDATE RLS policy (INSERT-only for members),
+    // so the increment goes through the service client; every guard above
+    // (window, enrollment, revocation, lab, budget) has already passed.
+    const existingRow = (existingVotes || []).find(
+      (v) => v.problem_statement_id === problem_statement_id
+    );
 
-    if (error) {
-      return dbError(error);
+    let data: { id: number; created_at: string };
+    if (existingRow) {
+      const { data: updated, error } = await createServiceClient()
+        .from("votes")
+        .update({ vote_count: existingRow.vote_count + vote_count })
+        .eq("id", existingRow.id)
+        .select("id, created_at")
+        .single();
+      if (error) {
+        return dbError(error);
+      }
+      data = updated;
+    } else {
+      const { data: inserted, error } = await auth.supabase
+        .from("votes")
+        .insert({ cycle_id, voter_id, problem_statement_id, vote_count })
+        .select("id, created_at")
+        .single();
+      if (error) {
+        return dbError(error);
+      }
+      data = inserted;
     }
 
     return NextResponse.json(

--- a/app/api/votes/route.ts
+++ b/app/api/votes/route.ts
@@ -6,7 +6,7 @@ import { isCurrentlyRevoked } from "@/lib/enrollment/revocation";
 import { checkWindow } from "@/lib/auth/windows";
 import { dbError } from "@/lib/api/errors";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
-import { voteSchema } from "@/lib/validations/votes";
+import { voteSchema, voteSetSchema } from "@/lib/validations/votes";
 import { requireCompleteProfile } from "@/lib/participants/placeholder";
 import { rejectOrgCycle } from "@/lib/cycle/guards";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
@@ -157,5 +157,148 @@ export const POST = withAuth(
       { ...data, votes_remaining: budget - totalAllocated - vote_count },
       { status: 201 }
     );
+  }
+);
+
+// Set-absolute allocation: "set my votes on this statement to N" (N >= 0).
+// One path covers add / increase / decrease / remove — the ballot's stepper +
+// edit UI submits the desired total, not a delta. N = 0 deletes the row
+// (votes stores one row per (voter, statement); zero-count rows aren't a
+// supported state). Guard chain mirrors POST verbatim.
+export const PUT = withAuth(
+  async (request: NextRequest, auth: AuthenticatedRequest) => {
+    const body = await parseBody(request, voteSetSchema);
+    if (isErrorResponse(body)) return body;
+    const { cycle_id, problem_statement_id, vote_count } = body;
+    const voter_id = auth.user.participantId;
+
+    if (!voter_id) {
+      return NextResponse.json({ error: "Not a registered participant" }, { status: 403 });
+    }
+
+    const guard = await requireCompleteProfile(auth.supabase, voter_id);
+    if (guard) return guard;
+
+    const orgRejection = await rejectOrgCycle(auth.supabase, cycle_id);
+    if (orgRejection) return orgRejection;
+
+    const window = await checkWindow(auth.supabase, cycle_id, "voting");
+    if (!window.open) {
+      return NextResponse.json({ error: window.message }, { status: 403 });
+    }
+
+    if (!isEnrolledParticipant(auth.user, cycle_id)) {
+      return NextResponse.json({ error: "You must be enrolled in this cycle" }, { status: 403 });
+    }
+
+    if (
+      !isActiveParticipant(auth.user, cycle_id) &&
+      (await isCurrentlyRevoked(voter_id, cycle_id))
+    ) {
+      return NextResponse.json(
+        { error: "Your access to this cycle has been revoked." },
+        { status: 403 }
+      );
+    }
+
+    // Same-lab guard + validates the statement belongs to this cycle.
+    const { data: target } = await auth.supabase
+      .from("problem_statements")
+      .select("metro_id")
+      .eq("id", problem_statement_id)
+      .eq("cycle_id", cycle_id)
+      .maybeSingle();
+    if (!target) {
+      return NextResponse.json({ error: "Problem statement not found" }, { status: 404 });
+    }
+    const { data: voter } = await auth.supabase
+      .from("participants")
+      .select("metro_id")
+      .eq("id", voter_id)
+      .maybeSingle();
+    if ((target.metro_id ?? null) !== (voter?.metro_id ?? null)) {
+      return NextResponse.json(
+        { error: "You can only vote on your own lab's problem statements" },
+        { status: 403 }
+      );
+    }
+
+    // Budget
+    const { data: submission } = await auth.supabase
+      .from("problem_statements")
+      .select("id")
+      .eq("cycle_id", cycle_id)
+      .eq("participant_id", voter_id)
+      .limit(1)
+      .maybeSingle();
+
+    const { data: config } = await auth.supabase
+      .from("cycle_config")
+      .select("submitter_votes, non_submitter_votes")
+      .eq("cycle_id", cycle_id)
+      .single();
+
+    if (!config) {
+      return NextResponse.json({ error: "Cycle config not found" }, { status: 500 });
+    }
+
+    const budget = submission ? config.submitter_votes : config.non_submitter_votes;
+
+    const { data: existingVotes } = await auth.supabase
+      .from("votes")
+      .select("id, problem_statement_id, vote_count")
+      .eq("cycle_id", cycle_id)
+      .eq("voter_id", voter_id);
+
+    const existingRow = (existingVotes || []).find(
+      (v) => v.problem_statement_id === problem_statement_id
+    );
+
+    // Votes allocated to *other* statements — the new total for this statement
+    // is checked against the budget net of those, so lowering or removing this
+    // statement's allocation always frees budget.
+    const allocatedElsewhere = (existingVotes || []).reduce(
+      (sum, v) => (v.problem_statement_id === problem_statement_id ? sum : sum + v.vote_count),
+      0
+    );
+
+    if (allocatedElsewhere + vote_count > budget) {
+      return NextResponse.json(
+        {
+          error: `Vote budget exceeded. Budget: ${budget}, allocated elsewhere: ${allocatedElsewhere}, requested: ${vote_count}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    // votes has no UPDATE/DELETE RLS policy (INSERT-only for members), so
+    // updates and deletes go through the service client; every guard above has
+    // already passed. New rows still insert via the RLS-scoped client so the
+    // votes_insert WITH CHECK (voter_id = current_participant_id()) applies.
+    if (vote_count === 0) {
+      if (existingRow) {
+        const { error } = await createServiceClient()
+          .from("votes")
+          .delete()
+          .eq("id", existingRow.id);
+        if (error) return dbError(error);
+      }
+    } else if (existingRow) {
+      const { error } = await createServiceClient()
+        .from("votes")
+        .update({ vote_count })
+        .eq("id", existingRow.id);
+      if (error) return dbError(error);
+    } else {
+      const { error } = await auth.supabase
+        .from("votes")
+        .insert({ cycle_id, voter_id, problem_statement_id, vote_count });
+      if (error) return dbError(error);
+    }
+
+    return NextResponse.json({
+      vote_count,
+      votes_remaining: budget - allocatedElsewhere - vote_count,
+    });
   }
 );

--- a/docs/feedback-running-list.md
+++ b/docs/feedback-running-list.md
@@ -1,0 +1,62 @@
+# Feedback — Running List
+
+Raw feedback thoughts captured during hands-on testing. **Not yet deduped** against changes already made — review and reconcile before acting.
+
+Status legend: 🆕 new · 🔍 needs-dedupe · ✅ addressed · ❌ won't-do
+
+| # | Date | Area | Feedback | Status |
+|---|------|------|----------|--------|
+| 1 | 2026-07-12 | Cycle registration | Can't register for a cycle while the problem-statement window is open, but registration *should* be allowed during that window. **Root cause confirmed** — Register CTA only renders for `status='upcoming'` cycles; disappears once cycle goes `active`. | 🔍 |
+| 2 | 2026-07-12 | Problem statements | After submitting a problem statement, I should be able to see my own submission (confirmation / list of what I submitted). | 🆕 |
+| 3 | 2026-07-12 | Voting UX | Exceeding vote budget: interaction is confusing (shows "can't click" icon, buffers, then applies one vote anyway), and the follow-up error message on trying again isn't clear. Should say "You have used all of your votes. Remove votes from a problem statement before adding them to a new one." | ✅ |
+| 4 | 2026-07-12 | Voting UX | Can't see where my votes went — no visibility into which problem statement(s) I've allocated votes to. | ✅ |
+| 5 | 2026-07-12 | Voting UX | No ability to remove/undo votes once cast on a problem statement. | ✅ |
+
+## Details
+
+### 1 — Registration blocked while problem statements are open (2026-07-12)
+**Observed:** While a cycle's problem-statement window is open, cycle registration is unavailable. Expectation is that a participant should still be able to register during that window (registration and problem-statement submission windows should overlap, or registration shouldn't be gated closed by the problem-statement phase).
+
+**Root cause (confirmed 2026-07-12):** There is *no* registration-window gate — enrollment is gated purely on cycle `status`. The only "Register" CTA in the UI is in `app/(dashboard)/cycles/page.tsx` (`upcomingCycles` filter, ~lines 80-82):
+```js
+const upcomingCycles = otherCycles.filter(
+  (c) => c.mode !== "org" && c.status === "upcoming"
+);
+```
+Once a cycle flips `upcoming` → `active` (which is also when the problem-statement window opens), it's rendered instead as a read-only "View cycle" quick-link to `cycles/[cycle_id]/page.tsx`, which has **no Register/Join button**. The join flow itself (`/cycles/[id]/join` + `api/cycles/[id]/agreement`) still *accepts* `status='active'` — it's purely that nothing in the UI links to it anymore.
+
+**Possible fixes:** (a) surface the Register CTA for `active` open cycles too; or (b) gate registration on a real registration window (`registration_open`/`registration_close` — note these columns do **not** currently exist in `cycle_config`) instead of `status`.
+
+**To dedupe against:** the pod-registration redesign (two status-keyed windows, decoupling membership from enrollment) — likely the intended home for a proper registration window. Reconcile before implementing.
+
+### 2 — Can't see my own problem statement after submitting (2026-07-12)
+**Observed:** After submitting a problem statement, there's no way to view my own submission — no confirmation showing what I submitted, and it doesn't appear in a "my submissions" list. Expectation is that once submitted, I can see my problem statement(s) back.
+
+**To investigate:** whether the propose flow shows a post-submit confirmation of the actual text, and whether the cycle page / a "my problem statements" view lists the current user's own submissions. The GET route (`app/api/problem-statements/[cycle_id]/route.ts`) filters by the viewer's `metro_id`/lab — check whether that filtering hides the user's own just-submitted statement (e.g. metro mismatch, or listing only surfaces during the voting phase).
+
+### 3 — Confusing UX when a vote exceeds the vote budget (2026-07-12)
+**Observed:** When casting a vote that would exceed the participant's vote budget, the UI shows a "can't click" cursor icon, buffers, and then applies one vote anyway (inconsistent with the disabled-looking state). Trying to vote again afterward shows an error, but the error message isn't clear about *why*.
+
+**Expected:** A clear, actionable error: "You have used all of your votes. Remove votes from a problem statement before adding them to a new one."
+
+**To investigate:** the vote-casting client component and API route for problem-statement votes — likely near `submitter_votes`/`non_submitter_votes`/`vote_threshold` in `cycle_config` and wherever votes are POSTed. Check: (a) why a vote is applied despite the disabled-looking cursor state (race condition / stale disabled check?), and (b) what error message/copy the API currently returns on budget-exceeded vs. what's rendered client-side.
+
+**Addressed (2026-07-12):** Made over-budget voting unreachable in the UI rather than relying on the server's cryptic 400. In `app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx`: the number input now clamps typed values to `[0, remaining]` (typing a higher number reverts to your max), the input and Vote button are disabled once `remaining <= 0`, and the budget bar shows "You've used all of your votes for this cycle." The server budget check in `app/api/votes/route.ts` stays as a defense-in-depth backstop. Vote removal (the "remove votes…" half of the proposed copy) is **not** built — tracked separately as #5.
+
+### 4 — No visibility into where my votes went (2026-07-12)
+**Observed:** After casting votes on problem statements, there's no way to see which statement(s) currently have my votes allocated to them — no per-statement "you voted N here" indicator, no summary of my own vote allocation.
+
+**Expected:** Some clear indication (e.g. a per-card badge/counter, or a "your votes" summary) showing how the participant's vote budget is currently distributed across statements.
+
+**To investigate:** likely the same voting UI area as #3 — check whether the votes-cast data is even fetched/returned to the client per-statement, or only aggregate totals are shown.
+
+**Addressed (2026-07-12):** Each ballot card now shows the viewer's own allocation. `GET /api/votes/[cycle_id]` already returned `my_votes` (per-statement), but `vote-ballot.tsx` discarded everything except the sum — it now keeps a `myVotes` map and renders "· you: N" on the tally line plus a "Your votes: N" state on the vote control. No server change was needed for visibility. Delivered together with #5.
+
+### 5 — No ability to remove votes (2026-07-12)
+**Observed:** Once a vote is cast on a problem statement, there's no way to remove/undo it. Combined with #3 (unclear budget-exceeded error) and #4 (can't see vote allocation), a participant who accidentally uses up their vote budget has no path to correct it.
+
+**Expected:** Ability to remove/decrement a vote from a statement, freeing up budget to reallocate elsewhere — this is also a prerequisite for the error message proposed in #3 ("remove votes from a problem statement before adding them to a new one") to actually be actionable.
+
+**To investigate:** the vote POST/DELETE API surface for problem-statement votes — check whether a remove/decrement endpoint exists at all, or only additive voting is implemented.
+
+**Addressed (2026-07-12):** Only additive `POST` existed. Added a **set-absolute** `PUT /api/votes` (`app/api/votes/route.ts`) that takes the desired total for a statement (`voteSetSchema`, `vote_count >= 0`); one path covers add / increase / decrease / remove, and `vote_count = 0` deletes the row. It reuses POST's full guard chain (window, enrollment, revocation, same-lab, budget) and routes updates/deletes through the service client (`votes` has no UPDATE/DELETE RLS policy — same pattern as the existing increment); the budget check nets out this statement's current allocation so lowering it always frees budget. In `vote-ballot.tsx` the number-input + Vote button became a stepper (− N +) with an explicit Vote/Save submit: unvoted cards show the stepper directly; voted cards rest at "Your votes: N" with an Edit button that reopens the stepper (dial to 0 to remove, Cancel to back out). This also makes the #3 error copy ("remove votes… before adding them to a new one") actionable. Original `POST` left in place as a backstop; the ballot now uses `PUT` exclusively.

--- a/lib/auth/windows.ts
+++ b/lib/auth/windows.ts
@@ -29,11 +29,13 @@ export async function checkWindow(
   // (nothing stops that today) would otherwise open a formation-only
   // action for a workstream. Org cycles have no formation windows by
   // design (docs/ORG_CYCLES.md); reject before the timestamp logic runs.
+  // maybeSingle: a missing cycle_config row must surface as the explicit
+  // "configuration not found" message below, not a PostgREST .single() error.
   const { data: config } = await supabase
     .from("cycle_config")
     .select(`${field}_open, ${field}_close, cycles(mode)`)
     .eq("cycle_id", cycleId)
-    .single();
+    .maybeSingle();
 
   if (!config) {
     return { open: false, message: "Cycle configuration not found." };

--- a/lib/validations/votes.ts
+++ b/lib/validations/votes.ts
@@ -54,3 +54,16 @@ export const voteSchema = z.object({
     .int()
     .min(1, "vote_count must be >= 1"),
 });
+
+// Set-absolute vote allocation: "set my votes on this statement to N".
+// Unlike voteSchema (additive POST), 0 is allowed and means "remove my votes".
+export const voteSetSchema = z.object({
+  cycle_id: z.number().int({ message: "cycle_id must be a number" }),
+  problem_statement_id: z.number().int({
+    message: "problem_statement_id must be a number",
+  }),
+  vote_count: z
+    .number()
+    .int()
+    .min(0, "vote_count must be >= 0"),
+});


### PR DESCRIPTION
## What

Fixes the problem-statement and voting bugs from the July 11 testing session (`docs/testing-feedback-2026-07-11.md`, Problem Statements + Problem Voting sections): wrong vote budget shown to submitters, no vote stacking, misleading "not currently open" failures, and the propose form leaving the viewport at the footer between steps.

Now also folds in the voting items from the July 12 hands-on session (`docs/feedback-running-list.md` #3, #4, #5): a clear over-budget UX, per-card visibility into your own allocation, and the ability to remove/reallocate votes.

## Changes

- Vote page resolves `isSubmitter` server-side and passes it to the ballot; the ballot initializes from the correct config budget (`cycle_config.submitter_votes` / `non_submitter_votes`) instead of always showing the non-submitter value.
- `GET /api/votes/[cycle_id]` returns the caller's own allocations (`my_votes`) so remaining budget is right after a reload.
- `POST /api/votes` supports **stacking**: an existing (voter, problem) row is incremented via the service client (votes has INSERT-only RLS for members) instead of failing on `UNIQUE(voter_id, problem_statement_id, cycle_id)`. Budget enforcement unchanged.
- Ballot helper text states the viewer's actual budget and that stacking is allowed.
- Propose page, vote page, and `checkWindow` use `maybeSingle()` and show an explicit "cycle isn't configured yet" message when the `cycle_config` row is missing.
- Propose form scrolls to top on step change.

### Vote visibility & removal — feedback #4 and #5

These two are coupled (you can't sensibly remove votes without seeing where they went) and are delivered together:

- **Set-absolute `PUT /api/votes`** (`app/api/votes/route.ts`): submits the *desired total* for a statement (`voteSetSchema`, `vote_count >= 0`) rather than a delta — one path covers add / increase / decrease / remove, and `vote_count = 0` deletes the row. Reuses `POST`'s entire guard chain (window, enrollment, revocation, same-lab, budget). The budget check nets out this statement's current allocation, so lowering or removing an allocation always frees budget. Updates/deletes route through the service client (mirroring the stacking increment, since `votes` has no UPDATE/DELETE RLS policy); new rows still insert via the RLS-scoped client. `POST` is kept as a backstop; the ballot now uses `PUT` exclusively.
- **Ballot UI** (`vote-ballot.tsx`): the `my_votes` data (already fetched, previously discarded) is now kept and surfaced. Each card shows the community tally plus "· you: N", and the number-input + Vote button is replaced by a **stepper (− N +) with an explicit Vote/Save**. Unvoted cards show the stepper directly; voted cards rest at "Your votes: N" with an **Edit** button that reopens the stepper — dial down to 0 to remove, or Cancel to back out. This also makes the #3 over-budget copy ("remove votes… before adding them to a new one") actionable.
- `docs/feedback-running-list.md` #4 and #5 marked ✅.

## Verify

- Voted as a seeded submitter and non-submitter locally: budgets show 3/1 per config, stacking on one problem works, over-budget still 400s, reload keeps remaining count correct.
- Stepped through the propose form: viewport resets to top on Continue/Back.

For the vote visibility/removal commit:
- [x] `npm run build` compiles successfully; changed files typecheck and lint clean.
- [ ] End-to-end runtime drive (cast → reload persists → edit down → set to 0 deletes the row → over-budget rejected) — pending a live walk-through against a cycle with an open voting window. The unit-test suite could not run in this environment (the `vitest` dependency isn't installed locally; unrelated to these changes).

- [x] `npm run lint` passes
- [x] `npm run build` passes

## Database

- [x] No schema change (vote removal reuses the existing `votes` table; `PUT` deletes/updates rows via the service client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX)_
