### PR TITLE
fix(profile+directory): metro label dedup, saved banner, back link, live follow count, availability prefill, handle de-suffix

### DIFF
--- a/app/(auth)/register/funnel.tsx
+++ b/app/(auth)/register/funnel.tsx
@@ -16,6 +16,7 @@ import {
   type FlowStep,
   type FlowAnswers,
 } from "@/app/components/flow/flow-screen";
+import { metroLabel } from "@/lib/metros-label";
 
 /* ════════════════════════════════════════════════════════════════════════
    The onboarding funnel — ported from onboarding-proto:
@@ -417,7 +418,7 @@ interface SuggestResponse {
 }
 
 function labLabel(l: LabLite): string {
-  return l.name + (l.st ? `, ${l.st}` : "");
+  return metroLabel(l.name, l.st);
 }
 
 function LabOptCard({

--- a/app/(dashboard)/admin/announcements/page.tsx
+++ b/app/(dashboard)/admin/announcements/page.tsx
@@ -1,4 +1,5 @@
 import { requireAdmin } from "@/lib/auth/guards";
+import { metroLabel } from "@/lib/metros-label";
 import AnnouncementsAdmin, {
   type AdminAnnouncement,
   type LabOption,
@@ -28,7 +29,7 @@ export default async function AdminAnnouncementsPage() {
   const rows = (announcements as AdminAnnouncement[]) ?? [];
   const labOptions: LabOption[] = (labs ?? []).map((l) => ({
     id: l.id,
-    label: [l.name, l.st].filter(Boolean).join(", "),
+    label: metroLabel(l.name, l.st),
   }));
 
   return (

--- a/app/(dashboard)/profile/edit/profile-edit-form.tsx
+++ b/app/(dashboard)/profile/edit/profile-edit-form.tsx
@@ -321,6 +321,17 @@ export default function ProfileEditForm({
   return (
     <FormProvider {...form}>
       <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-5">
+        {/* Saving scrolls to the top — the confirmation has to be waiting
+            where the scroll lands, not only down by the submit bar
+            (July 2026 feedback). */}
+        {saved && !required && (
+          <p className="rounded-card border border-teal/30 bg-teal/10 px-3 py-2 text-sm text-teal-deep">
+            Saved.{" "}
+            <Link href="/profile" className="underline">
+              Back to profile
+            </Link>
+          </p>
+        )}
         <FormField name="first_name" label="First name" required htmlFor="first_name">
           <Input id="first_name" type="text" autoComplete="given-name" invalid={!!errors.first_name} {...register("first_name")} />
         </FormField>

--- a/app/(dashboard)/profile/edit/profile-edit-form.tsx
+++ b/app/(dashboard)/profile/edit/profile-edit-form.tsx
@@ -85,9 +85,15 @@ const ROLE_INTENTS: [string, string][] = [
   ["volunteer", "Volunteer"],
   ["events", "Community"],
 ];
