### PR TITLE
fix(register): prefill names from the Google profile; drop the names/zip helper text

### DIFF
--- a/app/(auth)/register/funnel.tsx
+++ b/app/(auth)/register/funnel.tsx
@@ -93,7 +93,6 @@ function signupSteps(email: string): FlowStep[] {
       id: "about",
       type: "fields",
       q: "Tell us who you are",
-      help: "Your zip just finds the lab nearest you — nothing else.",
       fields: [
         { id: "first", label: "First name", ph: "Alex", required: true, half: true },
         { id: "last", label: "Last name", ph: "Rivera", required: true, half: true },
@@ -180,9 +179,14 @@ const ROLE_OPTIONS: {
 export default function RegistrationFunnel({
   email,
   authUserId,
+  initialFirstName = "",
+  initialLastName = "",
 }: {
   email: string;
   authUserId: string;
+  /** Prefill from the Google OAuth profile — editable like any answer. */
+  initialFirstName?: string;
+  initialLastName?: string;
 }) {
   const router = useRouter();
   const [stage, setStage] = useState<"roles" | "flow" | "lab" | "already">(
@@ -289,7 +293,12 @@ export default function RegistrationFunnel({
       finalLabel="Continue"
       finalClass="btn-red"
       submittingLabel="One moment…"
-      initialAnswers={flowAnswers ?? undefined}
+      initialAnswers={
+        flowAnswers ??
+        (initialFirstName || initialLastName
+          ? { first: initialFirstName, last: initialLastName }
+          : undefined)
+      }
       initialStepIndex={flowAnswers ? steps.length - 1 : 0}
       onComplete={async (answers) => {
         setFlowAnswers(answers);

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -26,5 +26,32 @@ export default async function RegisterPage() {
     redirect("/dashboard");
   }
 
-  return <RegistrationFunnel email={user.email ?? ""} authUserId={user.id} />;
+  // Google's OAuth profile rides along on user_metadata — seed the name
+  // fields from it so a new member isn't retyping what we already know
+  // (July 2026 feedback). Fall back to splitting the display name when the
+  // structured fields are absent.
+  const meta = (user.user_metadata ?? {}) as Record<string, unknown>;
+  const displayName =
+    typeof meta.full_name === "string"
+      ? meta.full_name
+      : typeof meta.name === "string"
+        ? meta.name
+        : "";
+  const firstName =
+    typeof meta.given_name === "string"
+      ? meta.given_name
+      : (displayName.split(" ")[0] ?? "");
+  const lastName =
+    typeof meta.family_name === "string"
+      ? meta.family_name
+      : displayName.split(" ").slice(1).join(" ");
+
+  return (
+    <RegistrationFunnel
+      email={user.email ?? ""}
+      authUserId={user.id}
+      initialFirstName={firstName}
+      initialLastName={lastName}
+    />
+  );
 }


### PR DESCRIPTION
## What

Registration-funnel items from the July 11 testing feedback: prefill first/last name from the Google account, and remove the helper text on the names/zip step that testers found confusing.

## Changes

- `app/(auth)/register/page.tsx` extracts `given_name`/`family_name` from the OAuth `user_metadata` (falling back to splitting `full_name`/`name`) and passes them to the funnel.
- `RegistrationFunnel` seeds the flow's `first`/`last` answers from those props on first entry; both fields remain editable, and resuming from the lab stage still restores the user's own answers.
- The "Tell us who you are" step's zip helper line is removed.

## Verify

- New-user path: name fields arrive prefilled from Google metadata and can be edited; zip behavior unchanged.
- Back/resume within the funnel keeps user-entered values (prefill only applies before any answers exist).

- [x] `npm run lint` passes
- [x] `npm run test` passes (255)
- [x] `npm run build` passes

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX)_