### PR TITLE
fix(events): agenda skeleton, stable pills, wider search, square gallery

### DIFF
--- a/app/(public)/events/[slug]/gallery.tsx
+++ b/app/(public)/events/[slug]/gallery.tsx
@@ -30,9 +30,9 @@ export default function Gallery({
       >
         {slides.map((g, i) =>
           g === "IMG" ? (
-            <MediaFrame key={i} img={img} />
+            <MediaFrame key={i} img={img} square />
           ) : (
-            <MediaFrame key={i} grad={g} />
+            <MediaFrame key={i} grad={g} square />
           )
         )}
       </div>

--- a/app/(public)/events/page.tsx
+++ b/app/(public)/events/page.tsx
@@ -40,12 +40,28 @@ export default async function EventsPage() {
       {/* ── Browse: the month-grouped agenda island, full-width ── */}
       <section className="section">
         <div className="container">
-          {/* The island reads useSearchParams — Suspense keeps Next happy. */}
-          <Suspense>
+          {/* The island reads useSearchParams — Suspense keeps Next happy.
+              The fallback holds the agenda's rough height so the page doesn't
+              render short and then jump when the island hydrates (July 2026
+              feedback: page "landing at the footer"). */}
+          <Suspense fallback={<AgendaSkeleton />}>
             <EventsAgenda events={events} nowMs={nowMs} syncUrl />
           </Suspense>
         </div>
       </section>
     </>
+  );
+}
+
+function AgendaSkeleton() {
+  return (
+    <div aria-hidden className="animate-pulse">
+      <div className="h-[38px] w-full max-w-xl rounded-card bg-ink/5" />
+      <div className="mt-6 space-y-3">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-28 rounded-card bg-ink/5" />
+        ))}
+      </div>
+    </div>
   );
 }

--- a/app/components/content/events-agenda.tsx
+++ b/app/components/content/events-agenda.tsx
@@ -200,11 +200,14 @@ export default function EventsAgenda({
       {/* One slim toolbar — segmented view toggle, compact search, filter
           chips, kind dropdown, reset — so the cards start near the fold. */}
       <div className="flex flex-wrap items-center gap-2">
+        {/* No live counts in the segment labels — a changing digit resized
+            the pill as filters narrowed the list (July 2026 feedback); the
+            "N of M" readout at the row's end already carries the number. */}
         <div className="seg" role="group" aria-label="Upcoming or past events">
           {(
             [
-              { key: "upcoming", label: "Upcoming", n: filteredUpcoming.length },
-              { key: "past", label: "Past", n: filteredPast.length },
+              { key: "upcoming", label: "Upcoming" },
+              { key: "past", label: "Past" },
             ] as const
           ).map((v) => (
             <button
@@ -214,7 +217,7 @@ export default function EventsAgenda({
               aria-pressed={view === v.key}
               onClick={() => set({ view: v.key })}
             >
-              {v.label} <span className="tabular-nums">{v.n}</span>
+              {v.label}
             </button>
           ))}
         </div>
@@ -224,7 +227,7 @@ export default function EventsAgenda({
           value={qInput}
           onChange={(e) => setQInput(e.target.value)}
           aria-label="Search events"
-          className="h-[38px] w-full rounded-card border border-ink/10 bg-white px-3 text-sm text-ink placeholder:text-meta-soft focus:border-teal focus:outline-none focus:ring-[3px] focus:ring-teal/15 transition-[border-color,box-shadow] duration-150 md:w-60"
+          className="h-[38px] w-full rounded-card border border-ink/10 bg-white px-3 text-sm text-ink placeholder:text-meta-soft focus:border-teal focus:outline-none focus:ring-[3px] focus:ring-teal/15 transition-[border-color,box-shadow] duration-150 md:w-80"
         />
         {LOC_FILTERS.map((f) => {
           const active = loc === f.key;

--- a/app/globals.css
+++ b/app/globals.css
@@ -905,10 +905,12 @@ button:focus-visible {
   }
 
   /* ── gallery (event detail) ── */
-  .gallery { position: relative; }
+  /* Square slides (July 2026 feedback: photos rendered as rectangles);
+     width-capped so a 1:1 hero doesn't tower over the detail column. */
+  .gallery { position: relative; max-width: 640px; }
   .gallery-track { display: flex; overflow-x: auto; scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch; border-radius: var(--r); gap: 0; }
   .gallery-track::-webkit-scrollbar { height: 0; }
-  .gallery-track .media { flex: 0 0 100%; scroll-snap-align: center; aspect-ratio: 16/10; border-radius: var(--r); }
+  .gallery-track .media { flex: 0 0 100%; scroll-snap-align: center; aspect-ratio: 1/1; border-radius: var(--r); }
   .gallery-dots { position: absolute; bottom: 12px; left: 0; right: 0; display: flex; gap: 6px; justify-content: center; pointer-events: none; }
   .gallery-dots i { width: 6px; height: 6px; border-radius: 50%; background: rgba(255, 255, 255, 0.55); transition: all 0.2s; }
   .gallery-dots i.on { background: #fff; width: 18px; border-radius: 3px; }


### PR DESCRIPTION
## What

Events-page items from the July 11 testing feedback: the page "landing at the footer", jumping filter pills, the Upcoming/Past pill length, the small search bar, and rectangular photos.

## Changes

- **Suspense fallback skeleton** for the agenda island: the empty fallback rendered a short page, so restored scroll positions landed at the footer until the island hydrated. The skeleton holds the agenda's rough height.
- **Upcoming/Past segment** drops its live result counts — a 2→1-digit change resized the pill while filtering (the "jumping" report), and dropping them shortens the pill as asked. The `N of M` readout at the toolbar's end still shows the filtered count.
- **Search input** grows from `md:w-60` to `md:w-80`.
- **Detail gallery** slides render **1:1** (`gallery.tsx` passes `square`; `globals.css` `.gallery-track .media` → `aspect-ratio: 1/1`), with the gallery width-capped at 640px so a square hero doesn't tower over the detail column. List thumbnails were already square.

**On load time**: the route is inherently dynamic — the `(public)` layout reads cookies for the auth-aware nav, so page/ISR caching can't apply (and `cacheComponents` isn't enabled). The skeleton addresses the perceived jump; if production still feels slow, the next step is profiling the events query and lambda cold starts with real data, which this workspace (no DB env) can't do.

## Verify

- Events page: no scroll jump on load with a restored scroll position; pills keep their width while typing in search; gallery slides square on the detail page.

- [x] `npm run lint` passes
- [x] `npm run test` passes (255)
- [x] `npm run build` passes

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX)_