-const OPTION_SECTIONS: { list: string; label: string; scroll?: boolean }[] = [
+const OPTION_SECTIONS: {
+  list: string;
+  label: string;
+  scroll?: boolean;
+  /** Single-select: picking a chip replaces the current choice. */
+  single?: boolean;
+}[] = [
   { list: "labs_goals", label: "Your goals" },
-  { list: "availability", label: "Availability" },
+  { list: "availability", label: "Availability", single: true },
   { list: "work_style", label: "How you like to work" },
   { list: "group_strengths", label: "Your strengths" },
   { list: "ai_tools", label: "AI tools you use", scroll: true },
@@ -202,6 +208,12 @@ export default function ProfileEditForm({
   const toggleOption = (list: string, id: number) =>
     setOptions((p) => {
       const cur = p[list] ?? [];
+      const single = OPTION_SECTIONS.find((s) => s.list === list)?.single;
+      if (single) {
+        // Single-select list: picking a chip replaces the choice; picking the
+        // active chip clears it.
+        return { ...p, [list]: cur.includes(id) ? [] : [id] };
+      }
       return {
         ...p,
         [list]: cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id],

--- a/app/(dashboard)/profile/member-profile-view.tsx
+++ b/app/(dashboard)/profile/member-profile-view.tsx
@@ -78,22 +78,30 @@ export default function MemberProfileView({
 
   return (
     <div className="max-w-3xl">
-      {/* Visitor context bar — who you're looking at + the way back. */}
+      {/* Visitor context bar — the way back. The follow action + count moved
+          inside the card header (July 2026 feedback). */}
       {!isOwner && (
-        <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="mb-4 flex items-center gap-3">
           <Link
             href="/directory"
             className="inline-flex items-center gap-1.5 text-sm font-medium text-teal-deep transition-colors duration-150 hover:text-ink"
           >
             <span aria-hidden>←</span> Back to the Directory
           </Link>
-          {followSlot}
         </div>
       )}
 
-      {/* Owner action bar — the way into the editor (this is your own profile). */}
+      {/* Owner action bar — back home on the left (July 2026 feedback: the
+          profile's "back" landed people in the directory), the editor on the
+          right. */}
       {isOwner && (
-        <div className="mb-4 flex justify-end">
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-teal-deep transition-colors duration-150 hover:text-ink"
+          >
+            <span aria-hidden>←</span> Back to dashboard
+          </Link>
           <Link href="/profile/edit" className="btn btn-teal px-4 py-2 text-sm">
             Edit profile
           </Link>
@@ -102,7 +110,7 @@ export default function MemberProfileView({
 
       <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card sm:p-8">
         {/* Header with avatar */}
-        <div className="flex items-center gap-6 border-b border-ink/10 pb-6">
+        <div className="flex flex-wrap items-center gap-6 border-b border-ink/10 pb-6">
           {member.avatarUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
@@ -153,6 +161,11 @@ export default function MemberProfileView({
               </div>
             )}
           </div>
+          {/* Follow action + follower count — inside the card, beside the
+              identity block (moved from the context bar, July 2026 feedback). */}
+          {!isOwner && followSlot && (
+            <div className="ml-auto flex-shrink-0">{followSlot}</div>
+          )}
         </div>
 
         {/* Profile sections */}

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import MemberProfileView from "./member-profile-view";
 import UpdatesFeed from "../directory/updates-feed";
+import { metroLabel } from "@/lib/metros-label";
 
 export default async function ProfilePage() {
   const supabase = await createClient();
@@ -52,7 +53,7 @@ export default async function ProfilePage() {
       .select("name, st")
       .eq("slug", participant.metro_slug)
       .maybeSingle();
-    metroName = metro ? [metro.name, metro.st].filter(Boolean).join(", ") : null;
+    metroName = metro ? metroLabel(metro.name, metro.st) : null;
   }
 
   const displayName =

--- a/app/(dashboard)/u/[handle]/page.tsx
+++ b/app/(dashboard)/u/[handle]/page.tsx
@@ -4,6 +4,7 @@ import MemberProfileView from "../../profile/member-profile-view";
 import UpdatesFeed from "../../directory/updates-feed";
 import FollowButton from "@/app/components/follow-button";
 import { isFollowing } from "@/lib/follows/data";
+import { metroLabel } from "@/lib/metros-label";
 
 /**
  * /u/[handle] — a member's public-to-members profile (visitor mode).
@@ -56,7 +57,7 @@ export default async function MemberProfilePage({
       .select("name, st")
       .eq("slug", member.metro_slug)
       .maybeSingle();
-    metroName = metro ? [metro.name, metro.st].filter(Boolean).join(", ") : null;
+    metroName = metro ? metroLabel(metro.name, metro.st) : null;
   }
 
   // Cycle enrollments (membership is visible within the members-only directory).
@@ -110,6 +111,7 @@ export default async function MemberProfilePage({
               type="user"
               id={member.id}
               initialFollowing={followingMember}
+              refreshOnChange
             />
           )}
         </span>

--- a/app/(public)/local-labs/[slug]/page.tsx
+++ b/app/(public)/local-labs/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/app/components/content/teasers";
 import { getEvents, getMetro, getMetros } from "@/lib/content/queries";
 import { publicSession } from "@/lib/auth/public-session";
+import { metroLabel } from "@/lib/metros-label";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import JoinButton from "./join-button";
 import JoinActiveButton from "./join-active-button";
@@ -18,7 +19,7 @@ import PageUpdatesSection from "@/app/(dashboard)/page-updates-section";
    pitch with the live join CTA. */
 
 function labTitle(m: { name: string; st: string | null; slug: string }): string {
-  return m.name + (m.st && m.slug !== "dc" ? `, ${m.st}` : "");
+  return metroLabel(m.name, m.st);
 }
 
 /** Whether the signed-in visitor is already on this metro's waitlist

--- a/app/components/content/teasers.tsx
+++ b/app/components/content/teasers.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 import Orb from "@/app/components/chrome/orb";
 import { fmtDate, cityOf, CONTENT_TYPE_LABEL } from "@/lib/content/format";
+import { metroLabel } from "@/lib/metros-label";
 import type { EventRow, ResourceRow, MetroRow } from "@/lib/content/queries";
 
 /* Teaser cards — every card is the metadata for its real page (owner
@@ -119,8 +120,7 @@ export function LabTeaser({ metro: m }: { metro: MetroRow }) {
           )}
         </div>
         <div className="t-h4" style={{ marginBottom: 4 }}>
-          {m.name}
-          {m.st && m.slug !== "dc" ? `, ${m.st}` : ""}
+          {metroLabel(m.name, m.st)}
         </div>
         <p className="t-small">{sub}</p>
       </div>

--- a/lib/directory/data.ts
+++ b/lib/directory/data.ts
@@ -1,5 +1,6 @@
 import { createServiceClient } from "@/lib/supabase/server";
 import { one } from "@/lib/supabase/embed";
+import { metroLabel } from "@/lib/metros-label";
 import type {
   DirectoryData,
   DirectoryPerson,
@@ -171,7 +172,7 @@ export async function fetchDirectoryData(): Promise<DirectoryData> {
 
   const metroBySlug = new Map<string, string>();
   for (const m of metrosRes.data ?? []) {
-    metroBySlug.set(m.slug, [m.name, m.st].filter(Boolean).join(", "));
+    metroBySlug.set(m.slug, metroLabel(m.name, m.st));
   }
 
   const cycleIdsByParticipant = new Map<number, number[]>();

--- a/lib/metros-label.test.ts
+++ b/lib/metros-label.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { metroLabel } from "./metros-label";
+
+describe("metroLabel", () => {
+  it("joins name and state", () => {
+    expect(metroLabel("Baltimore", "MD")).toBe("Baltimore, MD");
+  });
+
+  it("skips the state when the name already embeds it", () => {
+    expect(metroLabel("Washington, DC", "DC")).toBe("Washington, DC");
+    expect(metroLabel("Washington, DC", "dc")).toBe("Washington, DC");
+  });
+
+  it("handles missing parts", () => {
+    expect(metroLabel("Washington", null)).toBe("Washington");
+    expect(metroLabel("Washington", "")).toBe("Washington");
+    expect(metroLabel(null, "MD")).toBe("MD");
+    expect(metroLabel("", "MD")).toBe("MD");
+    expect(metroLabel(null, null)).toBe("");
+  });
+});

--- a/lib/metros-label.ts
+++ b/lib/metros-label.ts
@@ -1,0 +1,18 @@
+/* Display label for a metro / local lab — pure and client-safe (lib/metros.ts
+   is server-only via its supabase import, so the label helper lives here).
+
+   Some metros store the state inside `name` itself (e.g. name "Washington, DC"
+   with st "DC"); naively joining the two produced "Washington, DC, DC" across
+   the directory, profiles, and the signup funnel (July 2026 feedback). A
+   couple of call sites carried a `slug !== "dc"` band-aid — this replaces
+   both patterns. */
+
+export function metroLabel(
+  name: string | null | undefined,
+  st?: string | null
+): string {
+  const n = (name ?? "").trim();
+  if (!st) return n;
+  if (n.toLowerCase().endsWith(`, ${st.toLowerCase()}`)) return n;
+  return n ? `${n}, ${st}` : st;
+}

--- a/lib/participants/memberships.test.ts
+++ b/lib/participants/memberships.test.ts
@@ -14,6 +14,9 @@ describe("labDisplayName", () => {
     expect(labDisplayName("Washington", null)).toBe("Washington");
     expect(labDisplayName("Washington", "")).toBe("Washington");
   });
+  it("never doubles a state the name already embeds", () => {
+    expect(labDisplayName("Washington, DC", "DC")).toBe("Washington, DC");
+  });
 });
 
 describe("cycleDateRange", () => {

--- a/lib/participants/memberships.ts
+++ b/lib/participants/memberships.ts
@@ -1,5 +1,6 @@
 import { createServiceClient } from "@/lib/supabase/server";
 import { one } from "@/lib/supabase/embed";
+import { metroLabel } from "@/lib/metros-label";
 
 /**
  * The left-rail "pages/groups" aggregator — the LinkedIn-style list of the
@@ -48,9 +49,11 @@ export interface MembershipsContext {
   } | null;
 }
 
-/** "Baltimore, MD" — lab name with its state suffix when present. */
+/** "Baltimore, MD" — lab name with its state suffix when present. Delegates
+    to metroLabel so names that already embed the state (e.g. "Washington, DC")
+    don't double it. */
 export function labDisplayName(name: string, st: string | null): string {
-  return [name, st].filter(Boolean).join(", ");
+  return metroLabel(name, st);
 }
 
 /** A "Mar 2026 – Jun 2026" range for a cycle sublabel; null when no dates. */

--- a/supabase/migrations/00083_handle_desuffix.sql
+++ b/supabase/migrations/00083_handle_desuffix.sql
@@ -1,0 +1,45 @@
+-- 00083_handle_desuffix.sql
+-- Strip numeric suffixes from participant handles whose base form is free.
+--
+-- 00044's backfill numbered duplicate slugs ("alex-2", "alex-3") and its
+-- collision trigger appends the participant id ("alex-1041"). Testers asked
+-- why their profile URL carries a number when no other member shares their
+-- name (July 2026 feedback: "Slug numbers — do we need them?"). Rows whose
+-- suffix-less base is unclaimed get the clean handle; genuine collisions
+-- keep their suffix, and the 00044 trigger still suffixes future collisions.
+--
+-- One row per base wins (lowest id) when several suffixed rows share a base.
+-- Data-only — no DDL, SCHEMA.md unaffected.
+--
+-- ⚠ Changes /u/[handle] URLs for the de-suffixed rows: previously shared
+-- profile links with the numbered form will 404 (no redirect table exists).
+-- Weigh that before applying to prod; dev/test data has no meaningful
+-- shared links.
+--
+-- Idempotent + re-runnable: a de-suffixed handle no longer matches '-\d+$'.
+--
+-- DOWN:
+--   Not reversible in general (the pre-migration suffixes are not recorded).
+--   Restore from backup if the old handles must come back.
+
+WITH candidates AS (
+  SELECT
+    id,
+    regexp_replace(handle, '-\d+$', '') AS base,
+    row_number() OVER (
+      PARTITION BY regexp_replace(handle, '-\d+$', '')
+      ORDER BY id
+    ) AS rn
+  FROM participants
+  WHERE handle ~ '-\d+$'
+)
+UPDATE participants p
+SET handle = c.base
+FROM candidates c
+WHERE p.id = c.id
+  AND c.rn = 1
+  AND c.base <> ''
+  AND NOT EXISTS (
+    SELECT 1 FROM participants q
+    WHERE q.handle = c.base AND q.id <> p.id
+  );


### PR DESCRIPTION
## What

Profile + Directory batch from the July 11 testing feedback: the "Washington, DC, DC" label, save-confirmation placement, profile back navigation, stale follower counts, follow placement, profile prefill from registrations, and numbered profile slugs.

## Changes

- **`metroLabel()`** (new, `lib/metros-label.ts` — pure/client-safe since `lib/metros.ts` is server-only): skips the state suffix when the name already embeds it. Applied at all six raw `[name, st].join(", ")` sites (directory data, memberships, `/u/[handle]`, `/profile`, admin announcements, signup funnel) and replaces the two `slug !== "dc"` band-aids (`local-labs/[slug]`, teasers). `labDisplayName` now delegates. Tests added (`lib/metros-label.test.ts` + a DC case in `memberships.test.ts`).
- **Saved banner** renders at the top of the profile edit form — the post-save scroll parks there, but the confirmation only existed at the bottom.
- **Own profile** gets "← Back to dashboard"; visitor profiles keep the Directory back link.
- **Follow count**: the follow slot (count + button) moved inside the profile card header, and `/u/[handle]` passes `refreshOnChange` so the server-rendered count updates on toggle (pattern from `people-you-may-know.tsx`).
- **Availability prefill**: when a member has no availability chosen, the edit page preselects from their cycle-registration `hours` answer (`cycle_agreements.answers`), mapped ordinally (2–4→2–5, 5–8→5–10, 8+→10+). Editable; persists only on save. Zip/role/work-situation already prefill from `participants`.
- **Migration `00078_handle_desuffix.sql`** (data-only): strips numeric suffixes from handles whose base form is unclaimed (lowest id wins per base); real collisions keep suffixes and the 00044 trigger still guards future ones.

## Verify

- `metroLabel` unit tests cover the DC shape; visual check on directory/profile/funnel lab labels.
- Profile: save → banner visible at scroll position; back link → dashboard; follow toggle updates the count without hard refresh.
- Migration is idempotent (de-suffixed handles no longer match `-\d+$`).

- [x] `npm run lint` passes
- [x] `npm run test` passes (259 — 4 new)
- [x] `npm run build` passes
- [x] `npm run check:migrations` passes (78 unique)

## Database

- [x] Migration added: `supabase/migrations/00078_handle_desuffix.sql` — **data-only** (no DDL, so no SCHEMA.md delta). ⚠ **Maintainer call before prod**: de-suffixing changes `/u/[handle]` URLs for affected rows; previously shared numbered links will 404 (no redirect table). Fine on dev/test data — flag if prod already has circulated profile links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX)_