### PR TITLE
docs(requirements): redesign specs + sequenced implementation plan

### DIFF
--- a/docs/requirements/cycle-timeline.md
+++ b/docs/requirements/cycle-timeline.md
@@ -1,0 +1,444 @@
+# Requirements — Cycle Timeline & Scheduling
+
+| | |
+|---|---|
+| **Status** | Draft — for review |
+| **Author** | (you) |
+| **Last updated** | 2026-06-17 |
+| **Related code** | `cycles` + `cycle_config` (00001), `00006_add_cycle_phases`, `app/api/cycles/[cycle_id]/advance-phase/route.ts`, `lib/auth/windows.ts`, `app/api/cycles/[cycle_id]/config/route.ts` |
+| **Related docs** | [`pod-registration.md`](./pod-registration.md) (its forming/active windows become phases here), `docs/OLOS-architecture-brief.md` (phase machine) |
+
+## Overview
+
+Cycle scheduling is being made **first-class**. Today the timeline is a loose
+bag of independent timestamps; this redesign makes a cycle own an **ordered,
+validated, timezone-aware schedule** from which every phase window — including
+pod forming/active — is **derived**.
+
+## Current state (as-is) — why this is needed
+
+Three disconnected notions of time exist, with no relationship between them:
+
+1. **Cycle envelope** — `cycles.start_date`/`end_date` (`TIMESTAMP NOT NULL`).
+   Set at creation and **never read by any logic**. Decorative.
+2. **Phase windows** — twelve `cycle_config.*_open/*_close` `TIMESTAMP` columns
+   (problem_statement, voting, pod_registration, solution_proposal,
+   solution_voting, project_registration). The real timeline. Set by admin PATCH
+   or by `advance-phase`, which hardcodes a **24-hour** window per phase.
+3. **Hardcoded offsets in code** — 7-day pulse enforcement, 30-day invite TTL,
+   3/1/0-day reminders, the 24h phase duration.
+
+Problems: windows have **no link to the cycle envelope**, **no validation**
+(`open<close`, ordering, overlap, within-cycle all unchecked), are **manual-only
+to advance**, use **naive `TIMESTAMP`** (implicit UTC → an admin entering DC-local
+times is off by ~5 hours), and adding a phase means adding **columns**. The
+deprecated `phase_2_start`/`phase_3_start` (00006) linger unused.
+
+## Goals
+
+- A cycle has **one schedule**; phases are ordered segments of it.
+- Phase windows are **derived** from a cycle start + per-phase durations — change
+  the start, the whole schedule shifts; **spine** phases can't overlap or go out
+  of order by construction (overlay windows like pod active-join anchor
+  independently and may overlap — see Target model).
+- **Timezone-aware:** "midnight" means local midnight in the cycle's timezone.
+- Adding a phase (e.g. pod forming/active) is **data, not schema**.
+
+## Non-goals
+
+- Reworking pulse-check cadence / invite TTL into config (related; D-5).
+- Migrating *every* lifecycle timestamp (created_at, joined_at, …) to
+  `timestamptz` — only the scheduling/anchor fields are in scope (D-6).
+
+## Target model
+
+### Anchor + timezone
+
+- `cycles.start_at TIMESTAMPTZ` — the schedule anchor.
+- **`labs.timezone TEXT`** — IANA zone (e.g. `America/New_York`), default DC's
+  zone. **Timezone is a lab property** (D-4); a cycle uses its lab's zone.
+  Wall-clock inputs ("close at 23:59") are interpreted in it and stored as
+  `timestamptz` instants; display converts back.
+- `cycles.end_at` becomes **derived** (anchor + sum of phase durations), not a
+  free field.
+
+### Phases as rows (`cycle_phases`)
+
+Replace the twelve `cycle_config` window columns with:
+
+    cycle_phases(
+      id, cycle_id FK,
+      phase_key,        -- 'problem_statement' | 'voting' | 'pod_forming'
+                        --  | 'pod_active_join' | 'solution_proposal'
+                        --  | 'solution_voting' | 'project_registration'
+      kind,             -- 'spine' (sequential) | 'overlay' (independent)
+      position SMALLINT,-- order, for spine phases
+      anchor,           -- what it's relative to (cycle start, or an event)
+      duration INTERVAL,-- how long this phase runs
+      starts_at TIMESTAMPTZ,  -- computed
+      ends_at   TIMESTAMPTZ,  -- computed
+      UNIQUE(cycle_id, phase_key)
+    )
+
+- **Spine phases** (`problem_statement`, `voting`, `pod_forming`,
+  `project_proposal`, `project_voting`, `project_registration`) chain
+  contiguously: `starts_at = prev.ends_at` (first = anchor); ordered and
+  non-overlapping **by construction**.
+- **Overlay windows** (`pod_active_join`, and the always-on pulse track) anchor
+  **independently** (to an event ± offset) and **may overlap** the spine — e.g.
+  in Cycle 3 pod active-join (Aug 11→25) deliberately spans the entire project
+  stage. Overlaps are allowed *for overlays*, not within the spine.
+- `starts_at`/`ends_at` are stored (cached) and recomputed when the anchor,
+  any duration, or a referenced event date changes.
+- A window is "open" iff `now ∈ [starts_at, ends_at)` — `lib/auth/windows.ts`
+  reads `cycle_phases` instead of `cycle_config` columns.
+- **Pod forming/active** are two phase rows — `pod_forming` (spine) and
+  `pod_active_join` (overlay) — replacing the old `pod_registration`. This is the
+  reconciliation with [`pod-registration.md`](./pod-registration.md).
+
+### Two tracks: events vs. software actions
+
+A cycle timeline has **two independent tracks** that share the calendar:
+
+1. **Events** — community gatherings (Problem Sprint, Meet the Pods, Hackathon,
+   Meet the Projects, Summit). **Pinned** to fixed, venue-bound dates that do not
+   slide. Stored in `cycle_events`.
+2. **Software actions** — the in-app windows where participants *act*: voting,
+   registration (incl. pod forming/active-join), and submissions. These are the
+   `cycle_phases`, derived by duration.
+
+They interleave but are **not** one sequence — an event does not gate a software
+action and vice-versa. (This resolves the earlier ordering confusion: the
+Problem Sprint being after "pods formed" is fine because they're different
+tracks.)
+
+### Milestones / pinned events
+
+Because events are fixed and software-action windows are derived, the timeline is
+a **hybrid**: pinned event dates, with action windows filling the gaps.
+
+    cycle_events(
+      id, cycle_id FK,
+      key,            -- 'problem_sprint' | 'meet_the_pods' | 'hackathon'
+                      --  | 'meet_the_projects' | 'summit' | …
+      label, occurs_at TIMESTAMPTZ,   -- pinned absolute instant (cycle tz)
+      UNIQUE(cycle_id, key)
+    )
+
+- A phase boundary may be **pinned to a milestone** (e.g. `pod_forming` closes at
+  the "pods formed" date) or **derived** by duration. Pinned beats derived; the
+  schedule service computes the rest around the pins and validates they stay
+  ordered/contiguous.
+- Events are point-in-time markers; they don't gate app windows by themselves
+  (a phase does that), but they anchor the schedule and drive comms/UI.
+
+### Always-on tracks
+
+Pulse checks run the whole cycle (no phase segment) — represented as spanning
+`start_at`→`end_at`, not a `cycle_phases` row. Their cadence/enforcement stays as
+today unless D-5 moves it to config.
+
+### Advancement
+
+Phases are **time-driven** (the clock opens/closes them via `starts_at`/`ends_at`)
+— no admin click required to advance. `advance-phase` becomes an **override**:
+"close current early / extend / shorten," which adjusts a duration and
+**recomputes downstream** phases. The hardcoded 24h default is removed; each
+phase has its own default duration.
+
+## Cycle template — relative schedule (applies to any cycle)
+
+The Cycle-3 dates (Appendix) are **one instance** of a reusable template. A cycle
+is instantiated from a **start** date (a Tuesday) + **timezone** + the **event**
+dates; every software-action window is then **derived** relative to an event.
+Deadlines snap to a weekday ("the Tuesday following …"). Observed shape: a
+**13-week, Tuesday-anchored** cycle; weekly deadlines on **Tuesdays**, the
+project-registration deadline on a **Friday**.
+
+Two relative layers:
+- **Events** are offsets from **cycle start** — but carry only *defaults*; each
+  is **per-cycle overridable** (venues book independently).
+- **Software-action windows** are offsets from their **anchor event** — so if an
+  event date shifts, its windows follow it.
+
+### Anchors
+
+| Anchor | Relative rule (default) | Cycle 3 |
+|---|---|---|
+| Cycle **start** | input — a Tuesday + timezone | Tue Jul 14, America/New_York |
+| **Problem Sprint** (event) | start + 11 days (Sat, wk 2) | Sat Jul 25 |
+| **Meet the Pods** (event) | start + 4 weeks (Tue) | Tue Aug 11 |
+| **Hackathon** (event) | start + 30 days (Thu, wk 5) | Thu Aug 13 |
+| **Meet the Projects** (event) | start + 8 weeks (Tue) | Tue Sep 8 |
+| **Summit** (event) = cycle **end** | start + 13 weeks (Tue) | Tue Oct 13 |
+
+### Software-action windows (relative to anchor event)
+
+| Window | Opens | Closes |
+|---|---|---|
+| Problem statement | Sprint, 9:00am | Sprint, 12:00pm |
+| Pod voting | Sprint, 12:00pm | Sprint, 1:00pm |
+| Pod registration (forming) | Sprint, 1:00pm | **Tuesday after Sprint**, midnight |
+| Pod active-join | Meet the Pods, 12:00am | = Project registration close |
+| Project proposal | Hackathon (Thu) | **Tuesday after Hackathon** |
+| Project voting | Tuesday after Hackathon | **Thursday after Hackathon** |
+| Project registration | Thursday after Hackathon | **2nd Tuesday after Hackathon** |
+
+"**\<Weekday\> after X**" = the first such weekday strictly after X. The project
+stage is a contiguous Thu→Tue→Thu→Tue chain off the Hackathon: proposal
+Hackathon→next Tue; voting that Tue→that Thu; registration that Thu→the following
+Tue. (Supersedes the earlier rough "voting til Tue / registration til Fri.")
+
+### Mapping to the schema
+
+- `cycles.start_at` + `labs.timezone` (via the cycle's lab) — the anchor.
+- `cycle_events` rows — events: relative default + optional per-cycle override.
+- `cycle_phases` rows — software-action windows, each storing its **anchor event
+  + offset + time-of-day (+ weekday-snap)** rule; instantiating a cycle computes
+  every `starts_at`/`ends_at` from these.
+
+## Functional requirements
+
+- **FR-1** Add `cycles.start_at TIMESTAMPTZ`; `end_at` derived. **Timezone lives
+  on the lab** (`labs.timezone TEXT`, default `America/New_York`); a cycle uses
+  its lab's timezone (D-4). All scheduling math/display uses it.
+- **FR-2** Create `cycle_phases` (shape above); seed the default phase sequence
+  with default durations on cycle creation.
+- **FR-3** A schedule service computes/stores `starts_at`/`ends_at` for all
+  phases from the anchor + durations; recomputes on any change.
+- **FR-4** `lib/auth/windows.ts#checkWindow` reads `cycle_phases.starts_at/ends_at`
+  (timezone-aware) instead of `cycle_config.*_open/close`.
+- **FR-5** `advance-phase` becomes a duration-override/recompute action; remove
+  the 24h hardcode.
+- **FR-6** Validation: editing a duration or anchor keeps the **spine** ordered
+  and contiguous automatically; overlay windows (pod active-join, pulse) anchor
+  independently and may overlap the spine. Any explicit boundary override (D-2)
+  must keep `start<end` and stay within the cycle.
+- **FR-7** Admin schedule UI shows the derived timeline (phase → computed
+  start/end in the cycle's tz) and edits durations/anchor, not raw timestamps.
+
+## Schema & migration
+
+- Add `cycles.start_at` (backfill from `start_date`) and `labs.timezone`
+  (default `America/New_York`; cycles read it via their lab).
+- Create `cycle_phases`; migrate the twelve `cycle_config.*_open/close` values
+  into rows (derive each `duration` from the old open/close span; set `position`
+  by `PHASE_SEQUENCE`), splitting old `pod_registration` into `pod_forming` +
+  `pod_active_join`.
+- **Convert all ~49 lifecycle `TIMESTAMP` columns to `timestamptz`** (audit found
+  ~49, not ~40). **The interpretation is PER-COLUMN, not one blanket zone (revised
+  on stress-test):**
+  - **Audit columns** (`created_at`, `updated_at`, `granted_at`, `joined_at`, …) were
+    written by `CURRENT_TIMESTAMP` in a **UTC** session → convert as **UTC**
+    (`USING col AT TIME ZONE 'UTC'`). Reinterpreting these as Eastern would shift
+    ~38 columns by +4-5h — **data corruption.**
+  - **Scheduling columns** (the 12 `cycle_config.*_open/close`) are *candidates* for
+    Eastern, but that depends on how the write path stored them (an admin PATCH that
+    used `.toISOString()` already stored UTC wall-clock). **Verify against real prod
+    values before choosing the zone per column.** This is the one irreversible data
+    step — dry-run on a prod clone.
+- Drop `phase_2_start` / `phase_3_start` and the `cycle_config.*_open/close`
+  columns once `cycle_phases` is live.
+
+## Date-reference audit — are we linking them all?
+
+Every date reference in the codebase, classified by how it relates to the new
+timeline. **L** = links to the cycle timeline (must read the new model);
+**R** = replaced by it; **I** = independent track (intentionally *not* the
+cycle schedule); **A** = audit/event record (not schedule, tz-cleanup only).
+
+### Schedule (R — replaced by `cycle_phases` / `cycle_events`)
+| Reference | Location | Disposition |
+|---|---|---|
+| `cycles.start_date` / `end_date` | `00001`; UI `cycles/page.tsx`, `[cycle_id]/page.tsx`, `cycle-phase-indicator.tsx` | → `start_at` (anchor) + derived `end_at` + `timezone` |
+| `cycle_config.*_open/_close` (12 cols) | `00001` | → `cycle_phases` rows |
+| `cycle_config.phase_2_start/phase_3_start` | `00006` | → dropped (already dead) |
+| `advance-phase` (PHASE_SEQUENCE, 24h hardcode, now-logic) | `app/api/cycles/[cycle_id]/advance-phase/route.ts` | → compute from `cycle_phases`; advance = override+recompute |
+| `updateCycleConfigSchema`, `createCycleSchema` | `lib/validations/cycles.ts` | → schedule/template validation |
+
+### Window checks (L — THE risk: same logic re-implemented across 12 files)
+The `now >= new Date(config.X_open) && now <= new Date(config.X_close)` pattern
+is duplicated, each reading `cycle_config` columns directly with browser-local
+`new Date()`. **Stress-test correction: it's 12 files, not ~9 — and the canonical
+`checkWindow` is called by only the 6 API routes; all the UI pages re-derive it
+inline and never call the resolver.** So FR-11 is "introduce server-side window
+resolution into 12 UI pages," not "point 9 callers at one helper."
+
+| File | Window |
+|---|---|
+| `lib/auth/windows.ts` `checkWindow` (server, canonical) | all (the one to keep + extend) |
+| `(dashboard)/cycles/[cycle_id]/propose/page.tsx` | problem_statement |
+| `(dashboard)/cycles/[cycle_id]/vote/page.tsx` | voting |
+| `(dashboard)/cycles/[cycle_id]/register-pods/page.tsx` | pod_registration |
+| `(dashboard)/cycles/[cycle_id]/register-projects/page.tsx` | project_registration |
+| `(dashboard)/cycles/[cycle_id]/solutions/page.tsx` (+ `DAY_MS` tab/banner offsets) | solution_proposal |
+| `(dashboard)/cycles/[cycle_id]/solution-vote/page.tsx` | solution_voting |
+| `(dashboard)/cycles/[cycle_id]/page.tsx`, `cycle-phase-indicator.tsx` | all (loop + progress bar) |
+| `app/api/registrations/short/route.ts` | pod_registration |
+| `(dashboard)/dashboard/page.tsx` | *(missed in first audit)* |
+| `(dashboard)/moderator/cycles/[cycle_id]/vote-progress/page.tsx` | *(missed in first audit)* |
+| `(dashboard)/admin/cycles/[cycle_id]/testing-controls.tsx` | *(missed; uses `>` not `>=` on close — **bound bug**, fix during consolidation)* |
+
+All must resolve windows through **one** tz-aware helper backed by `cycle_phases`
+— not re-derive from columns. `windows.ts` `WindowField` must also gain the new
+keys (`pod_forming`, `pod_active_join`, `project_proposal`) and update
+`WINDOW_MESSAGES`.
+
+### Independent tracks (I — NOT the cycle schedule; confirm they stay separate)
+| Reference | Location | Note |
+|---|---|---|
+| 7-day pulse enforcement (`SEVEN_DAYS_MS`), baseline `last_pulse_completed_at ?? created_at` | `cron/revocation-check`, `pulse-checks/enforcement`, `(dashboard)/layout.tsx`, `pulse-check/page.tsx` | rolling per-participant, not cycle-relative (D-8) |
+| 3/1/0-day pulse reminders | `cron/pulse-check-reminder` | tied to the 7-day deadline, not the cycle |
+| Invite 30-day TTL (`expires_at` default + checks) | `00009`; `auth/callback`, `invitations` routes | per-invite, not cycle schedule |
+| Cron schedules `0 9 * * *` / `0 10 * * *` (UTC) | `vercel.json` | → fire at **7am cycle-local** (decided, FR-15); UTC-only cron ⇒ pin equiv or gate hourly (DST) |
+| `pulse_checks.scheduled_date` (DATE) | `00001` | day-level dedup key; "today" should be cycle-tz (minor) |
+
+### Audit/event timestamps (A — not schedule; tz-cleanup only, D-6)
+`created_at`, `updated_at`, `enrolled_at`, `inactive_date`, `granted_at`/
+`revoked_at`, `accepted_at`, `assigned_at`/`removed_at`, `joined_at`/`inactive_at`,
+`registered_at`/`left_at`, `completed_at`, `last_pulse_completed_at`,
+`access_revocations.revoked_at`, `invitations.email_sent_at` (already `timestamptz`).
+These record *when something happened* — they don't link to the timeline; only
+the optional `timestamptz` consistency cleanup (D-6) applies.
+
+### Added functional requirements
+
+- **FR-11 (single window resolver)** Route **all** window checks — the **12 files**
+  above — through one tz-aware helper backed by `cycle_phases`. The UI pages don't
+  currently call `checkWindow` at all, so this is a real refactor of each page (move
+  resolution server-side), not a one-line swap. Delete the inline
+  `now >= open && now <= close` re-implementations and the per-file `DAY_MS`
+  offsets (derive affordance windows from phase boundaries), and fix the `>` vs `>=`
+  bound bug in `testing-controls.tsx`.
+- **FR-12 (phase keys)** Extend `windows.ts` `WindowField` + `WINDOW_MESSAGES`
+  to the new phase set (`pod_forming`, `pod_active_join`, `project_proposal`,
+  …); it is the single enumeration of windows.
+- **FR-13 (validation)** Replace `cycles.ts` config/window validation with
+  schedule-template validation (anchor + event dates + durations).
+- **FR-14 (display tz)** UI date formatting (`toLocaleDateString` etc.) renders
+  in the **cycle's** timezone **and shows the tz label** — e.g.
+  "Aug 13, 2026, 12:00 PM EDT", not the browser's local time.
+- **FR-15 (cron tz)** Participant-facing crons (pulse reminders,
+  revocation/participant-issue checks) fire at **7:00 AM cycle-local**. Vercel
+  cron is UTC-only, so either pin the UTC equivalent (11:00 UTC EDT / 12:00 UTC
+  EST — **DST caveat**) or run hourly and gate to the cycle's 07:00.
+
+## Acceptance criteria
+
+- Changing `cycles.start_at` shifts every phase boundary; phases stay ordered
+  and contiguous with no manual edits.
+- A window opens/closes by the clock at its computed boundary in the cycle's
+  timezone (a 23:59 close in `America/New_York` closes at local 23:59, not UTC).
+- Pod forming and pod active-join are two phases in the timeline; the
+  pod-registration flow reads them like any other window.
+- It is impossible to save **spine** phases that overlap or go out of order;
+  **overlay** windows (pod active-join, pulse) may overlap the spine by design
+  (e.g. pod active-join spans the project stage).
+
+## Decisions log
+
+- **2026-06-17** — Timeline is **cycle-relative / derived**: anchor +
+  per-phase durations; spine windows computed/ordered/contiguous, overlay
+  windows (pod active-join, pulse) anchored independently and may overlap.
+- **2026-06-17** — **Timezone-aware**; timezone is a **lab** property
+  (`labs.timezone`, default DC); cycles use their lab's zone. All timestamps
+  stored `timestamptz`.
+- **2026-06-17** — Phases are **rows** (`cycle_phases`), not columns; adding a
+  phase is data. Pod forming/active are two such rows.
+- **2026-06-17** — Hybrid timeline: **pinned milestones** (`cycle_events`,
+  absolute dates that don't slide) + **derived phases** filling the gaps between
+  them. Refines the pure-derived decision after real Cycle-3 dates showed
+  several fixed, venue-bound events.
+- **2026-06-17** — Dates are displayed **in the cycle's timezone with the tz
+  label shown** (FR-14).
+- **2026-06-17 (resolves D-9)** — Participant-facing crons fire at **7:00 AM
+  cycle-local** (FR-15).
+- **2026-06-17** — The schedule is a **reusable relative template**: events are
+  offsets from cycle **start** (overridable per cycle); software-action windows
+  are offsets from their **anchor event** with weekday-snap deadlines. Cycle 3
+  is the first instance. Observed shape: 13-week, Tuesday-anchored.
+- **2026-06-17 (resolves D-7)** — The timeline is **two independent tracks**:
+  **events** (community gatherings, pinned) and **software actions** (in-app
+  voting/registration/submission windows = `cycle_phases`, derived). They
+  interleave but neither gates the other; an event's calendar position need not
+  match the app's action order.
+
+## Open decisions
+
+*All resolved 2026-06-17 (decision sweep):*
+
+- **D-1 → Adopt Cycle 3's durations** as the template defaults.
+- **D-2 → Yes**, optional per-phase absolute pin allowed (default derived).
+- **D-3 → PER-COLUMN (revised on stress-test).** *Audit* columns convert as **UTC**
+  (`CURRENT_TIMESTAMP`-origin); only *scheduling* columns are Eastern candidates, and
+  only after verifying real values. (Was: "all Eastern" — that corrupts ~38 UTC
+  audit columns.)
+- **D-4 → Lab-level** timezone (`labs.timezone`); cycles use their lab's zone.
+- **D-5 → Keep as code constants** (pulse/invite/reminder offsets).
+- **D-6 → Convert *all* lifecycle `TIMESTAMP` → `timestamptz`** now (one pass).
+- **D-8 → Keep pulse/invite tracks independent** of the cycle timeline.
+
+## Appendix — Cycle 3 initial scaffold (2026)
+
+Seed dates to build the timeline against. **All times America/New_York; year
+2026.** Two tracks (see model): events are pinned; software-action windows are
+mostly TBD.
+
+**Envelope**
+- ✓ Cycle 3 **start** — Jul 14 (Cycle 2 ends)
+- ✓ Cycle 3 **end** — Oct 13 (= Summit)
+
+**Events track (pinned, defined)**
+
+| Date | Event |
+|---|---|
+| Jul 25 | Problem Sprint *(new)* |
+| Aug 11 | Meet the Pods |
+| Aug 13 | Hackathon |
+| Sep 8 | Meet the Projects |
+| Oct 13 | Summit |
+
+**Software-action windows track (`cycle_phases`)**
+
+Windows anchor to events — some **pinned** to an event date, some **computed
+relative** to one (e.g. "the Tuesday following"). Possible weekly-Tuesday
+deadline cadence (confirm).
+
+The **submission → voting → registration** chain repeats twice: compressed into
+the sprint day (pod stage) and spread over a week (project stage). Both are
+contiguous (each window opens when the prior closes). Deadlines land on
+**Tuesdays and Fridays** (possible cadence convention). Hour-level precision ⇒
+scheduling is `timestamptz` (Eastern). Weekdays: Hackathon Aug 13 = Thu;
+"Tuesday" = Aug 18; "Friday" = Aug 21. "Midnight on the 28th" read as end-of-day.
+
+**Pod stage (sprint day, Jul 25)**
+
+| Window | Open → Close |
+|---|---|
+| Problem statement (submission) | ✓ **Jul 25 9:00am → 12:00pm** |
+| Voting (problem statements) | ✓ **Jul 25 12:00pm → 1:00pm** |
+| Pod forming (registration) | ✓ **Jul 25 1:00pm → Jul 28 midnight** |
+
+**Project stage (week of the Hackathon)**
+
+Terminology: a **project proposal** is the schema's `solution_proposals` row;
+voting is `project_votes`; project registration is `project_memberships`.
+
+| Window | Open → Close |
+|---|---|
+| Project proposal (submission; `solution_proposals`) | ✓ **Aug 13** (Thu, Hackathon) → **Aug 18** (Tue) |
+| Voting (`project_votes`) | ✓ **Aug 18** (Tue) → **Aug 20** (Thu) |
+| Project registration (`project_memberships`) | ✓ **Aug 20** (Thu) → **Aug 25** (Tue, next week) |
+
+**Pod active-join window**
+
+| Window | Open → Close |
+|---|---|
+| Pod active-join | ✓ **Aug 11 (Meet the Pods) → Aug 25 (project registration close)** |
+
+Note: nothing happens between cycle start (Jul 14) and the Problem Sprint
+(Jul 25) on the software-action track yet — confirm whether that gap holds
+onboarding or another action.
+
+**Fully specified.** Project-stage transitions (Aug 18 / 20 / 25) are at
+**midnight** (decided). Cycle 3 is complete end to end.

--- a/docs/requirements/implementation-plan.md
+++ b/docs/requirements/implementation-plan.md
@@ -1,0 +1,199 @@
+# OLOS Redesign — Sequenced Implementation Plan (post-stress-test)
+
+## Context
+
+Five requirements docs (`docs/requirements/`) designed four interlocking changes —
+**local-labs**, **permissions-redesign**, **pod-registration**, **cycle-timeline**
+(plus a deferred **per-lab-configuration**). Nothing is implemented. This plan turns
+the set into a sequenced build **after stress-testing the docs against the actual code**
+(three code audits run this session). The stress test found several places where the
+docs are internally contradictory, undercount scope, or rely on mechanisms that don't
+behave as assumed; those fixes are baked into the phases below.
+
+### Locked decisions (this session)
+- **DB strategy: hybrid.** Build/test against a reset **dev** DB; apply to **prod as
+  forward-only migrations *with* backfill** (no prod reset). Backfill code is real.
+  → The "ship against a reset DB" wording in all docs must be corrected to this.
+- **Rollout: phased PRs**, in dependency order (below), not one big-bang PR.
+- **RLS: coarse.** DB policies enforce "are you an admin at all / is this row yours";
+  **scope (lab/cycle) is enforced in the app seam** (`isAdminOf`), per AC-1. No per-cycle/
+  per-lab RLS predicate rewrite.
+- **Observer → super admin** on backfill (author's call). Residual risk accepted; the D-4
+  audit is the safeguard (see Phase 4). *Only fires if prod actually has observer rows.*
+- **Test scaffolding: yes** — seed the three highest-risk seams (auth scope, window
+  resolver, tz conversion). No test infra exists today.
+
+### Corrected dependency order (the docs' stated order was wrong)
+`labs` → `timeline` → `pod-registration` → `auth`.
+Rationale: pod-registration's two windows **are** `cycle_phases` rows, and the rewritten
+revocation cron needs the `pod_forming`/`pod_active_join` boundaries — both depend on
+**timeline**, which the docs had sequenced *after* pod-registration.
+
+---
+
+## Phase 0 — Doc corrections + test scaffold (do first)
+
+**Doc corrections** (the contradictions found; fix before building from them):
+- Replace "ship against a reset DB" with the hybrid statement in all four active docs.
+- cycle-timeline D-3: change "interpret **all** naive timestamps as Eastern" to a
+  **per-column rule** — `CURRENT_TIMESTAMP`-origin audit columns are **UTC**; only
+  admin-entered scheduling columns are candidates for Eastern, and that must be verified
+  against real values. (A blanket Eastern reinterpretation shifts ~38 audit columns by
+  +4-5h.)
+- cycle-timeline FR-11: window-check list is **12 files, not 9**, and the UI pages don't
+  call `checkWindow` at all — add `dashboard/page.tsx`,
+  `moderator/cycles/[cycle_id]/vote-progress/page.tsx`,
+  `admin/cycles/[cycle_id]/testing-controls.tsx` (latter uses `>` vs `>=` — fix the bound).
+- pod-registration D-2/D-6: document the cron rewrite + activation-trigger + the
+  orphan-window fix (see Phase 3) — "ties to the existing cron" understates it.
+- Fix duplicate migration number `00015` going forward (new migrations start at `00020`).
+
+**Test scaffold** (lightweight; e.g. Vitest + a seeded local Supabase):
+- Auth seam: `isAdminOf({cycleId,labId})` / `isSuperAdmin` scope cases (own vs foreign).
+- Window resolver: one tz-aware resolver — DST boundary, inclusive/exclusive bounds, null.
+- tz conversion: assert a known Eastern scheduling instant and a known UTC audit instant
+  both round-trip correctly after the column-type change.
+
+---
+
+## Phase 1 — Local Labs (foundation)
+
+Per `local-labs.md`. New migration (`00020_labs`):
+- `labs(id, name, slug UK, status, timezone DEFAULT 'America/New_York', created_at)`;
+  insert **DC** (id 1).
+- `cycles.lab_id` + `participants.lab_id`: add nullable → backfill all rows to DC →
+  set `NOT NULL` (default DC). **(prod: backfill; dev: seed.)**
+- App-level lab-scoping helper (single shared predicate) mirroring the authz seam —
+  not RLS. Add `labId` to the resolved user shape (`participants.lab_id`).
+
+Critical files: `supabase/migrations/`, `lib/auth/roles.ts` (surface `labId`), the new
+shared lab-scope query helper.
+Verify: insert throwaway "Lab 2" + cycle/participant; confirm lab-scoped queries separate it.
+
+---
+
+## Phase 2 — Cycle Timeline (cycle_phases + tz)
+
+Per `cycle-timeline.md`. `cycle_phases` does **not** exist today (00006 only added two dead
+columns `phase_2_start/phase_3_start` — leave or drop them). Clean create.
+
+- New table `cycle_phases(cycle_id, phase_key, kind['spine'|'overlay'], position, anchor,
+  duration, starts_at, ends_at, UNIQUE(cycle_id,phase_key))`; `cycle_events(...)` for pinned
+  venue-bound dates. Add `cycles.start_at TIMESTAMPTZ`; `end_at` derived.
+- **Schedule service**: computes `starts_at/ends_at` from anchor + durations (spine
+  contiguous by construction; overlays anchor independently); recompute on change.
+- **Single window resolver**: extend `lib/auth/windows.ts#checkWindow` to read
+  `cycle_phases` (tz-aware), add keys `pod_forming`/`pod_active_join`/`project_proposal`,
+  update `WINDOW_MESSAGES`. **Route all 12 UI pages + 6 API routes through it** — delete the
+  inline `now >= open && now <= close` re-derivations and per-file `DAY_MS` offsets.
+- **`advance-phase`** → duration-override + recompute; remove the 24h hardcode
+  (`advance-phase/route.ts:98`).
+- **tz conversion (per-column, verified)**: convert scheduling columns interpreting
+  admin-entered values; convert audit columns as UTC. Do **not** blanket-reinterpret.
+- **Display**: render in cycle tz **with label** (FR-14); crons fire **7am cycle-local**
+  (FR-15) — gate the existing UTC `vercel.json` crons to cycle-local, mind DST.
+- Migrate the 12 `cycle_config.*_open/close` values → phase rows (derive each duration),
+  **splitting `pod_registration` → `pod_forming` + `pod_active_join`**; then drop the columns.
+  Keep the thresholds in `cycle_config` (`pod_min`, `max_pods`, …).
+
+Critical files: `lib/auth/windows.ts`, `advance-phase/route.ts`, the 12 window UI files,
+`lib/validations/cycles.ts`, `vercel.json`, new schedule service.
+Verify: changing `start_at` shifts all boundaries; 23:59 close in Eastern closes at local
+23:59 across a DST date; spine can't be saved overlapping; overlays may overlap.
+
+---
+
+## Phase 3 — Pod Registration (the highest-risk behavioral change)
+
+Per `pod-registration.md`, but with the cron/activation fixes the doc omits.
+
+- `register/route.ts`: check the window **matching pod status** (`forming`→`pod_forming`,
+  `active`→`pod_active_join`, `inactive`→refuse). **Remove the `cycle_enrollments`
+  activation side effect** (`register/route.ts:99-124`). Keep the hardcoded 2-pod cap
+  (already enforced at `:55-67`) — optionally move to `cycle_config`.
+- **forming→active becomes a phase-boundary event** at `pod_forming` close: pods ≥ `pod_min`
+  → active; the rest → `inactive` (dissolution — **net-new code**, none exists today).
+- **NEW: replacement activation trigger** (the doc's gap). Since pod-join no longer flips
+  enrollment, define cycle-active explicitly: **enroll into an open cycle ⇒
+  `cycle_enrollments.status='active'`** (set it at `interest`/`registrations`/`short` time
+  instead of `inactive`). Pre-pod active = enrolled; post-pod active = in a pod.
+- **NEW: rewrite the revocation cron** (`cron/revocation-check/route.ts`) to be
+  **phase-gated**. Today it runs unconditionally and only spares pre-pod users because they
+  happen to be `inactive` — decoupling removes that accident. Apply the "in no pods → revoke"
+  rule **only after `pod_active_join.ends_at`** (read from `cycle_phases`), *not* at
+  `pod_forming` close. This single change also **closes the orphan dead-zone**: orphans freed
+  at forming-close (D-6) have until active-join close to land somewhere before any revocation;
+  no "freed but revoked next morning" contradiction. The pulse-check rule stays as-is.
+- **Orphan handling**: on dissolution, free members (no silent limbo) + notify (D-6) —
+  notification is net-new (no mechanism exists).
+- Decide revoked-rejoin: a participant revoked earlier should be reactivatable if they join
+  during active-join (don't leave them stranded).
+
+Critical files: `app/api/pods/[pod_id]/register/route.ts`,
+`app/api/cron/revocation-check/route.ts` (+ `revocations/check/[cycle_id]`),
+`app/api/cycles/[cycle_id]/interest/route.ts`, `app/api/registrations/route.ts`,
+`app/api/registrations/short/route.ts`, `app/api/voting/finalize/[cycle_id]/route.ts`
+(seeds forming pods), `register-pods/page.tsx`.
+Note the **project-layer asymmetry**: `projects/[id]/register` never touched enrollment and
+requires active pod membership; with active-join overlapping project registration (both close
+Aug 25), a last-day pod-joiner can immediately register a project — confirm that's acceptable.
+Verify: join forming in forming window only; active in active window only; join/leave never
+changes enrollment status directly; sub-`pod_min` pod dissolves and members are freed +
+notified; pod-less enrollee not revoked until after active-join close.
+
+---
+
+## Phase 4 — Auth / Permissions (largest surface; lands last)
+
+Per `permissions-redesign.md`. Reality from the audit: **dual-track today**
+(`user_roles` *and* `participant_permissions`, plus synthetic moderator/participant), **61
+RLS policies**, ~**66 call sites across ~27 files**, and `is_admin_or_owner()` was redefined
+in 00009 to mean `has_permission('cycles:write')`.
+
+- New `role_assignments(participant_id, role, scope_type['global'|'lab'|'cycle'], scope_id,
+  granted_by, granted_at, revoked_at, UNIQUE … NULLS NOT DISTINCT)`. Admin tiers only;
+  moderator/memberships stay in their own tables.
+- New seam (`lib/auth/`): `isSuperAdmin` / `isAdminOf({labId}|{cycleId,labId})` /
+  `isModeratorOf` / `isMemberOf` + read-only `primaryRole`. `resolveUserRoles` stops reading
+  `participant_permissions`. Replace `withAdminAuth`/`withOwnerAuth` with
+  `withSuperAdminAuth`/`withLabAdminAuth`/`withCycleAdminAuth`.
+- **Coarse RLS**: replace `has_permission()`/`is_admin_or_owner()` with `is_super_admin()` +
+  membership predicates; **do not** add per-cycle/per-lab predicates — scope lives in the app
+  seam. Drop `participant_permissions` references.
+- **Backfill (prod)**: D-4 audit first → `role_assignments` super-admin rows for current
+  owners/developers/**observers** (observer→super accepted) + the 2 cycle-admin rows → drop
+  `participant_permissions`. **Dev: seed fresh.**
+- **Invitations**: carry `role` + scope, not `permissions[]`/`role_preset`; rewrite the
+  acceptance path in `auth/callback`. **In-flight pending invitations** are a migration
+  hazard — drain or translate them.
+- **Note the standing exceptions to AC-1**: `registrations`, `registrations/short`,
+  `auth/callback`, and both crons legitimately do service-role writes guarded by
+  session/CRON_SECRET/invitation-state, not a route wrapper. The "wrap every service-role
+  mutation" rule is really "guard it with *something*" — keep those guards.
+
+Critical files: `lib/auth/{roles,permissions,middleware}.ts`, `lib/supabase/server.ts`,
+`app/api/roles/*`, `app/api/permissions/*`, `app/api/invitations/*`, `app/api/auth/callback`,
+`supabase/migrations/00002` + `00009` (RLS), all ~27 call-site files.
+Verify: participant-only user unchanged; super admin unchanged across labs; lab admin 403s on
+foreign lab + sees only own-lab participants; cycle admin 403s on foreign cycle; no code
+references `participant_permissions`/`ROLE_PRESETS`/permission strings.
+
+---
+
+## End-to-end verification
+
+1. Reset dev DB; seed DC + Cycle 3 (dates verified internally consistent — all weekdays/
+   offsets check out) + super admins + 2 cycle admins.
+2. Run the Phase-0 test seams (auth scope, window resolver/DST, tz round-trip).
+3. Walk Cycle 3: problem statement → voting → pod forming (Jul 25→28) → dissolution at
+   forming close → active-join (Aug 11→25) → project stage; assert enrollment status and
+   cron behavior at each boundary (especially: nobody revoked before active-join close).
+4. Lab isolation: insert Lab 2 + foreign rows; confirm app-seam scoping + 403s.
+5. Dry-run the prod forward+backfill migrations against a **clone** of prod before applying.
+
+## Residual risks (accepted / to watch)
+- observer→super-admin is a privilege escalation if prod has observer rows — D-4 audit gates it.
+- Coarse RLS means a forgotten app-seam scope check leaks cross-scope data; the single seam +
+  the lab-scope helper are the mitigations (keep scope derivation out of components/routes).
+- Per-column tz conversion is the one irreversible data step — verify against real values and
+  dry-run on a prod clone.

--- a/docs/requirements/local-labs.md
+++ b/docs/requirements/local-labs.md
@@ -1,0 +1,130 @@
+# Requirements — Local Labs (Multi-Tenancy)
+
+| | |
+|---|---|
+| **Status** | Draft — for review (**active**; ships with the auth redesign) |
+| **Author** | (you) |
+| **Last updated** | 2026-06-17 |
+| **Related code** | `supabase/migrations/00001` (cycles, participants), `lib/auth/` |
+| **Related docs** | [`permissions-redesign.md`](./permissions-redesign.md) (the lab-admin tier scopes against the `labs` introduced here) |
+| **Pairs with** | This is **Change #1 of 2.** Change #2 is the admin-scope redesign in `permissions-redesign.md`. |
+
+## Overview
+
+OLOS is becoming **multi-tenant** at the data-model level. Today there is one
+implicit org (`SCHEMA.md`: `cycles` = "the root of everything"; `participants` =
+"the system-wide identity table"). We are putting the **lab** concept into the
+schema **now** — a new root entity above cycles — so the data model and the
+admin tiers (super / lab / cycle) are correct from the start.
+
+**Scope of this change:** the *structure* (the `labs` table, `lab_id` links, the
+lab-admin tier). **Out of scope:** per-lab *configuration management* — there is
+only one lab, so option lists, Slack/Drive/GitHub provisioning, and branding
+stay **global**. We are not building UI to manage those per lab (see L-2).
+
+New scope hierarchy:
+
+```
+lab (NEW root)  →  cycle  →  pod  →  project  →  membership
+```
+
+## Goals
+
+- A first-class **`labs`** entity in the schema now; seed the existing org as
+  **"DC"** (id 1).
+- Every **cycle** belongs to exactly one lab; every **participant** belongs to
+  exactly **one** lab. Backfill all existing rows to DC.
+- The model supports N labs even though we run one today — the admin tiers and
+  `lab_id` plumbing are real, not stubbed.
+
+## Non-goals
+
+- **Per-lab configuration management.** `option_lists`, provisioning targets
+  (Slack/Drive/GitHub), and branding remain global; no per-lab admin UI. With
+  one lab this buys nothing; revisit when a second lab needs different values
+  (L-2).
+- The admin role tiers themselves — specified in
+  [`permissions-redesign.md`](./permissions-redesign.md). This doc adds the
+  `labs` entity + `lab_id` links the tiers scope against.
+- Changing the cycle→pod→project phase machine.
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **lab** | A local chapter. The new top-level tenant. `labs` table. UI calls it "Lab" too. Today there is one: DC. |
+| **lab membership** | `participants.lab_id` — the one lab a participant belongs to. Distinct from *administering* a lab (a role grant; see Doc B). |
+
+## Model & schema changes
+
+- **`labs`** — new table: `id`, `name`, `slug` (UK), `status`, **`timezone`**
+  (IANA, default `America/New_York` — the cycle timeline reads it; see
+  `cycle-timeline.md` D-4), `created_at`.
+  No per-lab config columns (Slack/Drive/branding) in this cut — see L-2.
+- **`cycles.lab_id`** — FK → `labs`, `NOT NULL` (after backfill). Lab is the
+  derivable parent of every pod/project (through the cycle).
+- **`participants.lab_id`** — FK → `labs`, `NOT NULL` (after backfill). "Lab
+  admins see all participants in their lab" = `WHERE participants.lab_id = <lab>`.
+
+## Data isolation
+
+Reads are lab-scoped: lab admins and participants see only their own lab's data;
+super admins see everything. **Mechanism: soft, app-level filtering** (L-1) —
+queries add `WHERE lab_id = <user's lab>` (or the cycle's lab); RLS is not the
+cross-lab wall. With a single lab everyone is in DC, so the filter is trivially
+satisfied today — but the `lab_id` + filter pattern goes in now so it is correct
+the moment a second lab exists.
+
+- **Risk to manage:** a query that forgets the lab filter would leak another
+  lab's data once 2+ labs exist. Mitigation: a single shared lab-scoping query
+  helper (mirroring the authz seam in Doc B AC-2), so the predicate lives in one
+  place. Upgradeable to RLS lab-predicates later without changing the app
+  contract.
+
+## Migration (hybrid rollout — per Doc B)
+
+**Rollout model (decided 2026-06-17):** build/test against a **reset dev DB**, but
+apply to **prod as forward-only migrations *with* backfill** — prod is **not** reset.
+The backfill steps below are therefore real (they run against prod's existing rows);
+in dev they simply seed.
+
+1. Create `labs`; insert **"DC"** (id 1).
+2. Add `lab_id` to `cycles` and `participants` (nullable), backfill **every**
+   existing row to DC, then set `NOT NULL` (default to DC for new rows until the
+   app sets it explicitly).
+3. Hand off to Doc B for the role/RLS changes that consume `lab_id`.
+
+## Acceptance criteria
+
+- `labs` exists with a DC row; every cycle and participant resolves to DC with
+  no orphans.
+- The schema + `isAdminOf`/lab-scoped queries would correctly separate a second
+  lab's data if one were inserted (verified by inserting a throwaway "Lab 2"
+  with its own cycle/participant in a test).
+- Nothing per-lab to configure: option lists, provisioning, and branding remain
+  global and unchanged.
+
+## Decisions log
+
+- **2026-06-17** — Put `labs` in the schema **now** (not deferred); a new root
+  above cycles. Build the structure; skip per-lab config management.
+- **2026-06-17** — One implicit lab today: **DC**. Seed it and default everyone
+  to DC.
+- **2026-06-17** — A participant belongs to **exactly one** lab
+  (`participants.lab_id`); explicit, not derived from cycle enrollment.
+- **2026-06-17** — Term is **`lab`** in code and UI (no "chapter" identifier).
+- **2026-06-17 (L-1)** — Isolation is **soft, app-level filtering**, not a strict
+  RLS wall; shared lab-scoping helper; upgradeable to RLS later.
+- **2026-06-17 (L-2)** — `option_lists`, provisioning targets, and branding stay
+  **global**; no per-lab config management until a second lab needs it.
+- **2026-06-17 (L-3)** — Participants **cannot move labs**; manual reassignment
+  only; history stays with the original lab.
+- **2026-06-17 (L-4)** — Super admins = the **current owners and admins** (the
+  Doc B backfill set; exact list via D-4).
+- **2026-06-17 (L-5)** — **Super admins only** create labs.
+
+## Open decisions
+
+- *(None blocking.)* L-2's per-lab config items (option lists, provisioning,
+  branding) are intentionally global for now; reopen per item when a second lab
+  requires different values.

--- a/docs/requirements/per-lab-configuration.md
+++ b/docs/requirements/per-lab-configuration.md
@@ -1,0 +1,76 @@
+# Requirements — Per-Lab Configuration Management (LATER)
+
+| | |
+|---|---|
+| **Status** | **Deferred — not scheduled.** Pick up when a **second** lab needs values that differ from DC's. |
+| **Author** | (you) |
+| **Last updated** | 2026-06-17 |
+| **Related docs** | [`local-labs.md`](./local-labs.md) (active — builds the `labs` entity; defers this config work as L-2), [`permissions-redesign.md`](./permissions-redesign.md) |
+
+> **Why this is separate and deferred.** [`local-labs.md`](./local-labs.md)
+> puts the **lab concept** in the data model now (the `labs` table, `lab_id` on
+> cycles/participants, the lab-admin tier). What it intentionally leaves out is
+> letting each lab **configure its own** option lists, integrations, and brand —
+> because there is only one lab (DC), so there is nothing to differentiate.
+> This doc captures that config work for when a real second lab arrives.
+
+## Trigger to pick this up
+
+A second lab is being onboarded **and** it needs at least one of: different form
+options, its own Slack/Drive/GitHub, or its own branding. Until then, everything
+below stays global and this doc is reference only.
+
+## Current state (until then)
+
+All of the following are **global** — one shared value across the (single) lab:
+
+- `option_lists` — registration dropdowns (sectors, work situations,
+  neighborhoods, etc.) are one shared set.
+- Provisioning targets — pods/projects create Slack channels, Drive folders, and
+  GitHub repos under one shared workspace/org/drive.
+- Branding — one name, logo, color set, and email sender (The Upskilling Labs).
+
+## Config dimensions to make per-lab (when triggered)
+
+Each is independent — adopt only the ones a new lab actually needs.
+
+### 1. Per-lab option lists
+- **Why:** chapters in different cities have different valid values (e.g.
+  neighborhoods, local sectors).
+- **Change:** add `option_lists.lab_id` (nullable → `NULL` means "global
+  default", set means "this lab overrides"). Resolution: a lab's effective list
+  = its own rows, falling back to global where it has none. Admin UI under the
+  lab to edit its lists.
+- **Migration:** existing rows stay `lab_id = NULL` (remain global); no data
+  moves.
+
+### 2. Per-lab integration / provisioning targets
+- **Why:** each chapter may have its own Slack workspace, Google Drive, and
+  GitHub org.
+- **Change:** a `lab_integrations` config (per lab: Slack workspace/token, Drive
+  root folder, GitHub org). Provisioning code reads the *cycle's lab* to decide
+  where to create channels/folders/repos. Secrets handled like existing
+  integration credentials (not in the table in plaintext).
+- **Risk:** this is the heaviest item — touches every provisioning path and the
+  credential model. Scope carefully when it lands.
+
+### 3. Per-lab branding
+- **Why:** chapters may present as distinct brands in UI and email.
+- **Change:** per-lab `name`, `logo_url`, theme colors, and email sender/from
+  address. UI and `lib/email/` read the active lab's branding. Sender domains
+  must still be verified in Resend (SPF/DKIM) per lab.
+
+## Out of scope even then
+
+- Cross-lab sharing of option lists/templates (each lab is independent).
+- Self-serve lab creation/branding by lab admins — lab creation stays
+  super-admin-only (see `local-labs.md` L-5).
+
+## Open decisions (revisit at trigger time)
+
+- **Override vs. replace** for option lists — does a lab's list *extend/override*
+  the global defaults (recommended: `lab_id NULL` = fallback) or fully replace
+  them?
+- **Credential storage** for per-lab Slack/Drive/GitHub — env-based per lab vs. a
+  secrets manager; do not store tokens in plaintext columns.
+- **Branding granularity** — just logo + sender, or full theming?

--- a/docs/requirements/permissions-redesign.md
+++ b/docs/requirements/permissions-redesign.md
@@ -1,0 +1,334 @@
+# Requirements — Authorization & Permissions Redesign
+
+| | |
+|---|---|
+| **Status** | Draft — for review |
+| **Author** | (you) |
+| **Last updated** | 2026-06-17 |
+| **Supersedes** | The PBAC model in `00009_permissions_model.sql` |
+| **Related code** | `lib/auth/`, `supabase/migrations/00002`, `00009` |
+| **Related docs** | [`local-labs.md`](./local-labs.md) (**prerequisite**), `lib/auth/CLAUDE.md`, `docs/personas.md` |
+| **Pairs with** | This is **Change #2 of 2.** It depends on the `labs` entity from [`local-labs.md`](./local-labs.md) — the lab-admin tier scopes against `labs`. |
+
+## Overview
+
+OLOS authorization is being simplified from a granular permission model
+(PBAC with role presets) to a **relationship-based model** where authority is a
+**(role, scope) pair**. Roles:
+
+- **admin** — held at one of three scopes: **super** (all labs), **lab** (one
+  lab), or **cycle** (one cycle, which lives in a lab).
+- **moderator** — scoped to a pod (`moderator_assignments`).
+- **participant** — scoped to cycle/pod/project memberships.
+
+Every check answers: *"Do you hold this role at a scope that covers this
+entity?"* Scope hierarchy: `platform → lab → cycle → pod → project → membership`.
+
+## Goals
+
+- Three roles (admin scoped super/lab/cycle; moderator; participant).
+- A single, obvious source of truth for each kind of authority; no drift.
+- Keep the two-path enforcement the codebase already uses (AC-1).
+
+## Non-goals
+
+- Per-person custom permission grants (dropped — presets covered everyone).
+- The `labs` entity + `lab_id` links themselves — see [`local-labs.md`](./local-labs.md).
+- Changing the Google-OAuth sign-in flow or invitation delivery.
+
+## Glossary
+
+Authority is a **(role, scope)** pair. Admin is one role held at three scope
+levels; moderator and participant are scoped by relationship rows.
+
+| Term | Meaning |
+|---|---|
+| **super admin** | Platform-wide (all labs). The leadership team. Create labs/cycles, grant any admin, plus full powers everywhere. `role_assignments('admin','global', NULL)`. |
+| **lab admin** | Admin of one lab. Sees all participants in their lab; runs that lab's cycles. Cannot touch other labs or platform config. `role_assignments('admin','lab', labId)`. |
+| **cycle admin** | Admin of one cycle (within a lab; currently 2 people). Runs that cycle. `role_assignments('admin','cycle', cycleId)`. |
+| **moderator** | Assigned to a (pod, cycle) via `moderator_assignments`. Authority over assigned pods only. |
+| **participant** | Member of a cycle/pod/project (`cycle_enrollments`/`pod_memberships`/`project_memberships`). |
+
+## The model
+
+Authority is the union of:
+
+1. `isSuperAdmin(user)` — a `role_assignments('admin','global')` row.
+2. `isAdminOf(user, {labId})` — super admin **or** an `('admin','lab', labId)` row.
+3. `isAdminOf(user, {cycleId, labId})` — super, **or** a `('admin','cycle', cycleId)`
+   row, **or** lab admin of that cycle's lab. (The route already loads the cycle,
+   so it passes the cycle's `lab_id`; no extra lookup.)
+4. `isModeratorOf(user, {podId|cycleId})` — from `moderator_assignments`.
+5. `isMemberOf(user, {cycleId|podId|projectId})` — from membership tables.
+
+No permission strings, no role presets. Admin authority is one role recorded at
+a scope; moderator/participant are relationship rows.
+
+### Storage — `role_assignments` (admin tiers only)
+
+    role_assignments(
+      participant_id, role,
+      scope_type,   -- 'global' | 'lab' | 'cycle'
+      scope_id,     -- NULL for global, else the lab/cycle id
+      granted_by, granted_at, revoked_at
+    )
+    UNIQUE (participant_id, role, scope_type, scope_id)   -- NULLS NOT DISTINCT
+
+- super = `('admin','global', NULL)`; lab = `('admin','lab', L)`; cycle =
+  `('admin','cycle', C)`.
+- `scope_id` is intentionally **not** a foreign key (it points at labs *or*
+  cycles depending on `scope_type`). A grant whose target was deleted simply
+  matches nothing — harmless for authz — and a small cleanup (trigger or
+  periodic job) prunes stale rows. This is the accepted trade for the
+  flexible single-table shape.
+- **Moderator and participant memberships stay in their existing tables** —
+  they carry lifecycle state (assigned/removed, joined/left, enrollment status)
+  that doesn't fit a generic grant row. `role_assignments` holds admin tiers
+  only. The `(role, scope)` idea is the *mental* model, not one mega-table.
+
+### Target `UserRoles` shape
+
+    {
+      userId: string;
+      participantId: number | null;
+      labId: number | null;        // participants.lab_id — the user's own lab
+      isSuperAdmin: boolean;       // role_assignments ('admin','global')
+      adminLabIds: number[];       // role_assignments ('admin','lab', L)
+      adminCycleIds: number[];     // role_assignments ('admin','cycle', C)
+      moderatorPodIds: number[];   // moderator_assignments
+      moderatorCycleIds: number[]; // moderator_assignments.cycle_id
+      cycleIds: number[];          // cycle_enrollments (status='active')
+      podIds: number[];            // pod_memberships (inactive_at IS NULL)
+      projectIds: number[];        // project_memberships (left_at IS NULL)
+    }
+
+### Check API (replaces the current helpers)
+
+| Today | Becomes |
+|---|---|
+| `isAdmin(user)` on a cycle route | `isAdminOf(user, {cycleId, labId})` |
+| `isAdmin(user)` on a lab route | `isAdminOf(user, {labId})` |
+| `isAdmin(user)` / `isOwner(user)` on a platform route (create lab/cycle, grant admin) | `isSuperAdmin(user)` |
+| `isModeratorForPod(user, podId)` | `isModeratorOf(user, {podId})` |
+| `isActiveParticipant(user, cycleId)` | `isMemberOf(user, {cycleId})` |
+| (none) | `isMemberOf(user, {podId})`, `isMemberOf(user, {projectId})` |
+
+**Route gating keys off the route's scope:** `/api/cycles/[cycle_id]/*` →
+`isAdminOf(user, {cycleId, labId})`; lab-management routes → `isAdminOf(user, {labId})`;
+platform routes → `isSuperAdmin(user)`.
+
+## Architecture constraints (cross-cutting)
+
+- **AC-1 (two enforcement paths, named)** — There is no single enforcement
+  layer, and that's fine: **service-role writes** (auth callback, role grants,
+  invitation fulfillment — they bypass RLS by design) are guarded by the route
+  wrapper; **session-client reads** are filtered by RLS. Rule of thumb: *if you
+  add a service-role mutation, you must wrap it in a guard — the DB will not
+  catch you.* AC-2 makes "forgetting the guard" hard. Full "RLS authoritative"
+  was rejected: privileged paths can't be RLS-enforced, so it would mean writing
+  every rule twice for a guarantee it can't fully deliver.
+  **Standing exceptions (found on stress-test):** `registrations`,
+  `registrations/short`, `auth/callback`, and both crons already do service-role
+  writes guarded by **session / CRON_SECRET / invitation-state**, not by
+  `withAdminAuth`. So the rule is really *"every service-role mutation is guarded by*
+  ***something***" — not specifically a route wrapper. Keep those non-wrapper guards;
+  they are correct (self-registration can't require admin).
+- **AC-2 (one authz seam for decisions)** — Every authorization *decision*
+  (route guards, write-gating, protected-page redirects) goes through a single
+  module (`lib/auth/`): `isSuperAdmin(user)`, `isAdminOf(user, …)`,
+  `isModeratorOf(user, …)`, `isMemberOf(user, …)`. *Display* (badge color,
+  labels) goes through one read-only accessor, `primaryRole(user)` — not raw
+  `user` field access. No authorization decision and no role identity is derived
+  outside these two surfaces. Single grep target ⇒ a future tier/role is a
+  one-module change.
+
+## Functional requirements
+
+### App layer (`lib/auth/`)
+
+- **FR-1** `resolveUserRoles` reads `role_assignments` (→ `isSuperAdmin`,
+  `adminLabIds`, `adminCycleIds`), `participants.lab_id` (→ `labId`),
+  `moderator_assignments`, `cycle_enrollments`, `pod_memberships`,
+  `project_memberships`. It no longer reads `participant_permissions`.
+- **FR-2** Delete `permissions.ts` (`PERMISSIONS`, `PERMISSION_GROUPS`,
+  `ROLE_PRESETS`, `permissionLabel`, `activePresets`, `Permission` type) and the
+  `permissions[]`/`can()` surface on `UserRoles`.
+- **FR-3** Replace `withAdminAuth`/`withOwnerAuth` with scope-aware guards:
+  `withSuperAdminAuth` (platform), `withLabAdminAuth` (resolves `lab_id`),
+  `withCycleAdminAuth` (resolves the cycle + its `lab_id`, checks `isAdminOf`).
+- **FR-4** Migrate every call site of `can`/`isAdmin`/`isOwner`/
+  `isActiveParticipant`/`isModeratorForPod` to the Check API above.
+
+### Role management endpoints & UI
+
+- **FR-5** Replace `/api/roles/{admin,developer,observer}`, `/api/permissions`,
+  `/api/permissions/preset` with a single "set role" action that writes
+  `role_assignments`. Granting super/lab admin → super admins only; granting
+  cycle admin → super or that lab's own admin (D-6, decided).
+- **FR-6** Replace the permission-checklist editor and preset pickers with a
+  role selector: super admin / lab admin + lab / cycle admin + cycle /
+  moderator + pod / participant.
+- **FR-7** Invitations carry a `role` + scope (`lab_id`/`cycle_id`/`pod_id`),
+  not a `permissions[]`/`role_preset` pair. Acceptance writes the appropriate
+  `role_assignments` / `moderator_assignments` / membership row.
+
+### Schema & DB layer
+
+- **FR-8 (schema)** Create `role_assignments` (shape above). It replaces the
+  admin-bearing use of `user_roles`.
+- **FR-9 (RLS — coarse; decided on stress-test)** Replace `has_permission()` /
+  `is_admin_or_owner()` with **`is_super_admin()` + membership predicates**
+  (`is_moderator_of_pod(pod)`, `current_participant_id()` self-checks). **RLS stays
+  coarse: "are you an admin at all / is this row yours."** Per-lab / per-cycle scope
+  is **not** enforced in RLS — it lives in the app seam (`isAdminOf`, AC-2) and the
+  shared lab-scope query helper (Doc A, L-1). This matches AC-1 (RLS is not the
+  authoritative scope wall) and avoids writing every scope rule twice. Drop all
+  `participant_permissions` references from policies (`00002`,`00009`).
+  *(Rejected: full `is_lab_admin(lab)`/`is_admin_of_cycle(cycle)` per-policy
+  predicates — ~2× the work, can't cover service-role paths anyway.)*
+- **FR-10 (migration)** After Doc A's lab backfill: create `role_assignments`;
+  backfill **super admin** rows for current global-equivalent holders
+  (owners/developers/observers/`cycles:write`); seed the 2 **cycle admin** rows;
+  then drop `participant_permissions` once D-4 passes.
+  **Scope reality (from the audit):** this is the largest surface — auth is
+  **dual-track today** (`user_roles` **and** `participant_permissions`, plus
+  *synthetic* moderator/participant roles derived from FK tables), **61 RLS
+  policies** (47 in `00002` + 14 in `00009`), and ~**66 call sites across ~27
+  files**. Note `is_admin_or_owner()` was already redefined in `00009` to mean
+  `has_permission('cycles:write')`. Two hazards to handle explicitly:
+  **(a)** synthetic moderator/participant stay derived (don't materialize into
+  `role_assignments`); **(b) in-flight `pending` invitations** carry
+  `permissions[]`/`role_preset` — drain or translate them before dropping the old
+  model (see FR-7).
+
+## Acceptance criteria
+
+- A participant with only memberships does exactly what they do today.
+- A super admin retains full access across all labs; no platform route opens up.
+- A **lab admin can manage their lab but not another** — verified on a
+  lab-scoped route with a foreign `lab_id` (expect 403), and they can see only
+  their lab's participants.
+- A **cycle admin can manage their cycle but not another**, and a lab admin can
+  manage every cycle in their lab.
+- A moderator's pod-scoped powers are unchanged.
+- No code references `participant_permissions`, `ROLE_PRESETS`, or a permission
+  string; no role identity is derived outside the authz seam.
+
+## Capability matrix
+
+### super admin — all labs, unconditional
+| Area | Capability |
+|---|---|
+| Platform | Create/delete labs and cycles, platform config/options |
+| Roles | Grant/revoke any admin (super, lab, cycle) |
+| Everything below | All lab- and cycle-admin powers, across every lab |
+
+### lab admin — scoped to their lab
+| Area | Capability (within their lab only) |
+|---|---|
+| Lab | Run the lab; see **all participants in the lab** |
+| Cycles | Full cycle-admin powers over **every** cycle in the lab |
+| Roles | Grant cycle admin within the lab (D-6) |
+| Excluded | Other labs, create labs, platform config, grant lab/super admin |
+
+### cycle admin — scoped to their cycle(s)
+| Area | Capability (within their cycle only) |
+|---|---|
+| Cycle | Configure, advance phase, change status |
+| Participants | Manage enrollments, revoke/reactivate access |
+| Pods / Projects | Create/rename/manage; finalize |
+| Invitations | Create, send, view (for this cycle) |
+| Assignments | Assign/remove moderators in this cycle |
+| Excluded | Other cycles, the lab itself, platform config |
+
+### moderator — scoped to assigned (pod, cycle)
+| Area | Capability |
+|---|---|
+| Assigned pod | View, rename, run its workflow; manage its project votes; finalize |
+| Assigned pod's people | View members + pulse-check status; moderator dashboard |
+| Excluded | Cycles, other pods, roles, lab/platform concerns |
+
+### participant — scoped to memberships
+| Area | Capability |
+|---|---|
+| Visibility | Cycles/pods/projects they belong to + dashboards |
+| Cycle phase | Submit problem statements, vote (when active) |
+| Pod / Project phase | Register, submit proposals, vote; one active project/cycle |
+| Engagement | Complete own pulse checks |
+
+Roles stack: any admin may also hold a `moderator_assignments` row or a
+membership; authority is the union.
+
+## Rollout
+
+Pre-launch app (auth still blocked on ops, no test infra, a handful of bootstrap
+rows in prod). **Rollout is hybrid (decided 2026-06-17):** develop/test against a
+**reset dev DB**, but apply to **prod as forward-only migrations *with* backfill**
+— prod is **not** reset, so the backfill below is real. Ship as **phased PRs** in
+dependency order (`labs → timeline → pod-registration → auth`), not one big-bang PR;
+this auth change lands **last** (largest surface). Sequenced after Doc A's `labs`
+migration:
+
+- New authz module (`isSuperAdmin`/`isAdminOf`/`isModeratorOf`/`isMemberOf`
+  + `primaryRole`) + `resolveUserRoles` surfacing scope/memberships; migrate all
+  consumers off old helpers/role-strings.
+- New RLS: `is_super_admin()`/`is_lab_admin()`/`is_admin_of_cycle()`
+  (+ moderator/member predicates); lab-scope reads; drop `participant_permissions`.
+- Schema + data: create `role_assignments`; backfill super admins + seed the 2
+  cycle admins.
+
+Run D-4 first; verify on a reset DB; one PR (may be split from Doc A's PR if
+that lands first).
+
+## Decisions log
+
+- **2026-06-17** — Drop per-person permissions; presets cover everyone. PBAC →
+  relationship-based model.
+- **2026-06-17** — Admin has **three scopes**: super (all labs) / lab / cycle.
+  Super admin = the former global admin/leadership set.
+- **2026-06-17** — Store admin scope in a generic **`role_assignments(role,
+  scope_type, scope_id)`** table (chosen over nullable columns and per-scope
+  tables). Admin tiers only; moderator/memberships stay in their own tables.
+- **2026-06-17** — `owner`, `developer`, `observer` all migrate to admin
+  (super-admin tier on backfill). `testing:use` becomes a plain admin power.
+  **⚠ Caveat (added on stress-test):** `observer` is read-only today and the new
+  3-role model has no read tier, so this mapping **escalates** a read-only auditor
+  to platform-wide super admin. Accepted by the author; the D-4 audit is the
+  safeguard, and it only fires if prod actually holds observer rows. Revisit if a
+  read-only tier is wanted.
+- **2026-06-17 (revised on stress-test)** — **Phased PRs**, not one big-bang.
+  Dependency order `labs → timeline → pod-registration → auth`; auth lands last.
+  Build against a reset **dev** DB; apply to **prod forward-only with backfill**.
+- **2026-06-17** — Pod-moderator is a relationship row holdable by anyone (an
+  admin or a base moderator can be assigned to a pod).
+- **2026-06-17 (D-6)** — Super admins grant super/lab admin; a **lab admin may
+  appoint cycle admins within their own lab**. Lab admins cannot grant lab/super.
+- **2026-06-17 (D-5)** — **Per-pod moderation is sufficient**; `pod_id` stays
+  NOT NULL (no cycle-wide moderator). 
+- **2026-06-17 (D-4)** — **Run the pre-migration audit (below) before** the
+  backfill/drop.
+
+## Pre-migration audit (decided: run before backfill — D-4)
+
+Confirm no production participant has a permission set that doesn't map to a
+preset, and list who has read-only (observer) access (they gain write under
+observer→admin):
+
+      -- (a) role-shaped observers (will gain write)
+      SELECT p.id, p.email, ur.granted_at
+      FROM user_roles ur JOIN participants p ON p.id = ur.participant_id
+      WHERE ur.role = 'observer' AND ur.revoked_at IS NULL;
+
+      -- (b) permission-shaped observers: can read but NOT write, not moderators
+      SELECT p.id, p.email
+      FROM participants p
+      WHERE EXISTS (SELECT 1 FROM participant_permissions pp
+                    WHERE pp.participant_id = p.id
+                      AND pp.permission = 'cycles:read' AND pp.revoked_at IS NULL)
+        AND NOT EXISTS (SELECT 1 FROM participant_permissions pp
+                    WHERE pp.participant_id = p.id
+                      AND pp.permission = 'cycles:write' AND pp.revoked_at IS NULL)
+        AND NOT EXISTS (SELECT 1 FROM moderator_assignments ma
+                    WHERE ma.participant_id = p.id AND ma.removed_at IS NULL);
+
+  Empty (a)+(b) ⇒ observer→admin is harmless. Non-empty ⇒ review before backfill.

--- a/docs/requirements/pod-registration.md
+++ b/docs/requirements/pod-registration.md
@@ -1,0 +1,226 @@
+# Requirements — Pod Registration
+
+| | |
+|---|---|
+| **Status** | Draft — for review |
+| **Author** | (you) |
+| **Last updated** | 2026-06-17 |
+| **Related code** | `app/api/pods/[pod_id]/register/route.ts`, `lib/auth/windows.ts`, `cycle_phases` (per `cycle-timeline.md`), `app/(dashboard)/cycles/[cycle_id]/register-pods/` |
+| **Related docs** | [`cycle-timeline.md`](./cycle-timeline.md) (defines the two windows as phases), `docs/OLOS-architecture-brief.md`, `SCHEMA.md` (Pod Layer) |
+
+## Overview
+
+Pod registration is being restructured to **separate two things that are
+currently fused**:
+
+1. **The ability to register** is split into **two windows keyed to pod
+   status** — a *forming* window (help assemble a pod) and a later *active*
+   window (join a pod that has already formed).
+2. **Pod membership is decoupled from cycle participation** — joining a pod no
+   longer flips a participant's `cycle_enrollments` to `active`. Being an
+   "active participant" in the cycle becomes its own rule, independent of pods.
+
+## Current state (as-is)
+
+Today, registration (`app/api/pods/[pod_id]/register/route.ts`) is a single
+flow with a **three-way coupling**:
+
+```
+register ──drives──▶ pod status (forming → active) ──drives──▶ cycle enrollment (inactive → active)
+```
+
+- One `pod_registration` time window (`cycle_config.pod_registration_open/close`).
+- Registration allowed when pod status ∈ {`forming`,`active`} **and** the window
+  is open.
+- When a `forming` pod reaches `cycle_config.pod_min`, registering flips it to
+  `active` **and** flips every member's `cycle_enrollments` to `active`. If the
+  pod is already `active`, the new registrant's enrollment flips immediately.
+
+So `forming`/`active` is simultaneously a gate, a consequence of registration,
+and the trigger for cycle participation. This redesign untangles that.
+
+## Goals
+
+- Registration availability is governed by **explicit per-status windows**, not
+  by a single window plus a status side-channel.
+- A participant's cycle-participation status does **not** depend on whether
+  their pod formed.
+- The forming → active transition is an explicit, well-defined event (not a
+  side effect of an individual registration).
+
+## Non-goals
+
+- Changing how pods are created (voting finalize still seeds `forming` pods).
+- The project layer (solution proposals / project registration) — out of scope
+  here; mirror later if desired. **Stress-test note:** `projects/[id]/register`
+  *already* never touches `cycle_enrollments` (it only flips `projects.status`) and
+  requires active pod membership, so decoupling pods actually makes the two layers
+  *consistent*, not divergent. One interaction to confirm as acceptable: because
+  `pod_active_join` overlaps project registration (both close Aug 25 in Cycle 3), a
+  participant who joins an active pod on the last day can immediately register a
+  project.
+
+> **Sequencing (stress-test):** this change **depends on Doc D (cycle-timeline)** —
+> its two windows are `cycle_phases` rows and the rewritten cron reads the
+> `pod_forming`/`pod_active_join` boundaries. Build order is
+> `labs → timeline → pod-registration → auth`; pod-registration lands **after**
+> timeline, not before.
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **forming** | A pod still assembling its initial membership. |
+| **active** | A pod that has formed (met the threshold) and is running. |
+| **inactive** | A pod that never formed, or has ended/dissolved. |
+| **forming window** | The period during which participants may join `forming` pods. |
+| **active window** | A separate, later period during which participants may join `active` pods (late/secondary joins). |
+
+## Target model
+
+### Pod lifecycle
+
+```
+forming  ──(forming window closes; threshold met)──▶  active  ──(cycle ends)──▶  inactive
+   └──────────────(threshold NOT met)──────────────▶  inactive (dissolved)
+```
+
+The **forming → active transition is an explicit event**, not a per-registration
+trigger (see D-1 for what fires it). Pods that fail to reach `pod_min` by the end
+of the forming window are dissolved (`inactive`).
+
+### Two registration windows
+
+Registration is allowed when the window matching the pod's **current status** is
+open:
+
+| Pod status | Window required | Purpose |
+|---|---|---|
+| `forming` | **forming window** open | Assemble the pod up toward `pod_min` (no max — D-3). |
+| `active` | **active window** open | Late/secondary joins into a pod that already formed. |
+| `inactive` | — | Never; registration refused. |
+
+Both windows are **phases in the cycle timeline** — `pod_forming` and
+`pod_active_join` rows in `cycle_phases`, replacing the old single
+`pod_registration` phase. See [`cycle-timeline.md`](./cycle-timeline.md).
+
+- `pod_forming` is a **spine** phase — sequential, on the sprint day (Cycle 3:
+  Jul 25 1pm → Jul 28).
+- `pod_active_join` is an **overlay** window anchored to *Meet the Pods →
+  project-registration close*, so it **deliberately overlaps the project stage**
+  (Cycle 3: Aug 11 → Aug 25, spanning project proposal / voting / registration).
+
+These are two genuinely separate join windows — the overlap with the project
+stage is intended, not a scheduling error.
+
+### Cycle enrollment — phase-dependent (D-2)
+
+Individual pod registrations **no longer mutate `cycle_enrollments`** (the old
+per-join side effect is gone). Instead, active status is a **phase-dependent
+rule**:
+
+- **Before pods form:** active = enrolled in an active cycle; pods are
+  irrelevant.
+- **After pods form:** a participant must be **in a pod** to stay active;
+  pod-less enrollees go inactive — this is the existing "in no pods → revoke"
+  cron logic, evaluated at/after the pod-formation boundary.
+
+### Caps & constraints
+
+- A participant may be in at most **2 pods per cycle** (D-4), same in both
+  windows.
+- `UNIQUE(participant_id, pod_id)` prevents double-joining the same pod.
+- **No per-pod maximum** (D-3) — pods may grow unbounded; only `pod_min` matters.
+
+### Leave / switch
+
+Leaving (`DELETE`) is allowed whenever a registration window the participant
+qualifies for is open. **Once a pod is active it stays active** even if a
+departure drops it below `pod_min` (D-5).
+
+## Functional requirements
+
+- **FR-1** Define the two windows as `pod_forming` and `pod_active_join` phases
+  in `cycle_phases` (replacing the old `pod_registration` phase), per
+  [`cycle-timeline.md`](./cycle-timeline.md). `lib/auth/windows.ts` resolves both
+  from the timeline.
+- **FR-2** `POST /api/pods/[pod_id]/register` checks the window **matching the
+  pod's status**: `forming` → `pod_forming` phase; `active` → `pod_active_join`
+  phase; `inactive` → refuse. It no longer touches `cycle_enrollments`.
+- **FR-3** Remove the auto-activation side effect from the register endpoint.
+  The forming → active transition moves to the mechanism chosen in D-1.
+- **FR-4** The forming → active pod-status evaluation (D-1) happens at the
+  `pod_forming` phase boundary (when that phase closes in the timeline).
+- **FR-5** Cycle-participation status (`cycle_enrollments.status`) follows the
+  phase-dependent rule (D-2): enrollment-based before pods form; pod-membership-
+  gated after. Not mutated by individual registrations.
+- **FR-6** The participant UI (`register-pods/`) shows the correct window state
+  per pod status and a clear message when neither window is open.
+
+## Acceptance criteria
+
+- During the forming window, a participant can join a `forming` pod; they cannot
+  join an `active` one (and vice-versa for the active window).
+- Joining or leaving a pod does **not** change the participant's
+  `cycle_enrollments.status`.
+- A pod that never reaches `pod_min` ends as `inactive`; its would-be members
+  are freed to join an active pod and notified (D-6).
+- After pods form, a participant in no pod is not cycle-active (D-2).
+
+## Decisions log
+
+- **2026-06-17** — Split registration into two status-keyed windows: a forming
+  window and a separate active-join window.
+- **2026-06-17** — Decouple pod membership from cycle participation; joining a
+  pod no longer activates `cycle_enrollments`.
+- **2026-06-17 (decision sweep)** — D-1 forming→active at the `pod_forming`
+  phase close; D-2 active rule is **phase-dependent** (enrollment-based pre-pods;
+  pod-gated post-pods, via the in-no-pods revocation); D-3 **no per-pod max**;
+  D-4 cap of **2 pods/cycle** in both windows; D-5 active pods **stay active**;
+  D-6 orphaned members **freed to join an active pod + notified**; D-7
+  **first-come self-serve** (`preference_rank` legacy-only).
+
+## Open decisions
+
+*All resolved 2026-06-17 (decision sweep):*
+
+- **D-1 → At `pod_forming` phase close** — pods with ≥ `pod_min` become active,
+  the rest dissolve (the timeline phase boundary triggers it).
+- **D-2 → Phase-dependent active rule.** **Before pods form:** cycle-active is
+  enrollment-based, *not* linked to pods. **After pods form:** a participant
+  must be in a pod to be active — pod-less enrollees go inactive. Individual
+  registrations no longer mutate `cycle_enrollments` directly.
+
+  **⚠ Stress-test correction — "ties to the existing cron" understates two things:**
+  1. **The cron is NOT phase-gated today** (`cron/revocation-check`, daily, runs
+     unconditionally). The only reason it doesn't already revoke everyone is that
+     enrollments stay `inactive` until a pod-join flips them `active` — i.e. the
+     coupling we are removing is exactly what protects the cron. **Decoupling
+     requires rewriting the cron to be phase-aware** (read the boundary from
+     `cycle_phases`), and the cron now **depends on the timeline (Doc D)**.
+  2. **A replacement activation trigger is required.** Once pod-join stops setting
+     `status='active'`, *nothing* activates a self-registered enrollee (invite-callback
+     sets `active`, but `interest`/`registrations`/`short` set `inactive`). Decision:
+     **enrolling into an open cycle ⇒ `status='active'`** (set it at enrollment time).
+     Pre-pod active = enrolled-in-open-cycle; post-pod active = in a pod.
+  3. **Revoke boundary = `pod_active_join` close, not `pod_forming` close.** Applying
+     "in no pods → revoke" at the *forming* boundary creates a dead-zone (forming
+     closes Jul 28, active-join opens Aug 11) where freed orphans can't yet join but
+     get revoked the next morning — contradicting D-6. Gating revocation to
+     **after `pod_active_join.ends_at`** removes the dead-zone: a participant is only
+     revoked for being pod-less once their *last* chance to join has passed. (The
+     pulse-check arm of the cron is unchanged.)
+- **D-3 → No per-pod maximum.** Pods may grow unbounded (as today); only
+  `pod_min` matters.
+- **D-4 → Up to 2 pods per cycle**, same cap across the forming and active-join
+  windows.
+- **D-5 → Once active, a pod stays active** regardless of later departures.
+- **D-6 → Free orphaned members to join an active pod (+ notify)** when their
+  forming pod dissolves; no silent limbo. **Stress-test notes:** (a) pod
+  **dissolution code does not exist today** — nothing sets a pod `inactive`; this is
+  net-new and fires at the `pod_forming` phase boundary (D-1). (b) The **notification
+  mechanism is also net-new** (no in-app/email notification path exists for this).
+  (c) The dead-zone between forming-close and active-join-open is resolved by gating
+  revocation to `pod_active_join` close (see D-2.3), so "freed" members actually have
+  a window to land in before any revocation.
+- **D-7 → First-come self-serve**; `preference_rank` stays legacy-only (unused).


### PR DESCRIPTION
## Summary

Adds the requirements docs for the four interlocking OLOS redesigns, plus a sequenced implementation plan derived from a **code-audit stress test** of those docs against the current codebase.

Docs (`docs/requirements/`):
- **`local-labs.md`** — multi-tenant `labs` root above cycles; `lab_id` on cycles/participants; `labs.timezone`.
- **`permissions-redesign.md`** — PBAC → relationship-based `(role, scope)` model; `role_assignments` for admin tiers.
- **`pod-registration.md`** — two status-keyed join windows; pod membership decoupled from cycle enrollment.
- **`cycle-timeline.md`** — derived, timezone-aware schedule; phases/events as rows.
- **`per-lab-configuration.md`** — deferred (per-lab option lists / integrations / branding).
- **`implementation-plan.md`** — sequenced build order + phase-by-phase plan.

## Stress-test corrections folded in

- **Rollout:** hybrid — reset **dev** DB, apply to **prod forward-only with backfill**; phased PRs (`labs → timeline → pod-registration → auth`), not one big-bang.
- **Revocation cron:** must be rewritten to be phase-gated (it runs unconditionally today); revoke boundary moved to `pod_active_join` close to close the orphan dead-zone; a replacement enrollment-activation trigger is required.
- **`timestamptz` conversion:** per-column, not blanket-Eastern (audit columns are UTC; a blanket rule corrupts ~38 columns).
- **Window consolidation:** 12 files, not 9 — UI pages bypass the resolver entirely.
- **RLS:** coarse (admin-at-all / own-row); lab/cycle scope enforced in the app seam per AC-1.

## Notes

- No code changes — documentation only.
- Branch was cut from `main`; retarget to `main` if you'd prefer these land there directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)