### PR TITLE
fix(dashboard): registration-first checklist, window-gated pod row, persistent collapse, dismissible hero, footer

### DIFF
--- a/app/(dashboard)/dashboard/cycle-commitments.tsx
+++ b/app/(dashboard)/dashboard/cycle-commitments.tsx
@@ -9,7 +9,7 @@ import { ANCHOR_EVENTS, fmtEvt, icsHref } from "@/lib/cycles/anchor-events";
 export default function CycleCommitments() {
   return (
     <section className="rounded-card border border-ink/10 bg-white p-5 shadow-card">
-      <div className="lbl lbl-teal mb-2">Locked in</div>
+      <div className="lbl lbl-teal mb-2">Key dates</div>
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <h2 className="t-h3 text-ink">Your commitments</h2>
         <a

--- a/app/(dashboard)/dashboard/dashboard-hero.tsx
+++ b/app/(dashboard)/dashboard/dashboard-hero.tsx
@@ -1,16 +1,25 @@
-import Link from "next/link";
+"use client";
+
+import { useEffect, useState } from "react";
 import Orb from "@/app/components/chrome/orb";
 
 /* The dashboard hero — the signed-in identity band (prototype panel-dashboard
    ".app-cover"): a warm dark orb cover carrying the member's avatar, a greeting,
    a one-line status, and (when engaged) an at-a-glance stat strip. LinkedIn's
-   identity header married to Airbnb's rounded, orb-lit cover. A plain server
-   component; OrbDefs is mounted once by the dashboard layout. */
+   identity header married to Airbnb's rounded, orb-lit cover.
+
+   Dismissible (July 2026 feedback: "make the big blue hero dismissible") —
+   the choice persists in localStorage like the other member-local dashboard
+   preferences, so it's a client component now; OrbDefs stays mounted once by
+   the dashboard layout. The "view your full profile" CTA was struck from the
+   header in the same feedback pass (the avatar menu covers it). */
 
 export interface HeroStat {
   value: string | number;
   label: string;
 }
+
+const KEY = "olos.heroDismissed.v1";
 
 export default function DashboardHero({
   initials,
@@ -27,8 +36,36 @@ export default function DashboardHero({
   lede: string;
   stats?: HeroStat[];
 }) {
+  const [state, setState] = useState<"pending" | "shown" | "dismissed">(
+    "pending"
+  );
+
+  useEffect(() => {
+    // Deferred past the effect body (repo pattern — see up-next.tsx) so the
+    // localStorage read isn't a synchronous setState-in-effect.
+    queueMicrotask(() => {
+      try {
+        setState(localStorage.getItem(KEY) === "1" ? "dismissed" : "shown");
+      } catch {
+        setState("shown");
+      }
+    });
+  }, []);
+
+  const dismiss = () => {
+    setState("dismissed");
+    try {
+      localStorage.setItem(KEY, "1");
+    } catch {
+      /* best effort */
+    }
+  };
+
+  // Render nothing until the store is read, so a dismissed hero never flashes.
+  if (state !== "shown") return null;
+
   return (
-    <section className="app-cover s-cover grain on-dark mb-8 rounded-card shadow-card">
+    <section className="app-cover s-cover grain on-dark relative mb-8 rounded-card shadow-card">
       <Orb />
       {/* Scrim — the orb never sits raw under text (design rule). */}
       <div
@@ -39,6 +76,14 @@ export default function DashboardHero({
             "linear-gradient(100deg, rgba(0,20,27,0) 42%, rgba(0,20,27,0.5) 100%)",
         }}
       />
+      <button
+        type="button"
+        aria-label="Hide the welcome banner"
+        onClick={dismiss}
+        className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full text-xl leading-none text-white/70 transition-colors duration-150 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+      >
+        ×
+      </button>
       <div className="app-cover-inner px-6 sm:px-10">
         <div className="flex flex-wrap items-center gap-5 sm:gap-7">
           {avatarUrl ? (
@@ -62,13 +107,6 @@ export default function DashboardHero({
             <div className="lbl lbl-teal mb-2">{eyebrow}</div>
             <h1 className="t-h1">{greeting}</h1>
             <p className="t-lede mt-2">{lede}</p>
-            <Link
-              href="/profile"
-              className="mt-3 inline-block text-sm font-semibold hover:underline"
-              style={{ color: "var(--od1)" }}
-            >
-              View your full profile &rarr;
-            </Link>
           </div>
           {stats && stats.length > 0 && (
             <div className="flex gap-7 sm:gap-9">

--- a/app/(dashboard)/dashboard/learning-log-card.tsx
+++ b/app/(dashboard)/dashboard/learning-log-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 
 /* The Learning Log — the weekly ritual, on the dashboard where the practice
    lives (owner decision: the ritual is Home, not a nav destination). Three
@@ -119,6 +120,7 @@ export default function LearningLogCard({
       render just the form. */
   embedded?: boolean;
 }) {
+  const router = useRouter();
   const pf = milestone?.prefill ?? null;
   const [clarity, setClarity] = useState(pf?.clarity ?? 3);
   const [alignment, setAlignment] = useState(pf?.alignment ?? 3);
@@ -288,8 +290,14 @@ export default function LearningLogCard({
       setNextFocus("");
       setShare(false);
       loadRecent();
+      // Refresh the server components so anything derived from log state
+      // updates in place — notably the setup checklist's "Save your first
+      // Learning Log" row, which is computed server-side (logCount > 0) and
+      // otherwise stayed unchecked until a manual refresh.
+      router.refresh();
       if (data.gate_cleared) {
-        // The gate reads server state — refresh so the chrome unlocks now.
+        // The gate reads server state — full reload so the locked chrome
+        // unlocks now (stronger than router.refresh for the layout gate).
         setTimeout(() => window.location.reload(), 1200);
       }
     } catch {

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -467,6 +467,20 @@ export default async function DashboardPage() {
   }
 
   const checklistItems: ChecklistItem[] = [
+    // Cycle registration leads the list — it's the reason most members are
+    // here, and testers looked for it above the housekeeping rows (July 2026
+    // feedback: "civics/elections registration comes first").
+    ...(registerCycle
+      ? [
+          {
+            key: "register",
+            label: `Register for ${registerCycle.name}`,
+            done: registerDone,
+            href: `/cycles/${registerCycle.id}/join`,
+            cta: "Register",
+          },
+        ]
+      : []),
     ...(fieldSurvey
       ? [
           {
@@ -492,20 +506,11 @@ export default async function DashboardPage() {
       href: "/directory",
       cta: "Find",
     },
-    ...(registerCycle
-      ? [
-          {
-            key: "register",
-            label: `Register for ${registerCycle.name}`,
-            done: registerDone,
-            href: `/cycles/${registerCycle.id}/join`,
-            cta: "Register",
-          },
-        ]
-      : []),
     // Pod + Learning Log steps belong to the running cohort — an upcoming
-    // cohort has no pods yet — so these stay tied to the active cycle.
-    ...(activeCycle
+    // cohort has no pods yet — so these stay tied to the active cycle. The
+    // pod row also waits for its registration window: showing "Choose a pod"
+    // before any pod is open was a reported bug.
+    ...(activeCycle && podWindowOpen
       ? [
           {
             key: "pod",
@@ -514,6 +519,10 @@ export default async function DashboardPage() {
             href: `/cycles/${activeCycle.id}/register-pods`,
             cta: "Choose",
           },
+        ]
+      : []),
+    ...(activeCycle
+      ? [
           {
             key: "log",
             label: "Save your first Learning Log",
@@ -702,7 +711,7 @@ export default async function DashboardPage() {
         memberships={memberships}
         mode={activeCycle?.mode ?? null}
       />
-      <QuickLinks cycleId={activeCycle?.id} />
+      <QuickLinks cycleId={activeCycle?.id} metroId={participant.metro_id} />
       {otherCycles.length > 0 && (
         <details className="rounded-card border border-ink/10 bg-white p-5 shadow-card">
           <summary className="lbl cursor-pointer hover:text-charcoal">

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -494,7 +494,9 @@ export default async function DashboardPage() {
       : []),
     {
       key: "profile",
-      label: "Complete your profile",
+      // Label names the exact fields that flip profileDone (bio || headline),
+      // so editing other profile fields not counting isn't a surprise.
+      label: "Add your bio and headline",
       done: profileDone,
       href: "/profile/edit",
       cta: "Edit",

--- a/app/(dashboard)/dashboard/quick-links.tsx
+++ b/app/(dashboard)/dashboard/quick-links.tsx
@@ -5,12 +5,22 @@ import Link from "next/link";
    A calm list of teal links divided by hairlines — LinkedIn's right rail in
    the light system. */
 
-export default function QuickLinks({ cycleId }: { cycleId?: number }) {
+export default function QuickLinks({
+  cycleId,
+  metroId,
+}: {
+  cycleId?: number;
+  metroId?: number | null;
+}) {
   const links: { label: string; href: string; external?: boolean }[] = [
     { label: "Your cycle", href: cycleId ? `/cycles/${cycleId}` : "/cycles" },
     { label: "Browse events", href: "/events" },
     { label: "Browse the library", href: "/library" },
-    { label: "Find your local lab", href: "/local-labs" },
+    // The lab finder only matters to members who haven't picked one —
+    // showing it to registered lab members read as a bug in testing.
+    ...(metroId == null
+      ? [{ label: "Find your local lab", href: "/local-labs" }]
+      : []),
     {
       label: "Support The Labs",
       href: "https://www.every.org/theupskillinglabs",

--- a/app/(dashboard)/dashboard/setup-checklist.tsx
+++ b/app/(dashboard)/dashboard/setup-checklist.tsx
@@ -130,12 +130,25 @@ export default function SetupChecklist({ items }: { items: ChecklistItem[] }) {
               </span>
             </span>
             {!item.done && item.href && (
-              <Link
-                href={item.href}
-                className="flex min-h-11 flex-shrink-0 items-center rounded-card bg-teal/10 px-3 py-1 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
-              >
-                {item.cta ?? "Start"} →
-              </Link>
+              // In-page anchors (e.g. #learning-log) use a plain <a>: a Next
+              // <Link> does a pushState soft-nav that scrolls but never fires
+              // `hashchange`, so the feed composer's hash listener wouldn't flip
+              // to the Learning Log tab. A native anchor fires it and still scrolls.
+              item.href.startsWith("#") ? (
+                <a
+                  href={item.href}
+                  className="flex min-h-11 flex-shrink-0 items-center rounded-card bg-teal/10 px-3 py-1 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+                >
+                  {item.cta ?? "Start"} →
+                </a>
+              ) : (
+                <Link
+                  href={item.href}
+                  className="flex min-h-11 flex-shrink-0 items-center rounded-card bg-teal/10 px-3 py-1 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+                >
+                  {item.cta ?? "Start"} →
+                </Link>
+              )
             )}
           </li>
         ))}

--- a/app/(dashboard)/dashboard/setup-checklist.tsx
+++ b/app/(dashboard)/dashboard/setup-checklist.tsx
@@ -1,14 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 /* The setup checklist — leads the dashboard for a new member (prototype
    panel-dashboard: "setup checklist first"). Actionable rows carry a
    visible "Start →" (no hover-only affordances, owner decision); once every
-   row is done the whole thing collapses to a "Setup · All done ✓" strip,
-   re-expandable. Done-ness is computed server-side; this only owns the
-   collapse. */
+   row is done the whole thing collapses to a "Setup" strip, re-expandable.
+   Done-ness is computed server-side; this only owns the collapse.
+
+   The collapse choice persists in localStorage (same member-local pattern
+   as up-next.tsx). Before this, collapse was derived purely from allDone —
+   adding a new cycle introduced fresh incomplete rows and silently
+   re-expanded the list for everyone (July 2026 feedback: "To Do list
+   reopens when a new Cycle is added"). The Show/Collapse control lives in
+   the header-right in both states so it never jumps position. */
 
 export interface ChecklistItem {
   key: string;
@@ -18,20 +24,62 @@ export interface ChecklistItem {
   cta?: string;
 }
 
+const KEY = "olos.setupChecklistCollapsed.v1";
+
 export default function SetupChecklist({ items }: { items: ChecklistItem[] }) {
   const allDone = items.every((i) => i.done);
-  const [expanded, setExpanded] = useState(false);
+  const doneCount = items.filter((i) => i.done).length;
 
-  if (allDone && !expanded) {
+  // null = no stored preference yet → fall back to auto-collapse when done.
+  const [stored, setStored] = useState<boolean | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    // Deferred past the effect body so the localStorage read + state set
+    // isn't a synchronous setState-in-effect (and never runs during SSR).
+    queueMicrotask(() => {
+      try {
+        const raw = localStorage.getItem(KEY);
+        if (raw === "1") setStored(true);
+        else if (raw === "0") setStored(false);
+      } catch {
+        /* no store — derive from done-ness */
+      }
+      setReady(true);
+    });
+  }, []);
+
+  const setCollapsed = (v: boolean) => {
+    setStored(v);
+    try {
+      localStorage.setItem(KEY, v ? "1" : "0");
+    } catch {
+      /* best effort */
+    }
+  };
+
+  // Completing setup cements the collapse, so later cycles adding fresh
+  // rows re-surface as a count on the strip instead of a full re-expansion.
+  useEffect(() => {
+    if (!(ready && allDone && stored === null)) return;
+    queueMicrotask(() => setCollapsed(true));
+  }, [ready, allDone, stored]);
+
+  // Render nothing until the store is read, so a collapsed list never flashes.
+  if (!ready) return null;
+
+  const collapsed = stored ?? allDone;
+
+  if (collapsed) {
     return (
       <div className="mb-6 flex items-center justify-between rounded-card border border-ink/10 bg-white px-5 py-3 shadow-card">
         <span className="text-sm font-semibold text-teal-deep">
-          Setup · All done ✓
+          {allDone ? "Setup · All done ✓" : `Setup · ${doneCount} / ${items.length} done`}
         </span>
         <button
           type="button"
           className="text-xs text-meta transition-colors hover:text-ink focus-visible:underline"
-          onClick={() => setExpanded(true)}
+          onClick={() => setCollapsed(false)}
         >
           Show
         </button>
@@ -39,14 +87,21 @@ export default function SetupChecklist({ items }: { items: ChecklistItem[] }) {
     );
   }
 
-  const doneCount = items.filter((i) => i.done).length;
-
   return (
     <section className="mb-6 rounded-card border border-ink/10 bg-white p-5 shadow-card">
-      <div className="flex items-baseline justify-between">
+      <div className="flex items-baseline justify-between gap-3">
         <h2 className="t-h3 text-ink">Get set up</h2>
-        <span className="text-xs text-meta tabular-nums">
-          {doneCount} / {items.length} done
+        <span className="flex items-baseline gap-3">
+          <span className="text-xs text-meta tabular-nums">
+            {doneCount} / {items.length} done
+          </span>
+          <button
+            type="button"
+            className="text-xs text-meta transition-colors hover:text-ink focus-visible:underline"
+            onClick={() => setCollapsed(true)}
+          >
+            Collapse
+          </button>
         </span>
       </div>
       <ul className="mt-4 divide-y divide-ink/10">
@@ -85,15 +140,6 @@ export default function SetupChecklist({ items }: { items: ChecklistItem[] }) {
           </li>
         ))}
       </ul>
-      {allDone && (
-        <button
-          type="button"
-          className="mt-3 text-xs text-meta transition-colors hover:text-ink focus-visible:underline"
-          onClick={() => setExpanded(false)}
-        >
-          Collapse
-        </button>
-      )}
     </section>
   );
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -8,6 +8,7 @@ import { one } from "@/lib/supabase/embed";
 import AppNav from "@/app/components/chrome/app-nav";
 import OrbDefs from "@/app/components/chrome/orb-defs";
 import FeedbackWidget from "@/app/components/feedback/feedback-widget";
+import DashboardFooter from "@/app/components/chrome/dashboard-footer";
 import { learningLogGate } from "@/lib/learning-logs/gate";
 
 export default async function DashboardLayout({
@@ -185,6 +186,7 @@ export default async function DashboardLayout({
         </div>
       )}
       <main className="app-main container w-full flex-1 py-8">{children}</main>
+      <DashboardFooter />
       <FeedbackWidget />
     </div>
   );

--- a/app/components/chrome/dashboard-footer.tsx
+++ b/app/components/chrome/dashboard-footer.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+/* The signed-in footer — a slim utility strip closing every dashboard page.
+   Carries the two asks testers couldn't find (July 2026 feedback: "more
+   prominent Support button, and add it to the footer"): the feedback/support
+   launcher (the same olos:open-feedback event the avatar menu fires — the
+   widget is mounted by the dashboard layout) and the every.org support link
+   that otherwise lives only in the dashboard's Quick links rail. */
+
+export default function DashboardFooter() {
+  return (
+    <footer className="mt-8 border-t border-ink/10 bg-white">
+      <div className="container flex flex-wrap items-center justify-between gap-x-6 gap-y-2 py-4">
+        <span className="text-xs text-meta">The Upskilling Labs</span>
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <button
+            type="button"
+            onClick={() =>
+              window.dispatchEvent(new CustomEvent("olos:open-feedback"))
+            }
+            className="text-sm font-semibold text-teal-deep hover:underline focus-visible:underline focus-visible:outline-none"
+          >
+            Get support / send feedback
+          </button>
+          <a
+            href="https://www.every.org/theupskillinglabs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-semibold text-teal-deep hover:underline"
+          >
+            Support The Labs &rarr;
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## What

The dashboard batch from the July 11 testing feedback: checklist ordering/gating bugs, copy softening, the reopening To-Do list, hero dismissibility, and the missing Support affordance.

## Changes

- **Checklist order**: the cycle-registration row now leads the list (feedback: "civics/elections registration comes first" — clarified by the owner as *any* cycle registration sorting above other tasks).
- **"Join a pod" gating**: the row renders only while `podWindowOpen` (already computed on the page) — it previously appeared right after cycle registration with no pod joinable.
- **"Locked in" → "Key dates"** on Your Commitments.
- **"Find your local lab"** quick link hides when the member already has a `metro_id`.
- **To-Do reopening**: collapse now persists in `localStorage` (`olos.setupChecklistCollapsed.v1`, same member-local pattern as `up-next.tsx`); completing setup cements the collapse, so a new cycle's fresh rows show as `Setup · 4/6 done` on the strip instead of silently re-expanding. Show/Collapse renders in the header-right in **both** states so the control never changes position.
- **Hero**: now dismissible (× top-right, persisted via `olos.heroDismissed.v1`) and the "View your full profile" CTA is removed. `DashboardHero` became a client component; props unchanged.
- **Footer**: new slim `DashboardFooter` in the dashboard layout — "Get support / send feedback" (fires the existing `olos:open-feedback` event) + the every.org "Support The Labs" link.

## Verify

- Checklist: register row first; pod row absent with the window closed, present when open; collapse survives reload and new-cycle row additions.
- Hero: × hides it, stays hidden across reloads; no profile CTA.
- Footer renders on all dashboard-group pages; feedback button opens the widget.

- [x] `npm run lint` passes (one pre-existing warning in `pod-join-section.tsx`, untouched)
- [x] `npm run test` passes (255)
- [x] `npm run build` passes

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX)_