### PR TITLE
docs(requirements): re-baseline redesign specs against shipped code (supersedes #231 drafts)

### DIFF
--- a/docs/requirements/cycle-timeline.md
+++ b/docs/requirements/cycle-timeline.md
@@ -1,0 +1,342 @@
+# Requirements — Cycle Timeline & Scheduling
+
+| | |
+|---|---|
+| **Status** | Draft — for review (**re-baselined 2026-07-12**; original 2026-06-17). The prescription survives; the "current state" it was written against has since grown a *fourth* time model. |
+| **Related code** | `cycles` + `cycle_config` (00001, 00006, 00026, 00047), `lib/auth/windows.ts`, `lib/cycle/week.ts`, `lib/cycle/milestones.ts`, `lib/cycles/anchor-events.ts`, `00035_luma_sync`, `app/api/cycles/[cycle_id]/advance-phase/route.ts`, `vercel.json` |
+| **Related docs** | [`pod-registration.md`](./pod-registration.md) (its two windows become phases here), [`local-labs.md`](./local-labs.md) (timezone home), [`implementation-plan.md`](./implementation-plan.md) |
+
+## Overview
+
+Cycle scheduling is being made **first-class**. Today the timeline is several
+loose, unrelated bags of dates; this redesign makes a cycle own an **ordered,
+validated, timezone-aware schedule** from which every window — including pod
+forming/active-join — is **derived**, and into which the shipped week-calendar
+and event tracks fold.
+
+## Current state (as-is, July 2026) — four coexisting time models
+
+The June version of this doc counted three disconnected notions of time. Prod
+now has **four**, still with no relationship between them:
+
+1. **Window columns** — twelve `cycle_config.*_open/_close` naive `TIMESTAMP`
+   columns (problem_statement, voting, pod_registration, solution_proposal,
+   solution_voting, project_registration). The real gating timeline. Set by
+   admin PATCH or by `advance-phase`, which still hardcodes a **24-hour**
+   window per phase (now explicitly a `testing:use` testing tool).
+2. **Legacy phase markers** — `cycle_config.phase_2_start` / `phase_3_start`
+   (`00006`). **Not dead** (the June doc was wrong by the time it merged):
+   they drive `cycle-phase-indicator.tsx` ("Meet The Pods" / "Meet The
+   Projects" progress) and are editable in the admin cycle-config form.
+3. **The week calendar** — `cycles.start_date`/`end_date` (still naive
+   `TIMESTAMP`) now **do** drive logic: `lib/cycle/week.ts#getCycleWeek`
+   interpolates a 13-marker week grid, and `cycle_config.milestone_mid_week` /
+   `milestone_final_week` (`00047`) schedule learning-log milestones **by week
+   number**. `00048` orders cycles by these dates for the single-active-cycle
+   invariant.
+4. **Anchor events** — the cycle's six public events are a **hardcoded
+   constant** (`lib/cycles/anchor-events.ts`, `start_at` "local ISO, no
+   timezone — rendered as written"), self-described as interim until the Luma
+   events cache (`00035_luma_sync`) serves them from the DB.
+
+Cross-cutting problems, unchanged from June:
+
+- **No validation** anywhere (`open<close`, ordering, overlap, within-cycle all
+  unchecked) and no link between any of the four models.
+- **Naive timestamps + no timezone anywhere.** No timezone column exists in
+  the schema; every comparison is `new Date()` in whatever zone the runtime or
+  browser happens to be in. An admin entering DC-local times is silently off
+  by 4–5 hours.
+- **Window logic is re-implemented everywhere.** `lib/auth/windows.ts#checkWindow`
+  is the canonical server resolver (6 keys, naive compare; one improvement
+  since June: it **rejects `mode='org'` cycles**, which must survive any
+  refactor). It is called by ~8 API routes + `lib/projects/finalize.ts` — but
+  the UI never calls it. `_open`/`_close` appears **~131 times across ~22
+  files**; a dozen-plus pages re-derive
+  `now >= new Date(open) && now <= new Date(close)` inline with browser-local
+  `Date` (e.g. `cycles/[cycle_id]/register-pods/page.tsx`, `…/join/page.tsx`,
+  `…/propose/page.tsx`, `…/vote/page.tsx`, `…/solutions/page.tsx`,
+  `…/solution-vote/page.tsx`, `…/register-projects/page.tsx`,
+  `dashboard/page.tsx`, `cycles/page.tsx`, `moderator/page.tsx`,
+  `moderator/pods/[pod_id]/page.tsx`,
+  `moderator/cycles/[cycle_id]/vote-progress/page.tsx`,
+  `cycle-phase-indicator.tsx`, `admin/cycles/[cycle_id]/testing-controls.tsx`).
+- Adding a phase still means adding **columns**.
+
+## Goals
+
+- A cycle has **one schedule**; phases are ordered segments of it; the week
+  grid, milestones, and events read the **same anchor**.
+- Phase windows are **derived** from a cycle start + per-phase durations —
+  change the start, the whole schedule shifts; **spine** phases can't overlap
+  or go out of order by construction (overlay windows anchor independently and
+  may overlap).
+- **Timezone-aware:** "midnight" means local midnight in the schedule's
+  timezone.
+- Adding a phase (e.g. pod forming/active-join) is **data, not schema**.
+
+## Non-goals
+
+- Reworking pulse-check cadence / invite TTL into config — those tracks stay
+  independent of the cycle schedule (D-5/D-8).
+- Changing the learning-log milestone *semantics* — milestone weeks stay
+  admin-editable week numbers; only their underlying week grid gets re-anchored.
+- Building the full Luma events cache — but `cycle_events` is designed to be
+  its landing table (see below).
+
+## Target model
+
+### Anchor + timezone
+
+- `cycles.start_at TIMESTAMPTZ` — the schedule anchor (backfilled from
+  `start_date`).
+- **`metros.timezone TEXT`** (IANA, default `America/New_York`) — reworked
+  from the June "timezone is a lab property" decision, because a live open
+  cycle **has no lab FK** under the sub-cohort model (`00067`; see
+  [`local-labs.md`](./local-labs.md)). Resolution rule:
+  - the **cycle schedule** computes/renders in the **HQ default zone**
+    (`America/New_York` until an HQ metro row says otherwise);
+  - **sub-cohort surfaces** may resolve `pods.lab_id → metros.timezone` for
+    display when a pod's metro differs.
+  Wall-clock inputs ("close at 23:59") are interpreted in the schedule zone and
+  stored as `timestamptz` instants; display converts back.
+- `cycles.end_at` becomes **derived** (anchor + sum of spine durations), not a
+  free field.
+
+### Phases as rows (`cycle_phases`)
+
+Replace the twelve `cycle_config` window columns with:
+
+    cycle_phases(
+      id, cycle_id FK,
+      phase_key,        -- 'problem_statement' | 'voting' | 'pod_forming'
+                        --  | 'pod_active_join' | 'solution_proposal'
+                        --  | 'solution_voting' | 'project_registration'
+      kind,             -- 'spine' (sequential) | 'overlay' (independent)
+      position SMALLINT,-- order, for spine phases
+      anchor,           -- what it's relative to (cycle start, or an event)
+      duration INTERVAL,
+      starts_at TIMESTAMPTZ,  -- computed, cached
+      ends_at   TIMESTAMPTZ,  -- computed, cached
+      UNIQUE(cycle_id, phase_key)
+    )
+
+- **Spine phases** chain contiguously (`starts_at = prev.ends_at`; first =
+  anchor); ordered and non-overlapping **by construction**.
+- **Overlay windows** (`pod_active_join`; the always-on pulse track stays
+  outside) anchor independently (to an event ± offset) and **may overlap** the
+  spine — pod active-join deliberately spans the project stage.
+- A window is "open" iff `now ∈ [starts_at, ends_at)`; the resolver reads
+  `cycle_phases` instead of `cycle_config` columns.
+- **Pod forming/active-join** are two phase rows replacing the old
+  `pod_registration` — the reconciliation with
+  [`pod-registration.md`](./pod-registration.md).
+- Org-mode cycles get **no phase rows** (or the resolver keeps its org-reject
+  guard — same effect; the guard is the simpler invariant).
+
+### Events as rows (`cycle_events`) — absorbing models 2 and 4
+
+    cycle_events(
+      id, cycle_id FK,
+      key,            -- 'kickoff' | 'problem_sprint' | 'meet_the_pods'
+                      --  | 'hackathon' | 'meet_the_projects' | 'summit' | …
+      label, occurs_at TIMESTAMPTZ,   -- pinned absolute instant
+      luma_api_id TEXT NULL,          -- when synced from Luma (00035)
+      UNIQUE(cycle_id, key)
+    )
+
+- **Pinned** venue-bound dates that do not slide; phases may anchor to them.
+- `cycle_events` **retires two of the four time models**:
+  - `lib/cycles/anchor-events.ts` — the hardcoded constant becomes seed data;
+    the Luma sync (`00035`) upserts `occurs_at`/`luma_api_id`, fulfilling that
+    file's own "interim until the events cache lands" note.
+  - `cycle_config.phase_2_start`/`phase_3_start` — become the
+    `meet_the_pods` / `meet_the_projects` event rows;
+    `cycle-phase-indicator.tsx` reads events + phases; columns then drop.
+- Events are point-in-time markers; they don't gate app windows by themselves
+  (a phase does that), but they anchor the schedule and drive comms/UI.
+
+### The week grid — re-anchoring model 3
+
+`getCycleWeek` (`lib/cycle/week.ts`) and the milestone-week config (`00047`)
+stay — they answer "what week are we in," which phases don't. Two changes only:
+
+- The grid derives from **`start_at`/derived `end_at`** (same anchor as
+  phases) instead of the free-floating `start_date`/`end_date`.
+- Week boundaries compute in the schedule timezone (a week flips at local
+  midnight, not UTC).
+
+`milestone_mid_week`/`milestone_final_week` remain admin-editable config; the
+learning-log cadence is otherwise untouched.
+
+### Two tracks: events vs. software actions
+
+Unchanged from June — a cycle timeline has **two independent tracks** sharing
+the calendar: **events** (community gatherings, pinned) and **software
+actions** (the in-app windows = `cycle_phases`, derived). They interleave but
+neither gates the other.
+
+### Advancement
+
+Phases are **time-driven** — the clock opens/closes them via
+`starts_at`/`ends_at`; no admin click advances the cycle. `advance-phase`
+becomes an **override** ("close early / extend"), adjusting a duration and
+recomputing downstream; the 24h hardcode goes away. It stays a
+`testing:use`-gated tool.
+
+## Cycle template — relative schedule
+
+Unchanged in substance from June (13-week, Tuesday-anchored; events carry
+per-cycle-overridable offsets from start; software windows anchor to events
+with weekday-snap deadlines). Retained as the instantiation spec:
+
+| Anchor | Relative rule (default) | Cycle 3 instance |
+|---|---|---|
+| Cycle **start** | input — a Tuesday + timezone | Tue Jul 14, America/New_York |
+| **Problem Sprint** (event) | start + 11 days (Sat, wk 2) | Sat Jul 25 |
+| **Meet the Pods** (event) | start + 4 weeks (Tue) | Tue Aug 11 |
+| **Hackathon** (event) | start + 30 days (Thu, wk 5) | Thu Aug 13 |
+| **Meet the Projects** (event) | start + 8 weeks (Tue) | Tue Sep 8 |
+| **Summit** (event) = cycle **end** | start + 13 weeks (Tue) | Tue Oct 13 |
+
+| Window | Opens | Closes |
+|---|---|---|
+| Problem statement | Sprint, 9:00am | Sprint, 12:00pm |
+| Pod voting | Sprint, 12:00pm | Sprint, 1:00pm |
+| Pod forming | Sprint, 1:00pm | Tuesday after Sprint, midnight |
+| Pod active-join | Meet the Pods, 12:00am | = Project registration close |
+| Project proposal | Hackathon (Thu) | Tuesday after Hackathon |
+| Project voting | Tuesday after Hackathon | Thursday after Hackathon |
+| Project registration | Thursday after Hackathon | 2nd Tuesday after Hackathon |
+
+"**\<Weekday\> after X**" = the first such weekday strictly after X.
+
+> **Timing reality (2026-07-12): Cycle 3 starts Jul 14 — this scaffolding will
+> not exist by then.** Cycle 3 runs on the manual window columns as today; its
+> dates above serve as the template's worked example and the migration test
+> fixture. The derived timeline **targets Cycle 4** (or a deliberate mid-Cycle-3
+> retrofit, which is explicitly out of scope unless separately decided — see
+> [`implementation-plan.md`](./implementation-plan.md)).
+
+## Functional requirements
+
+- **FR-1** Add `cycles.start_at TIMESTAMPTZ` (backfill from `start_date`) with
+  derived `end_at`; add `metros.timezone` (default `America/New_York`). All
+  scheduling math/display uses the resolution rule above.
+- **FR-2** Create `cycle_phases`; seed the default phase sequence with default
+  durations (Cycle-3 template values) on cycle creation.
+- **FR-3** A schedule service computes/stores `starts_at`/`ends_at` for all
+  phases from anchor + durations + event pins; recomputes on any change.
+- **FR-4** Create `cycle_events`; seed from `anchor-events.ts`; wire the Luma
+  sync (`00035`) to upsert into it; migrate `phase_2_start`/`phase_3_start`
+  into `meet_the_pods`/`meet_the_projects` rows and update
+  `cycle-phase-indicator.tsx`; then drop the two columns and retire
+  `anchor-events.ts`.
+- **FR-5** `advance-phase` becomes duration-override + recompute; remove the
+  24h hardcode; keep the `testing:use` gate and org-reject.
+- **FR-6** Validation: spine stays ordered/contiguous by construction;
+  overlays may overlap; any explicit pin keeps `start<end` and stays within
+  the cycle.
+- **FR-7** Admin schedule UI shows the derived timeline (phase → computed
+  start/end in the schedule tz) and edits durations/anchors, not raw
+  timestamps.
+- **FR-8 (week grid)** `getCycleWeek` + milestone weeks read
+  `start_at`/derived `end_at` and compute week boundaries in the schedule tz;
+  learning-log behavior otherwise unchanged.
+- **FR-11 (single window resolver)** Route **all** window checks through one
+  tz-aware resolver backed by `cycle_phases` — the ~8 API routes +
+  `lib/projects/finalize.ts` that already call `checkWindow`, **and every UI
+  page/component that today re-derives windows inline** (~22 files with
+  `_open`/`_close` references — the server pages resolve windows server-side
+  and pass results down). Delete the inline `now >= open && now <= close`
+  re-implementations and per-file `DAY_MS` offsets. Keep the org-mode reject.
+- **FR-12 (phase keys)** The resolver's `WindowField` + `WINDOW_MESSAGES`
+  extend to the new phase set (`pod_forming`, `pod_active_join`,
+  `project_proposal`, …) and remain the single enumeration of windows.
+- **FR-13 (validation surface)** Replace `lib/validations/cycles.ts`
+  config/window validation with schedule-template validation (anchor + event
+  dates + durations).
+- **FR-14 (display tz)** UI date formatting renders in the **schedule's**
+  timezone **with the tz label shown** ("Aug 13, 2026, 12:00 PM EDT"), not the
+  browser's local time. (Note: `lib/format/date.ts` currently pins UTC purely
+  as an SSR-hydration fix — replace with schedule-tz formatting.)
+- **FR-15 (cron tz)** Participant-facing crons (learning-log/leadership-log
+  reminders and windows, the re-scheduled revocation check per
+  [`pod-registration.md`](./pod-registration.md)) fire at a **cycle-local
+  morning hour**. Vercel cron is UTC-only: pin the UTC equivalent (mind DST)
+  or run hourly and gate to the schedule's local hour.
+
+## Schema & migration
+
+- Add `cycles.start_at` (backfill: `start_date AT TIME ZONE` the verified
+  source zone) + `metros.timezone`; create `cycle_phases`, `cycle_events`.
+- Migrate the twelve `cycle_config.*_open/close` values into phase rows
+  (derive each `duration` from the old span), splitting `pod_registration` →
+  `pod_forming` + `pod_active_join`; keep the non-window `cycle_config`
+  columns (thresholds, `pod_limit`, milestone weeks, pulse tuning). Then drop
+  the window columns + `phase_2_start`/`phase_3_start`.
+- **timestamptz conversion is PER-COLUMN — never blanket:**
+  - **Audit columns** (`created_at`, `granted_at`, `joined_at`, …) were written
+    by `CURRENT_TIMESTAMP` in a UTC session → convert `USING col AT TIME ZONE
+    'UTC'`. Reinterpreting them as Eastern shifts dozens of columns by 4–5h —
+    data corruption.
+  - **Scheduling columns** (the 12 window columns, `start_date`/`end_date`,
+    `phase_2/3_start`, `events.start_at/end_at` — the last documented in
+    SCHEMA.md as "local wall time") are Eastern *candidates*, but **verify
+    against real prod values per column before choosing** (a write path using
+    `.toISOString()` already stored UTC instants). This is the one
+    irreversible data step — dry-run on a prod clone.
+- New tables since ~`00033` already use `TIMESTAMPTZ`; they need no change.
+
+## Acceptance criteria
+
+- Changing `cycles.start_at` shifts every phase boundary and the week grid;
+  spine phases stay ordered and contiguous with no manual edits.
+- A window opens/closes by the clock at its computed boundary in the schedule
+  timezone (a 23:59 close in `America/New_York` closes at local 23:59, not
+  UTC — including across a DST transition).
+- Pod forming and active-join are two phases; the pod-registration flow reads
+  them like any other window.
+- It is impossible to save spine phases that overlap or go out of order;
+  overlays may overlap the spine by design.
+- `cycle-phase-indicator.tsx` renders from `cycle_events` + `cycle_phases`;
+  `phase_2_start`/`phase_3_start` and `anchor-events.ts` are gone.
+- `grep -r "_open\|_close" app/` finds no inline window comparisons — every
+  check goes through the resolver.
+- Learning-log milestone timing is unchanged for a cycle whose
+  `start_at`/`end_at` equal its old `start_date`/`end_date`.
+
+## Decisions log
+
+- **2026-06-17** — Timeline is cycle-relative/derived; phases are rows;
+  spine/overlay; hybrid pinned-events + derived-phases; display in schedule tz
+  with label; participant crons at cycle-local morning; reusable relative
+  template (13-week, Tuesday-anchored); events vs software actions are two
+  independent tracks. *(All retained.)*
+- **2026-06-17 (D-3, revised on stress-test)** — timestamptz conversion is
+  **per-column** (audit = UTC; scheduling = verify then convert). *(Retained.)*
+- **2026-06-17 (D-4)** — ~~timezone is a lab property; a cycle uses its lab's
+  zone~~ — **reworked 2026-07-12**: live open cycles have no lab
+  (`00067`); timezone lives on `metros` with an HQ default; schedule uses the
+  HQ zone, sub-cohort surfaces may localize display.
+- **2026-06-17 (D-5/D-8)** — pulse/invite/reminder offsets stay code
+  constants; pulse + invite tracks stay independent of the schedule.
+  *(Retained.)*
+- **2026-07-12 (re-baseline)** — The shipped **week grid + milestone weeks**
+  (`lib/cycle/week.ts`, `00047`) are kept and re-anchored, not replaced.
+  `cycle_events` absorbs `anchor-events.ts` (as Luma-cache landing table) and
+  `phase_2/3_start`. The June claim that `start_date`/`end_date` are "never
+  read" and `phase_2/3_start` "dead" was already false at merge time — both
+  are live; both must be *migrated*, not dropped.
+- **2026-07-12** — Cycle 3 (starts Jul 14) runs on the manual window columns;
+  the derived timeline targets **Cycle 4** unless a mid-cycle retrofit is
+  separately decided.
+
+## Open decisions
+
+- **T-1** — Mid-Cycle-3 retrofit vs. Cycle-4 target (default: Cycle 4).
+- **T-2** — Does the schedule zone come from an explicit HQ `metros` row
+  (`is_default = true`) or a platform setting? (Either satisfies FR-1; pick
+  during implementation.)
+- **T-3** — `pulse_checks.scheduled_date` (DATE) "today" derivation: switch to
+  schedule-tz "today" during FR-15, or leave as a known minor skew.

--- a/docs/requirements/cycle-timeline.md
+++ b/docs/requirements/cycle-timeline.md
@@ -186,37 +186,36 @@ recomputing downstream; the 24h hardcode goes away. It stays a
 
 ## Cycle template — relative schedule
 
-Unchanged in substance from June (13-week, Tuesday-anchored; events carry
-per-cycle-overridable offsets from start; software windows anchor to events
-with weekday-snap deadlines). Retained as the instantiation spec:
+13-week, **all-Tuesday** cadence; events carry per-cycle-overridable offsets
+from start; software windows anchor to events. **The June draft's dates were
+superseded by the booked Cycle-3 calendar** — the shipped source of truth is
+`lib/cycles/anchor-events.ts` (it already drives the Open Cycle Agreement
+ceremony and the `.ics` download). Real instance:
 
-| Anchor | Relative rule (default) | Cycle 3 instance |
+| Anchor | Relative rule (default) | Cycle 3 (real, per `anchor-events.ts`; all ET) |
 |---|---|---|
-| Cycle **start** | input — a Tuesday + timezone | Tue Jul 14, America/New_York |
-| **Problem Sprint** (event) | start + 11 days (Sat, wk 2) | Sat Jul 25 |
-| **Meet the Pods** (event) | start + 4 weeks (Tue) | Tue Aug 11 |
-| **Hackathon** (event) | start + 30 days (Thu, wk 5) | Thu Aug 13 |
-| **Meet the Projects** (event) | start + 8 weeks (Tue) | Tue Sep 8 |
-| **Summit** (event) = cycle **end** | start + 13 weeks (Tue) | Tue Oct 13 |
+| Cycle **start** = **Kickoff Summit** | input — a Tuesday + timezone | Tue Jul 14, 6:00–9:00 PM |
+| **Problem Sprint** (event) | start + 2 weeks | Tue Jul 28, 6:00–8:30 PM |
+| **Meet the Pods** (event) | start + 5 weeks | Tue Aug 18, 6:00–8:30 PM |
+| **Hackathon — Frame Sprint** (event) | start + 8 weeks | Tue Sep 8, 9:00 AM–6:00 PM |
+| **Meet the Projects** (event) | start + 9 weeks | Tue Sep 15, 6:00–8:30 PM |
+| **Showcase Summit** (event) = cycle **end** | start + 13 weeks | Tue Oct 13, 6:00–9:00 PM |
 
-| Window | Opens | Closes |
-|---|---|---|
-| Problem statement | Sprint, 9:00am | Sprint, 12:00pm |
-| Pod voting | Sprint, 12:00pm | Sprint, 1:00pm |
-| Pod forming | Sprint, 1:00pm | Tuesday after Sprint, midnight |
-| Pod active-join | Meet the Pods, 12:00am | = Project registration close |
-| Project proposal | Hackathon (Thu) | Tuesday after Hackathon |
-| Project voting | Tuesday after Hackathon | Thursday after Hackathon |
-| Project registration | Thursday after Hackathon | 2nd Tuesday after Hackathon |
+**Software-action windows for Cycle 3 are a pending product decision** — the
+June draft assumed a Saturday-morning sprint (9am–1pm windows); the real
+Sprint is a Tuesday *evening*, so those hours don't transfer. Decide and enter
+the real windows before Jul 28 (see the testing plan S5.1 for the entry
+convention). The structural rules stand: the submission → voting → forming
+chain compresses around the Sprint; the project chain hangs off the Hackathon;
+pod active-join runs Meet-the-Pods → project-registration close.
 
-"**\<Weekday\> after X**" = the first such weekday strictly after X.
-
-> **Timing reality (2026-07-12): Cycle 3 starts Jul 14 — this scaffolding will
-> not exist by then.** Cycle 3 runs on the manual window columns as today; its
-> dates above serve as the template's worked example and the migration test
-> fixture. The derived timeline **targets Cycle 4** (or a deliberate mid-Cycle-3
-> retrofit, which is explicitly out of scope unless separately decided — see
-> [`implementation-plan.md`](./implementation-plan.md)).
+> **Timing decision (2026-07-12, owner): the calendar overhaul targets
+> Cycle 3, staged inside the cycle.** Day 1 (Jul 14) runs on the manual window
+> columns; the `cycle_phases`/`cycle_events` schema + resolver land **before
+> the Problem Sprint (Jul 28)**; the two pod windows + remaining page
+> consolidation land **before Meet the Pods (Aug 18)**. Stage plan and the
+> simplifications that make this feasible are in
+> [`implementation-plan.md`](./implementation-plan.md).
 
 ## Functional requirements
 
@@ -328,13 +327,21 @@ with weekday-snap deadlines). Retained as the instantiation spec:
   `phase_2/3_start`. The June claim that `start_date`/`end_date` are "never
   read" and `phase_2/3_start` "dead" was already false at merge time — both
   are live; both must be *migrated*, not dropped.
-- **2026-07-12** — Cycle 3 (starts Jul 14) runs on the manual window columns;
-  the derived timeline targets **Cycle 4** unless a mid-cycle retrofit is
-  separately decided.
+- **2026-07-12 (T-1 resolved, owner)** — The overhaul **targets Cycle 3,
+  staged**: day 1 on manual columns; schema + resolver before the Sprint
+  (Jul 28); two pod windows + full consolidation before Meet the Pods
+  (Aug 18). Mass timestamptz conversion of legacy audit columns, DST
+  machinery (Cycle 3 sits entirely inside EDT), and the template-derivation
+  engine are **deferred to Cycle 4** — Cycle 3 phases are seeded as explicit
+  rows.
+- **2026-07-12** — The June draft's Cycle-3 dates were wrong; the real
+  calendar (all-Tuesday, evening events) comes from `anchor-events.ts`, which
+  stays the events source of truth until `cycle_events` absorbs it (its
+  retirement may slip to late Cycle 3 — the ceremony in PR #226 renders from
+  it, so both sources must agree until the swap).
 
 ## Open decisions
 
-- **T-1** — Mid-Cycle-3 retrofit vs. Cycle-4 target (default: Cycle 4).
 - **T-2** — Does the schedule zone come from an explicit HQ `metros` row
   (`is_default = true`) or a platform setting? (Either satisfies FR-1; pick
   during implementation.)

--- a/docs/requirements/cycle3-testing-plan.md
+++ b/docs/requirements/cycle3-testing-plan.md
@@ -1,0 +1,157 @@
+# Cycle 3 Launch — Testing Plan (2026-07-12)
+
+| | |
+|---|---|
+| **Scope** | Cycle 3 go-live (Jul 14) + the staged calendar work landing inside the cycle. Weighted toward the **early stages: invites, joining the cycle, joining a pod.** |
+| **Real Cycle 3 dates** | Kickoff **Tue Jul 14** 6–9 PM · Problem Sprint **Tue Jul 28** 6–8:30 PM · Meet the Pods **Tue Aug 18** · Hackathon **Tue Sep 8** · Meet the Projects **Tue Sep 15** · Showcase Summit **Tue Oct 13** (source: `lib/cycles/anchor-events.ts` — all Eastern) |
+| **Related docs** | [`cycle-timeline.md`](./cycle-timeline.md), [`pod-registration.md`](./pod-registration.md), [`implementation-plan.md`](./implementation-plan.md) |
+
+## How to use this plan
+
+Four **gates**, each tied to a calendar date. Run a gate's suites before its
+date; a red scenario blocks that gate, not the whole program. Early-stage
+suites (S2–S4) are the priority per the owner.
+
+| Gate | Date | Must pass |
+|---|---|---|
+| **G0 — pre-launch rehearsal** | by Jul 13 | S1 (handover), S5.1 (window-entry convention), fix-train merged (see Interlocks) |
+| **G1 — launch** | Jul 14 | S2 (invites), S3 (join cycle), S8 spot-checks |
+| **G2 — pre-Sprint** | by Jul 27 | S4 (pod joining), S6 (propose/vote), S5.2–5.4 if Stage 1B shipped |
+| **G3 — pre-Meet-the-Pods** | by Aug 17 | S7 (lifecycle/cron), active-join suite if two-window shipped |
+
+**Environment.** Run everything on a staging environment seeded from a prod
+clone (per the plan's rollout rule), then re-run the G1 smoke set on prod
+after the `dev → main` promotion. Test boundaries by editing the cycle's
+window values in admin (or `testing-controls`), **never** with
+`advance-phase` — it stamps a 24-hour window regardless of the schedule.
+
+**Two-clock rule.** Every time-sensitive scenario gets run twice: once in a
+browser set to Eastern, once set to Pacific (or a second device). The pass
+condition is always "both browsers agree with the Eastern wall-clock intent."
+
+## Personas (test accounts to seed)
+
+| # | Persona | Setup |
+|---|---|---|
+| P1 | **Owner** | Rooted owner (`participant_roles` owner row) |
+| P2 | **Admin/staff** | `admin` role; runs invites, config, voting finalize |
+| P3 | **Lab lead** | `lab_lead` of the DC metro; NOT admin |
+| P4 | **Poderator** | `moderator_assignments` row on one Cycle-3 pod (post-Sprint) |
+| P5 | **Returning member** | Cycle-2 participant: existing account, metro set, was in a Cycle-2 pod |
+| P6 | **Invited newcomer** | No account; receives an email invite with `cycle_id` = Cycle 3 |
+| P7 | **Self-serve newcomer** | No account, no invite; enters via `/register` funnel |
+| P8 | **Metro-less member** | Existing participant with `metro_id = NULL` (this is most legacy rows — see S4.4) |
+| P9 | **Observer** | `observer` role only (read-only leak checks, cf. PR #225) |
+| P10 | **Org contributor** | Member of an org-mode workstream pod (regression only) |
+| P11 | **Revoked returner** | Cycle-3 enrollee later revoked (S7) |
+
+## S1 — Cycle 2 → Cycle 3 handover (G0; rehearse on staging first)
+
+The riskiest untested moment happens **before** anyone joins anything.
+
+| ID | Persona | Scenario | Expected |
+|---|---|---|---|
+| S1.1 | P1 | Close out Cycle 2 (status → closed/archived) | Cycle-2 pods → `dissolved`; moderator assignments revoked; projects graduate; no errors |
+| S1.2 | P1 | Activate Cycle 3 while Cycle 2 still active | Blocked by the single-active-cycle rule with a clear message (do the close-out first) |
+| S1.3 | P1/P2 | Activate Cycle 3; check `cycle_config` row | Config exists with intended `pod_min`, `pod_limit`, `submitter_votes`/`non_submitter_votes`, milestone weeks — a missing config row breaks propose/vote pages (cf. PR #224's explicit-message fix) |
+| S1.4 | P5 | Sign in during the gap (Cycle 2 closed, Cycle 3 not yet active) and after | Dashboard renders sanely in the gap (no crash/blank); after activation, Cycle 3 is offered for registration |
+| S1.5 | P4 (Cycle-2 poderator) | Sign in after handover | Moderator surfaces for Cycle 2 gone/read-only; no orphaned nav |
+
+## S2 — Invitations (G1; the invite path is the **legacy** one — that's expected)
+
+| ID | Persona | Scenario | Expected |
+|---|---|---|---|
+| S2.1 | P2 → P6 | Create + send invite (cycle_id = Cycle 3), accept via Google | Lands signed-in; enrollment **active**; correct role rows; invitation `accepted` |
+| S2.2 | P6 variant | Invite with `pod_id` + `pod_role` (after pods exist) | co_lead → moderator + membership; member → membership only |
+| S2.3 | anyone | Forward the invite link to a different Google account | Rejected (email mismatch); no rows written |
+| S2.4 | P6 | Accept an **expired** invite | Clear failure; can still self-register |
+| S2.5 | P5 | Invite sent to an address that already has an account | Accept links to the existing participant; no duplicate |
+| S2.6 | P2 | Invite accepted mid-cycle (e.g. Aug) | Enrollment active; dashboard shows correct current phase, not day-1 state |
+
+## S3 — Joining the cycle (G1; heaviest suite)
+
+| ID | Persona | Scenario | Expected |
+|---|---|---|---|
+| S3.1 | P7 | Full funnel: Google sign-in → `/register` (names prefilled per #227) → metro pick → Open Cycle Agreement ceremony → signed | Enrolled in Cycle 3; agreement row written; ceremony lists the **five real core events with real dates** (#226) |
+| S3.2 | P5 | Returning member registers for Cycle 3 | Ceremony offered fresh (Cycle-2 agreement doesn't satisfy Cycle 3); after signing, `/cycles` shows "You're registered" not "Register" (#226) |
+| S3.3 | P5/P7 | Post-registration dashboard | Checklist leads with cycle registration (#228); **"Join a pod" row absent** until the forming window opens (#228); "Find your local lab" hidden when metro set |
+| S3.4 | P5/P7 | **Enrollment status check** (DB or admin view) | Known quirk: invite-path enrollees are `active`; self-registered are `inactive` until a pod join flips them. Confirm every participant-facing surface (dashboard, cycle page, counts shown to admins) treats both as "in" — flag any surface that hides content from `inactive` self-registrants |
+| S3.5 | P7 variant | Abandon funnel mid-way, return next day | Resumes/restarts cleanly; no half-created rows blocking re-entry |
+| S3.6 | P1/P2 | Kickoff-day dates audit (Jul 14) | Everywhere dates render — ceremony, dashboard, cycle page, `.ics` download — shows the **real** anchor dates, Eastern. One wrong surface = the two date sources (admin-entered windows vs `anchor-events.ts`) have drifted; see S5.1 |
+| S3.7 | P9 | Observer signs in | Sees read-only surfaces; **no pulse aggregates on the public pod page** (#225) |
+
+## S4 — Joining a pod (G2; run the whole suite before Jul 28)
+
+Sprint night is compressed (6–8:30 PM). Rehearse the full chain on staging
+with realistic timing before the real evening.
+
+| ID | Persona | Scenario | Expected |
+|---|---|---|---|
+| S4.1 | P2 | **Sprint-night pipeline rehearsal**: problem window closes → voting window → finalize → forming pods exist → forming window opens | Finalize (admin-triggered) seeds `forming` pods in the minutes between voting close and forming open; document exactly who clicks what, when |
+| S4.2 | P5/P7 | Join a `forming` pod inside the window | Joins; under current code the member's enrollment flips `active` — verify no error either way |
+| S4.3 | P5 | Join a second pod | Blocked at `cycle_config.pod_limit` (**default 1** — product must confirm 1 vs 2 before Jul 28; it's a config value) |
+| S4.4 | P8 | **Metro-less member joins a pod** | If Cycle-3 pods are lab-tagged (`pods.lab_id` set), the metro fence **blocks** every metro-less member — most legacy rows. Decide before Sprint: either pods stay HQ (`lab_id NULL`, fence moot) or run a metro backfill. This is the likeliest mass-failure of Sprint night |
+| S4.5 | P5 | Leave pod in-window, rejoin same pod | Leave works; rejoin reactivates the old membership row (no duplicate error) |
+| S4.6 | P5 | Pod reaches `pod_min` | Pod flips `active`; all members' enrollments `active` (current model) |
+| S4.7 | P5, two clocks | Join at the window boundary (e.g. close at 11:59 PM ET): try 11:55 PM ET and 12:05 AM ET | 11:55 works, 12:05 refused — **in both browser timezones**. This is the #1 timezone bug signature |
+| S4.8 | P5 | Join attempt when no window open (Jul 15–27) | Clean "not open" message on page AND api; dashboard shows no join row |
+| S4.9 | P4 | Poderator assigned post-formation | Sees their pod on moderator surfaces; pulse dashboard visible to them, invisible on the public pod page (#225) |
+
+## S5 — Calendar & timezone (G0 item 1 now; rest at G2 if Stage 1B ships)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| S5.1 | **Window-entry convention (do this FIRST, before entering real windows):** admin enters "opens Jul 28 6:00 PM" intent on staging; check the stored value, the rendered value, and when the gate actually flips (set a window 10 min ahead and watch it open) | The flip happens at 6:00 PM **Eastern**. Under the pre-overhaul naive columns, entered values are compared as UTC on the server (PR #224's ops note) — this test tells the admin exactly what to type so reality matches intent; write the convention down and use it for all Cycle-3 windows |
+| S5.2 | (Stage 1B) All ~critical pages show identical boundaries with an ET label; PT browser shows the same wall-clock + label | No page disagrees; no unlabeled times |
+| S5.3 | (Stage 1B) Admin shifts a phase boundary | Every surface (dashboard, join page, checklist row, moderator views) reflects it within a reload; legacy-column mirror (if dual-write bridge used) matches `cycle_phases` |
+| S5.4 | (Stage 1B) `getCycleWeek`/learning-log milestone timing after schema change | A cycle with unchanged dates produces identical week numbers and milestone windows |
+| S5.5 | Admin misuse guard | Confirm `advance-phase` is not reachable by non-`testing:use` admins; brief the team not to use it on the live cycle |
+
+*(Deliberately absent: DST scenarios — Cycle 3 runs Jul 14–Oct 13, entirely
+inside EDT. DST testing belongs to Cycle 4.)*
+
+## S6 — Sprint-night propose & vote (G2; post-#224 behavior)
+
+| ID | Persona | Scenario | Expected |
+|---|---|---|---|
+| S6.1 | P5 (submitter) | Submit problem statement; then vote | Budget = `submitter_votes`; form scroll resets between steps |
+| S6.2 | P7 (non-submitter) | Vote | Budget = `non_submitter_votes` |
+| S6.3 | P5 | Stack multiple votes on one problem; reload | Stacking allowed; remaining budget correct after reload; over-budget → clear error |
+| S6.4 | P2 | Finalize voting | Pods seeded from winning problems; ties/zero-vote edge handled (verify on staging with a tie) |
+
+## S7 — Lifecycle & cron (G3)
+
+| ID | Persona | Scenario | Expected |
+|---|---|---|---|
+| S7.1 | P2 | Decide + execute cron re-scheduling | **Do not schedule the "in no pods" arm while the gap stands**: with forming closing ~Jul 28 and active-join not existing until the two-window work ships (~Aug 18), a scheduled cron starts warning pod-less enrollees ~Jul 29 and revoking ~Aug 1 with no way back in — the dead-zone the requirements call out. Either ship the gate move with Stage 1C, or leave the cron unscheduled until then |
+| S7.2 | P5 | Pulse-check baseline for new enrollees | A Jul-14 joiner isn't warned before ~Jul 21 (7-day baseline from creation); banner timing matches |
+| S7.3 | P11 | Revoked member joins a pod during active-join (post-Stage-1C) | Reactivated cleanly |
+| S7.4 | P5 in dissolved pod (post-Stage-1C) | Forming-close dissolution | Members freed + notified; can join an active pod until active-join closes; not warned/revoked meanwhile |
+
+## S8 — Regression spot-checks (every gate)
+
+- P10: org-mode workstream pod untouched — no windows, no checklist changes,
+  no cron interference.
+- P3: lab lead sees their metro surfaces; 403 on another metro's admin
+  surfaces.
+- P1: owner console (dev branch, PRs #78-81 range) still gated owner-only.
+- Events page (#230), profile/directory (#229), including that `/u/handle`
+  links in circulation still resolve after the handle de-suffix migration —
+  the PR itself flags this as a maintainer call.
+
+## Interlocks with the open fix train (#224–#230)
+
+Test **after** these merge; they change the behavior under test:
+
+- **#224** — vote budgets/stacking + `checkWindow` hardening (S6, S5.1).
+- **#225** — pulse-data leak fix (S3.7, S4.9).
+- **#226** — ceremony copy + real event dates (S3.1, S3.6).
+- **#227** — funnel name prefill (S3.1).
+- **#228** — checklist order + window-gated pod row (S3.3, S4.8).
+- **#229** — ⚠ carries migration `00078_handle_desuffix`, which **collides**
+  with `00078_owner_actions_audit` already on dev — renumber before merge
+  (`npm run check:migrations` on a rebased branch catches it).
+- **#230** — events page fixes (S8).
+
+Merge the train (in order, rebased, CI green), promote `dev → main`, then run
+G1 on prod.

--- a/docs/requirements/implementation-plan.md
+++ b/docs/requirements/implementation-plan.md
@@ -12,129 +12,154 @@ that premise (see [`pr231-evaluation.md`](./pr231-evaluation.md)):
 - **Auth storage**: shipped — `participant_roles` unification
   (`00054`–`00066`). What remains is **finishing** it
   ([`permissions-redesign.md`](./permissions-redesign.md)).
-- **Timeline**: not built; prod now runs **four** uncoordinated time models
+- **Timeline**: not built; prod runs **four** uncoordinated time models
   ([`cycle-timeline.md`](./cycle-timeline.md)).
 - **Pod registration**: core change (two windows, decoupled enrollment) not
   built; the enrollment seam (`lib/enrollment/reconciler.ts`) and a
   phase-gated (but **unscheduled**) revocation cron shipped
   ([`pod-registration.md`](./pod-registration.md)).
 
-**Timing constraint:** Cycle 3 starts **Jul 14, 2026** and runs on the manual
-window columns. Schema-touching timeline work targets **Cycle 4** (or a
-deliberately-decided mid-cycle retrofit); nothing below may disrupt a live
-formation window.
+**Timing decision (2026-07-12, owner): the calendar overhaul targets Cycle 3,
+staged inside the live cycle.** Cycle 3's real calendar (all Eastern, per
+`lib/cycles/anchor-events.ts`): Kickoff **Jul 14** · Problem Sprint **Jul 28**
+· Meet the Pods **Aug 18** · Hackathon **Sep 8** · Meet the Projects **Sep 15**
+· Summit **Oct 13**. The stage boundaries below are those dates. Testing gates
+per stage: [`cycle3-testing-plan.md`](./cycle3-testing-plan.md).
+
+### Simplifications that make Cycle-3 targeting feasible
+
+1. **Dual-write bridge instead of a 22-file big-bang.** `cycle_phases` becomes
+   the source of truth and the schedule service **mirrors computed boundaries
+   back into the legacy `cycle_config.*_open/close` columns**. Every
+   not-yet-migrated page keeps working unchanged; pages move to the resolver
+   in batches; the mirror (and the columns) drop only when the last page has
+   moved. Removes the launch-window cliff entirely.
+2. **Seed, don't derive.** Cycle 3's phases/events are inserted as explicit
+   rows from the decided dates. The template-derivation engine
+   (offsets/weekday-snap; FR-2/FR-3's recompute machinery beyond simple
+   boundary edits) is Cycle-4 work.
+3. **No DST machinery now.** Cycle 3 runs Jul 14–Oct 13, entirely inside EDT —
+   pin cron hours to fixed UTC equivalents; hourly-gating waits for Cycle 4.
+4. **No mass timestamptz conversion now.** New tables (`cycle_phases`,
+   `cycle_events`) are born TIMESTAMPTZ; the ~49 legacy naive columns stay
+   untouched until Cycle 4 (the irreversible per-column conversion is off the
+   critical path). The legacy mirror columns keep their current storage
+   convention, verified by test S5.1.
+5. **`anchor-events.ts` retires late.** It feeds the live agreement ceremony
+   (PR #226); `cycle_events` is seeded *from* it and the ceremony swaps data
+   source only when convenient — until then both must agree (single edit
+   point: the constant).
 
 ### Standing decisions (carried forward)
 
 - **DB strategy: hybrid.** Build/test against a reset **dev** DB; apply to
   **prod as forward-only migrations with backfill** (no prod reset).
 - **Rollout: phased PRs** in dependency order, not one big-bang.
-- **Migration numbering:** next free number is **00082** (`00078`–`00081` are
-  on `dev`); claim numbers per `CONTRIBUTING.md`.
-- **Tests:** dev already carries unit tests (`lib/owner/*.test.ts`) — extend
-  that harness for the three risk seams (window resolver incl. DST, tz
-  conversion round-trip, reconciler policy), don't invent a new one.
+- **Migration numbering:** `00078`–`00081` are taken on `dev`, **and open
+  PR #229 carries a colliding `00078_handle_desuffix`** (its base predates the
+  owner-lifecycle merge) — renumber it at merge time; `npm run
+  check:migrations` on a rebased branch catches it. Claim the next free
+  number per `CONTRIBUTING.md` at branch time.
+- **Tests:** dev already carries unit tests (`lib/owner/*.test.ts`, 255+
+  passing per the fix-train PRs) — extend that harness for the risk seams
+  (window resolver, storage-convention round-trip, reconciler policy).
 
-## Phase 0 — Independent cleanups (small; safe during Cycle 3)
+## Stage 0 — before Kickoff (by Jul 13) — ops only, no schema
 
-- **Re-schedule the revocation cron** (`app/api/cron/revocation-check`) in
-  `vercel.json` — it has been unscheduled since PR #108; its current gate
-  (after `pod_registration_close`) is safe under today's single-window model.
-  Verify the two-stage warn→grace behavior against Cycle 3 config first.
-- Seed `cycle_events`-precursor data? **No** — do nothing speculative; the
-  timeline phase owns schema. Phase 0 is ops-only.
-- (Dropped from the June plan: the `testing-controls.tsx` `>`-vs-`>=` "bound
-  bug" — the current code is internally consistent; and the duplicate-`00015`
-  fix — renumbered to `00028` on 2026-06-02.)
+- **Merge the July-11 fix train (#224–#230, rebased, in order)** and promote
+  `dev → main`; these fixes (vote budgets/stacking, checklist gating, ceremony
+  dates, funnel prefill, pulse-leak fix) are launch-day behavior.
+- Run the **S5.1 window-entry convention test** and enter Cycle 3's decided
+  windows using it; complete the S1 handover rehearsal (close Cycle 2 →
+  activate Cycle 3) on staging, then execute for real.
+- **Leave the revocation cron unscheduled for now** (revised from the June
+  "re-schedule it" item): scheduling its "in no pods" arm before the
+  active-join window exists opens the orphan dead-zone ~Jul 29–Aug 18. It
+  gets scheduled in Stage 2 together with the gate move.
+- Confirm `cycle_config` values: `pod_min`, **`pod_limit` (1 vs 2 — product
+  call)**, `submitter_votes`/`non_submitter_votes`, milestone weeks.
 
-## Phase 1 — Cycle timeline (foundation; targets Cycle 4)
+## Stage 1 — calendar schema + resolver (land by ~Jul 24, before the Sprint)
 
-Per [`cycle-timeline.md`](./cycle-timeline.md). Everything else anchors here.
+Per [`cycle-timeline.md`](./cycle-timeline.md), minus the deferred items above.
 
-1. Schema (`00082+`): `cycles.start_at` (+ derived `end_at`),
-   `metros.timezone`, `cycle_phases`, `cycle_events`; migrate window columns →
-   phase rows (split `pod_registration` → `pod_forming` + `pod_active_join`);
-   migrate `phase_2/3_start` → event rows; per-column timestamptz conversion
-   (audit=UTC; scheduling=verified) — **dry-run on a prod clone first**.
-2. Schedule service (compute/recompute `starts_at`/`ends_at`; spine contiguous
-   by construction; overlays independent).
-3. Single tz-aware window resolver (extend `lib/auth/windows.ts`; new
-   `WindowField` keys; keep the org-mode reject) + **consolidate all ~22
-   inline-checking files onto it** (server-side resolution passed to pages).
-4. `advance-phase` → duration-override + recompute (keep `testing:use` gate).
-5. Re-anchor the week grid (`lib/cycle/week.ts` reads `start_at`; tz-aware
-   week boundaries); wire Luma sync → `cycle_events`; retire
-   `anchor-events.ts`; update `cycle-phase-indicator.tsx`; drop replaced
-   columns.
-6. FR-14 display tz + FR-15 cron-hour gating.
+1. Migration (next free number): `cycle_phases`, `cycle_events`,
+   `cycles.start_at` (backfill from `start_date` under the verified
+   convention), `metros.timezone`. Seed Cycle 3 rows (phases from the decided
+   windows; events from `anchor-events.ts`).
+2. Schedule service v1: boundary edits recompute downstream spine +
+   **mirror to legacy columns** (simplification 1).
+3. Resolver: `checkWindow` reads `cycle_phases` (tz-aware), gains the new
+   keys, keeps the org-reject and the #224 config-missing message. Migrate the
+   **critical-path pages** first: dashboard checklist row, join,
+   register-pods, propose, vote (the Sprint surface).
+4. `advance-phase`: keep gated as-is; do not use on the live cycle (testing
+   tool only). Full override/recompute UX is Cycle-4 polish.
 
-Verify: changing `start_at` shifts all boundaries + week grid; DST-crossing
-23:59 close closes at local 23:59; spine can't save overlapping; a cycle with
-`start_at == start_date` produces identical milestone timing; no
-`_open`/`_close` comparison outside the resolver.
+Gate: [`cycle3-testing-plan.md`](./cycle3-testing-plan.md) G2 (S4, S5.2–5.4,
+S6) green on staging against a prod clone before deploy; deploy in the quiet
+week (Jul 20–24), days before the Sprint.
 
-## Phase 2 — Pod registration (behavioral change; needs Phase 1)
+**Fallback:** if Stage 1 isn't green by Jul 24, the Sprint runs on manual
+columns exactly as today (the mirror means nothing user-facing depends on the
+new tables yet) — slip Stage 1 to the Jul 29–Aug 14 quiet stretch and keep
+Stage 2's date.
 
-Per [`pod-registration.md`](./pod-registration.md).
+## Stage 2 — two pod windows + lifecycle (land by ~Aug 14, before Meet the Pods)
 
-1. Register route checks the window matching pod status (`forming` →
-   `pod_forming`; `active` → `pod_active_join`); metro fence + `pod_limit`
-   unchanged.
-2. Reconciler policy change (enrollment decoupled from pod membership;
-   enrollment paths activate at enrollment time). Decide D-9 (retroactive
-   activation at cutover) before shipping.
-3. Forming-close boundary event: activate ≥ `pod_min`, **dissolve** the rest
-   (reuse `00063` status), free + notify orphans (notification is net-new).
-4. Move the revocation gate to `pod_active_join.ends_at`; confirm
-   revoked→rejoin reactivation works during active-join.
+Per [`pod-registration.md`](./pod-registration.md); needs Stage 1.
 
-Verify: join forming pod only in forming window (and vice versa); join/leave
-never touches enrollment status; sub-`pod_min` pod dissolves at forming close
-with members freed + notified; nobody warned/revoked before active-join close;
-project-layer interaction (last-day joiner can register a project) accepted.
+1. `pod_forming` / `pod_active_join` phase rows govern the register route
+   (window matching pod status); metro fence + `pod_limit` unchanged.
+2. Reconciler policy change (enrollment decoupled; enrollment paths activate
+   at enrollment time). Decide D-9 (retroactive activation for existing
+   `inactive` self-registrants) — recommended **yes** at cutover so the two
+   enrollment paths converge.
+3. Forming-close boundary event: activate ≥ `pod_min`, dissolve the rest
+   (reuse `00063` status), free + notify orphans. *(Note: with the Sprint on
+   Jul 28 and Stage 2 landing after it, Cycle 3's forming close is handled by
+   the current per-registration flip — the boundary event applies from
+   active-join close onward and for Cycle 4.)*
+4. Revocation cron: move the "in no pods" gate to `pod_active_join.ends_at`
+   **and schedule it** in `vercel.json` (fixed UTC hour ≈ 7 AM EDT).
+5. Migrate the remaining window pages (solutions, solution-vote,
+   register-projects, moderator views) to the resolver; drop the legacy
+   mirror + columns once the sweep is clean.
 
-## Phase 3 — Auth completion (largest call-site surface; lands last)
+Gate: G3 (S7 + active-join suite) green before Aug 17.
 
-Per [`permissions-redesign.md`](./permissions-redesign.md).
+## Stage 3 — auth completion (post-launch-crunch; no calendar dependency)
 
-1. Invitations → (role, scope): schema change, role-selector UI,
-   `fulfillInvitation` writes via `grantRole` + reconciler; translate or drain
-   in-flight pending invites (decide P-1).
-2. Drain `participant_permissions`: run the pre-drain audit; make
-   `capabilitiesForRoles` the sole `permissions[]` source; remove writers +
-   `00065` forward-sync triggers.
-3. Unify RLS: migrate the `has_permission()`/`is_admin_or_owner()` policy
-   family (~15 migrations) onto `is_admin()`/`is_owner()`/
-   `current_participant_id()`; drop legacy helpers, then
-   `participant_permissions` + `user_roles` (update `delete_participant`).
+Per [`permissions-redesign.md`](./permissions-redesign.md). Unchanged in
+content; start once Stages 0–2 are stable (September window is fine — nothing
+in Cycle 3 blocks on it):
 
-Verify: capability snapshot per participant identical before/after the drain;
-invitation acceptance produces only `participant_roles` + membership rows;
-grants attenuation tests pass; no reference to the legacy names remains.
+1. Invitations → (role, scope); translate/drain pending invites (P-1).
+2. Drain `participant_permissions` (pre-drain audit first).
+3. Unify RLS; drop legacy helpers + `user_roles`/`participant_permissions`.
 
 ## End-to-end verification
 
-1. Reset dev DB; seed a Cycle-4-shaped cycle from the template (Cycle 3 dates
-   as fixture) + owner/admin/lab_lead/participant fixtures.
-2. Run the seam tests (resolver/DST, tz round-trip, reconciler policy, grants).
-3. Walk the cycle: problem statement → voting → pod forming → forming-close
-   dissolution → active-join → project stage; assert enrollment status and
-   cron behavior at each boundary (especially: nobody revoked before
-   active-join close).
-4. Sub-cohort isolation: a lab pod only admits matching-metro participants;
-   lab_lead scope checks 403 on foreign labs.
-5. Dry-run every prod migration (esp. the tz conversion) against a prod clone
-   before applying.
+1. Staging = prod clone. Walk the full Cycle-3 calendar with the testing
+   plan's personas (P1–P11) at each gate.
+2. Seam tests: resolver bounds + storage-convention round-trip; reconciler
+   policy (Stage 2); grants attenuation (Stage 3).
+3. Dry-run every prod migration against the clone before applying; the Stage-1
+   migration is additive (new tables + nullable column) — rollback is a
+   drop, not a restore.
 
 ## Residual risks
 
-- **Per-column tz conversion** is the one irreversible data step — verify real
-  values per column; dry-run on a clone.
-- **Window consolidation** touches ~22 files during/near a live cycle — hence
-  the Cycle-4 targeting; land behind the resolver with unchanged semantics
-  first (naive→tz-aware flip is the schema migration moment, not the refactor
-  moment).
-- **Reconciler policy change** alters who counts as active mid-cycle if D-9 is
-  decided as retroactive — model the Cycle-3/4 boundary explicitly.
-- **Legacy-RLS unification** can silently widen/narrow row visibility —
-  policy-by-policy diff review + before/after query fixtures.
+- **Live-cycle deploys.** Stages 1–2 land inside a running cycle by design
+  (owner call). Mitigations: additive schema + dual-write mirror (old pages
+  never break), deploys in quiet stretches between anchor events, per-stage
+  fallback to manual columns.
+- **Sprint-night compression.** Jul 28's submit → vote → finalize → forming
+  chain runs inside ~3 hours with an admin in the loop — rehearse end-to-end
+  (S4.1) regardless of which stage has shipped.
+- **Metro fence vs. metro-less members** (S4.4): decide HQ-pods vs.
+  metro-backfill before Jul 28 — likeliest mass-failure of Sprint night.
+- **Reconciler policy change mid-cycle** (Stage 2): D-9 decision changes who
+  counts as active on real data; snapshot enrollment statuses before/after.
+- **Legacy-RLS unification** (Stage 3): policy-by-policy diff + before/after
+  fixtures, as before.

--- a/docs/requirements/implementation-plan.md
+++ b/docs/requirements/implementation-plan.md
@@ -1,0 +1,140 @@
+# OLOS Redesign — Sequenced Implementation Plan (2026-07 re-baseline)
+
+## Context
+
+The June 2026 plan sequenced four redesigns (`labs → timeline → pod-registration
+→ auth`) on the premise that none were built. Six weeks of shipping changed
+that premise (see [`pr231-evaluation.md`](./pr231-evaluation.md)):
+
+- **Labs**: shipped **differently** — metros + HQ-cycle sub-cohorts
+  (`00060`/`00062`/`00067`/`00068`). The labs phase is **dropped**;
+  [`local-labs.md`](./local-labs.md) is a superseded record.
+- **Auth storage**: shipped — `participant_roles` unification
+  (`00054`–`00066`). What remains is **finishing** it
+  ([`permissions-redesign.md`](./permissions-redesign.md)).
+- **Timeline**: not built; prod now runs **four** uncoordinated time models
+  ([`cycle-timeline.md`](./cycle-timeline.md)).
+- **Pod registration**: core change (two windows, decoupled enrollment) not
+  built; the enrollment seam (`lib/enrollment/reconciler.ts`) and a
+  phase-gated (but **unscheduled**) revocation cron shipped
+  ([`pod-registration.md`](./pod-registration.md)).
+
+**Timing constraint:** Cycle 3 starts **Jul 14, 2026** and runs on the manual
+window columns. Schema-touching timeline work targets **Cycle 4** (or a
+deliberately-decided mid-cycle retrofit); nothing below may disrupt a live
+formation window.
+
+### Standing decisions (carried forward)
+
+- **DB strategy: hybrid.** Build/test against a reset **dev** DB; apply to
+  **prod as forward-only migrations with backfill** (no prod reset).
+- **Rollout: phased PRs** in dependency order, not one big-bang.
+- **Migration numbering:** next free number is **00082** (`00078`–`00081` are
+  on `dev`); claim numbers per `CONTRIBUTING.md`.
+- **Tests:** dev already carries unit tests (`lib/owner/*.test.ts`) — extend
+  that harness for the three risk seams (window resolver incl. DST, tz
+  conversion round-trip, reconciler policy), don't invent a new one.
+
+## Phase 0 — Independent cleanups (small; safe during Cycle 3)
+
+- **Re-schedule the revocation cron** (`app/api/cron/revocation-check`) in
+  `vercel.json` — it has been unscheduled since PR #108; its current gate
+  (after `pod_registration_close`) is safe under today's single-window model.
+  Verify the two-stage warn→grace behavior against Cycle 3 config first.
+- Seed `cycle_events`-precursor data? **No** — do nothing speculative; the
+  timeline phase owns schema. Phase 0 is ops-only.
+- (Dropped from the June plan: the `testing-controls.tsx` `>`-vs-`>=` "bound
+  bug" — the current code is internally consistent; and the duplicate-`00015`
+  fix — renumbered to `00028` on 2026-06-02.)
+
+## Phase 1 — Cycle timeline (foundation; targets Cycle 4)
+
+Per [`cycle-timeline.md`](./cycle-timeline.md). Everything else anchors here.
+
+1. Schema (`00082+`): `cycles.start_at` (+ derived `end_at`),
+   `metros.timezone`, `cycle_phases`, `cycle_events`; migrate window columns →
+   phase rows (split `pod_registration` → `pod_forming` + `pod_active_join`);
+   migrate `phase_2/3_start` → event rows; per-column timestamptz conversion
+   (audit=UTC; scheduling=verified) — **dry-run on a prod clone first**.
+2. Schedule service (compute/recompute `starts_at`/`ends_at`; spine contiguous
+   by construction; overlays independent).
+3. Single tz-aware window resolver (extend `lib/auth/windows.ts`; new
+   `WindowField` keys; keep the org-mode reject) + **consolidate all ~22
+   inline-checking files onto it** (server-side resolution passed to pages).
+4. `advance-phase` → duration-override + recompute (keep `testing:use` gate).
+5. Re-anchor the week grid (`lib/cycle/week.ts` reads `start_at`; tz-aware
+   week boundaries); wire Luma sync → `cycle_events`; retire
+   `anchor-events.ts`; update `cycle-phase-indicator.tsx`; drop replaced
+   columns.
+6. FR-14 display tz + FR-15 cron-hour gating.
+
+Verify: changing `start_at` shifts all boundaries + week grid; DST-crossing
+23:59 close closes at local 23:59; spine can't save overlapping; a cycle with
+`start_at == start_date` produces identical milestone timing; no
+`_open`/`_close` comparison outside the resolver.
+
+## Phase 2 — Pod registration (behavioral change; needs Phase 1)
+
+Per [`pod-registration.md`](./pod-registration.md).
+
+1. Register route checks the window matching pod status (`forming` →
+   `pod_forming`; `active` → `pod_active_join`); metro fence + `pod_limit`
+   unchanged.
+2. Reconciler policy change (enrollment decoupled from pod membership;
+   enrollment paths activate at enrollment time). Decide D-9 (retroactive
+   activation at cutover) before shipping.
+3. Forming-close boundary event: activate ≥ `pod_min`, **dissolve** the rest
+   (reuse `00063` status), free + notify orphans (notification is net-new).
+4. Move the revocation gate to `pod_active_join.ends_at`; confirm
+   revoked→rejoin reactivation works during active-join.
+
+Verify: join forming pod only in forming window (and vice versa); join/leave
+never touches enrollment status; sub-`pod_min` pod dissolves at forming close
+with members freed + notified; nobody warned/revoked before active-join close;
+project-layer interaction (last-day joiner can register a project) accepted.
+
+## Phase 3 — Auth completion (largest call-site surface; lands last)
+
+Per [`permissions-redesign.md`](./permissions-redesign.md).
+
+1. Invitations → (role, scope): schema change, role-selector UI,
+   `fulfillInvitation` writes via `grantRole` + reconciler; translate or drain
+   in-flight pending invites (decide P-1).
+2. Drain `participant_permissions`: run the pre-drain audit; make
+   `capabilitiesForRoles` the sole `permissions[]` source; remove writers +
+   `00065` forward-sync triggers.
+3. Unify RLS: migrate the `has_permission()`/`is_admin_or_owner()` policy
+   family (~15 migrations) onto `is_admin()`/`is_owner()`/
+   `current_participant_id()`; drop legacy helpers, then
+   `participant_permissions` + `user_roles` (update `delete_participant`).
+
+Verify: capability snapshot per participant identical before/after the drain;
+invitation acceptance produces only `participant_roles` + membership rows;
+grants attenuation tests pass; no reference to the legacy names remains.
+
+## End-to-end verification
+
+1. Reset dev DB; seed a Cycle-4-shaped cycle from the template (Cycle 3 dates
+   as fixture) + owner/admin/lab_lead/participant fixtures.
+2. Run the seam tests (resolver/DST, tz round-trip, reconciler policy, grants).
+3. Walk the cycle: problem statement → voting → pod forming → forming-close
+   dissolution → active-join → project stage; assert enrollment status and
+   cron behavior at each boundary (especially: nobody revoked before
+   active-join close).
+4. Sub-cohort isolation: a lab pod only admits matching-metro participants;
+   lab_lead scope checks 403 on foreign labs.
+5. Dry-run every prod migration (esp. the tz conversion) against a prod clone
+   before applying.
+
+## Residual risks
+
+- **Per-column tz conversion** is the one irreversible data step — verify real
+  values per column; dry-run on a clone.
+- **Window consolidation** touches ~22 files during/near a live cycle — hence
+  the Cycle-4 targeting; land behind the resolver with unchanged semantics
+  first (naive→tz-aware flip is the schema migration moment, not the refactor
+  moment).
+- **Reconciler policy change** alters who counts as active mid-cycle if D-9 is
+  decided as retroactive — model the Cycle-3/4 boundary explicitly.
+- **Legacy-RLS unification** can silently widen/narrow row visibility —
+  policy-by-policy diff review + before/after query fixtures.

--- a/docs/requirements/local-labs.md
+++ b/docs/requirements/local-labs.md
@@ -1,0 +1,66 @@
+# Requirements — Local Labs (Multi-Tenancy)
+
+| | |
+|---|---|
+| **Status** | **Superseded — implemented differently** (2026-07 re-baseline; see [`pr231-evaluation.md`](./pr231-evaluation.md)) |
+| **Last updated** | 2026-07-12 |
+| **What shipped instead** | `metros` promotion + HQ-cycle sub-cohorts: migrations `00060`, `00062_local_labs`, `00067_hq_open_cycle_sub_cohorts`, `00068_pods_local` |
+| **Live remnant** | A timezone home — picked up by [`cycle-timeline.md`](./cycle-timeline.md) |
+
+## What this doc proposed (June 2026)
+
+A new `labs` root table **above** cycles: every cycle and every participant would
+carry a `NOT NULL lab_id`, all existing rows backfilled to a single "DC" lab, and
+each lab would run its own cycles.
+
+## What actually shipped (July 2026) — the opposite hierarchy
+
+The codebase answered the multi-tenancy question differently, and the shipped
+model **contradicts this doc's core premise**. Do not build from this doc; the
+record below is kept so the divergence is explicit.
+
+- **No `labs` table.** The existing **`metros`** table (public "Local Labs"
+  content, `00033`) was promoted into the organizational lab anchor
+  (`00062_local_labs`): `slug`/`name`/`st`/`status ('active'|'waitlist')`/
+  `zip_prefixes`/`is_default`. A participant's lab is **`participants.metro_id`**
+  (nullable), not `lab_id`.
+- **Labs are sub-cohorts *inside* the cycle, not parents *above* it.**
+  Open-mode is a **single HQ-run cycle**; `00067` folds any per-lab open cycle
+  into the HQ stream and adds the CHECK `cycles_open_is_hq_when_live` —
+  a live open cycle is *forbidden* from having a `lab_id`. A pod's lab lives on
+  **`pods.lab_id`** (its host sub-cohort), and `00068` fences membership:
+  active open-mode lab pods only admit participants whose `metro_id` matches.
+- **Per-lab cycles exist only for `mode='org'`** (internal team cycles,
+  `00060`/`00062`: `one_active_org_cycle_per_lab`).
+- **Lab leadership** is a role grant: `participant_roles(role='lab_lead',
+  lab_id=…)` (the `lab_leads` table from `00062` was folded into the unified
+  role model by `00064`/`00065`). The app seam is `lib/auth/lab.ts`
+  (`requireLabAccess`, `labForCycle`, `labForPod`) — the "single shared
+  lab-scoping helper" this doc asked for exists in that form.
+- **No backfill to "DC id 1" ever ran**; metro membership is assigned through
+  registration/directory flows instead.
+
+See `SCHEMA.md` for the current shapes.
+
+## The one live remnant: a timezone home
+
+This doc placed `timezone` on `labs`. No timezone column exists anywhere in the
+schema today, and the cycle-timeline work still needs one. Since a live open
+cycle has no lab FK, the June rule "a cycle uses its lab's timezone" no longer
+has a path. Recommendation, carried into
+[`cycle-timeline.md`](./cycle-timeline.md):
+
+- Add **`metros.timezone TEXT`** (IANA, default `America/New_York`).
+- The **cycle schedule** renders/computes in the HQ default zone; **sub-cohort
+  surfaces** (a lab pod's pages, lab-scoped comms) may resolve
+  `pods.lab_id → metros.timezone` for display. Today every metro is US-Eastern,
+  so the default is correct everywhere; the column makes the first non-Eastern
+  metro a data change, not a schema change.
+
+## Decisions log
+
+- **2026-06-17** — (original) `labs` above cycles; backfill to DC; timezone on
+  the lab. **Superseded by shipped code (00060/00062/00067/00068).**
+- **2026-07-12** — Doc re-baselined: keep as a superseded record; the timezone
+  question moves to `cycle-timeline.md` with `metros.timezone` as the
+  recommended home.

--- a/docs/requirements/per-lab-configuration.md
+++ b/docs/requirements/per-lab-configuration.md
@@ -1,0 +1,79 @@
+# Requirements — Per-Metro Configuration Management (LATER)
+
+| | |
+|---|---|
+| **Status** | **Deferred — not scheduled.** Pick up when a second **active metro sub-cohort** needs values that differ from the HQ defaults. |
+| **Last updated** | 2026-07-12 (re-baselined on the shipped metros model; original 2026-06-17) |
+| **Related code** | `metros` (`00033`, `00038`, `00062`), `option_lists` (`00012`), `lib/email/` |
+| **Related docs** | [`local-labs.md`](./local-labs.md) (superseded record of the shipped metros/sub-cohort model), [`permissions-redesign.md`](./permissions-redesign.md) |
+
+> **Why this is separate and deferred.** The multi-tenancy that shipped
+> (`metros` as lab anchor; labs as sub-cohorts of the single HQ open cycle —
+> see [`local-labs.md`](./local-labs.md)) intentionally leaves configuration
+> **global**: one set of option lists, integrations, and branding. With one
+> effective tenant there is nothing to differentiate. This doc captures the
+> config work for when a real second active metro arrives.
+
+## Trigger to pick this up
+
+A second metro sub-cohort is being onboarded **and** it needs at least one of:
+different form options, its own Slack/Drive/GitHub, or its own branding. Until
+then, everything below stays global and this doc is reference only.
+
+## Current state (until then)
+
+All of the following are **global** — one shared value across metros:
+
+- `option_lists` — registration dropdowns (sectors, work situations,
+  neighborhoods, etc.) are one shared set.
+- Provisioning targets — pods/projects create Slack channels, Drive folders, and
+  GitHub repos under one shared workspace/org/drive.
+- Branding — one name, logo, color set, and email sender (The Upskilling Labs).
+- (Once `metros.timezone` lands per [`cycle-timeline.md`](./cycle-timeline.md),
+  timezone becomes the first genuinely per-metro config value.)
+
+## Config dimensions to make per-metro (when triggered)
+
+Each is independent — adopt only the ones a new metro actually needs.
+
+### 1. Per-metro option lists
+- **Why:** chapters in different cities have different valid values (e.g.
+  neighborhoods, local sectors).
+- **Change:** add `option_lists.metro_id` (nullable → `NULL` means "global
+  default", set means "this metro overrides"). Resolution: a metro's effective
+  list = its own rows, falling back to global where it has none. Admin UI under
+  the metro to edit its lists.
+- **Migration:** existing rows stay `metro_id = NULL` (remain global); no data
+  moves.
+
+### 2. Per-metro integration / provisioning targets
+- **Why:** each chapter may have its own Slack workspace, Google Drive, and
+  GitHub org.
+- **Change:** a `metro_integrations` config (per metro: Slack workspace/token,
+  Drive root folder, GitHub org). Provisioning code reads the **pod's metro**
+  (`pods.lab_id`, per `00067`/`00068` — a live open cycle has no lab of its
+  own) to decide where to create channels/folders/repos. Secrets handled like
+  existing integration credentials (not in the table in plaintext).
+- **Risk:** this is the heaviest item — touches every provisioning path and the
+  credential model. Scope carefully when it lands.
+
+### 3. Per-metro branding
+- **Why:** chapters may present as distinct brands in UI and email.
+- **Change:** per-metro `name`, `logo_url`, theme colors, and email sender/from
+  address. UI and `lib/email/` read the active metro's branding. Sender domains
+  must still be verified in Resend (SPF/DKIM) per metro.
+
+## Out of scope even then
+
+- Cross-metro sharing of option lists/templates (each metro is independent).
+- Self-serve metro creation/branding by lab leads — metro creation stays
+  admin/owner-only.
+
+## Open decisions (revisit at trigger time)
+
+- **Override vs. replace** for option lists — does a metro's list *extend/
+  override* the global defaults (recommended: `metro_id NULL` = fallback) or
+  fully replace them?
+- **Credential storage** for per-metro Slack/Drive/GitHub — env-based per metro
+  vs. a secrets manager; do not store tokens in plaintext columns.
+- **Branding granularity** — just logo + sender, or full theming?

--- a/docs/requirements/permissions-redesign.md
+++ b/docs/requirements/permissions-redesign.md
@@ -1,0 +1,181 @@
+# Requirements — Finish the Authorization Unification
+
+| | |
+|---|---|
+| **Status** | Draft — for review (**re-baselined 2026-07-12**; original 2026-06-17 proposal largely shipped via the 00054–00066 unification — see [`pr231-evaluation.md`](./pr231-evaluation.md)) |
+| **Baseline** | `participant_roles` is the authority source of truth (migrations `00054`, `00058`, `00064`, `00065`, `00066`; `lib/auth/roles.ts`, `lib/auth/grants.ts`, `lib/auth/CLAUDE.md`) |
+| **Related code** | `lib/auth/`, `app/api/invitations/*`, `app/api/auth/callback/route.ts`, `supabase/migrations/00009` (legacy PBAC), RLS policies across `00017`–`00074` |
+| **Related docs** | [`local-labs.md`](./local-labs.md) (superseded record of the metros model), `docs/personas.md` |
+
+## Overview
+
+The June 2026 version of this doc proposed replacing the PBAC model
+(permission strings + role presets) with a **relationship-based (role, scope)**
+model. That destination **substantially shipped** in July, under different
+names than proposed:
+
+- **`participant_roles`** — one table recording `(participant, role)` with
+  typed scope columns `cycle_id` / `pod_id` / `lab_id` / `project_id`, plus
+  provenance (`granted_by`) and history (`revoked_at`). Wider role vocabulary
+  than the June 3-role model: `owner, admin, developer, observer, poderator,
+  lab_lead, co_lead, member, dri, contributor, staff, tester, upskiller,
+  volunteer, mentor, events` (`00064`).
+- **One source of truth for app AND database.** `resolveUserRoles` and the DB
+  RLS helpers `is_admin()` / `is_owner()` read the same table (`00058`,
+  `00064`), so app and DB cannot disagree about who is admin/owner.
+- **Scope-aware seams** exist: `lib/auth/lab.ts` (`requireLabAccess`,
+  `labForCycle`, `labForPod`), `lib/auth/moderator.ts`
+  (`requireModeratorForPod`), `lib/auth/projects.ts` (`isProjectDri`,
+  `isProjectMember`).
+- **Governed grants**: all role writes go through `lib/auth/grants.ts`
+  (`canGrant`/`grantRole`/`revokeRole` with scope attenuation), backed by the
+  DB `guard_owner_grant` trigger and the rooted owner tree (`00066`).
+
+**What this doc now covers is the unfinished half:** the legacy PBAC surfaces
+that are still alive alongside the unified model. Until they are drained, the
+system is split-brained — two places to update, two ways to drift.
+
+## Current state (as-is, July 2026) — what's still legacy
+
+1. **Invitations still speak PBAC.** `invitations` rows carry `permissions
+   TEXT[]` + `role_preset` (+ `cycle_id`/`pod_id`/`pod_role`). On acceptance,
+   `fulfillInvitation` (`lib/auth/invitations.ts`) upserts
+   `participant_permissions` rows and writes legacy `user_roles` — new people
+   enter through the old door, and forward-sync triggers (`00065`) mirror them
+   into `participant_roles` after the fact.
+2. **Granular capabilities still read `participant_permissions`.**
+   `resolveUserRoles` unions role-derived capabilities
+   (`capabilitiesForRoles`, `lib/auth/permissions.ts`) with legacy per-person
+   rows. The role→capability derivation exists but the legacy table is still
+   load-bearing.
+3. **RLS is split-brained.** Newer policies use `is_admin()`/`is_owner()`
+   (read `participant_roles`); an older family still uses `has_permission()`
+   and `is_admin_or_owner()` (read `participant_permissions`; note `00009`
+   redefined `is_admin_or_owner()` as `has_permission('cycles:write')`).
+   The legacy family appears in ~15 migrations (`00017`, `00020`, `00021`,
+   `00023`, `00024`, `00029`, `00062`, `00070`–`00074`, …).
+4. **`user_roles` is written but never read** for authority (audit-trail
+   writes on invite fulfillment; deleted by `delete_participant`).
+
+## Goals
+
+- One authority model end to end: `participant_roles` + the grants path, with
+  no legacy write or read paths left.
+- Invitations express **who you'll be** (role + scope), not a permission list.
+- One RLS helper family; drop the PBAC helpers and tables.
+- No behavior change for existing users at each step (verified by comparing
+  resolved capabilities before/after).
+
+## Non-goals
+
+- Redesigning the role vocabulary or the grants/attenuation rules — they
+  shipped and work.
+- A separate cycle-scoped admin tier. Under the single-HQ-open-cycle model
+  (`00067`) cycle-admin ≈ global admin, and `lab_lead` covers sub-cohorts.
+  Revisit only if genuinely parallel cycles return.
+- Changing the Google-OAuth sign-in flow or invitation delivery (Resend).
+
+## Functional requirements (in build order)
+
+### FR-1 — Invitations carry (role, scope)
+
+- Replace `permissions[]` + `role_preset` on `invitations` with `role`
+  (values from the `participant_roles` CHECK) + the existing scope columns
+  (`cycle_id`, `pod_id`; add `lab_id` if lab_lead invites are wanted). Keep
+  `pod_role` semantics (`00060`: co_lead/member) — they map onto `role`.
+- `fulfillInvitation` writes through the **grants path** (`grantRole`) and the
+  membership/enrollment reconciler — no direct `participant_permissions` or
+  `user_roles` writes.
+- The invitation create/send UI offers a role selector (role + scope picker),
+  not a permission checklist or preset picker.
+- **In-flight `pending` invitations are a migration hazard**: translate
+  existing rows (`role_preset`→role; drop `permissions[]` after confirming
+  every pending row's permission set matches its preset) or drain them before
+  the cutover.
+
+### FR-2 — Drain `participant_permissions`
+
+- Make `capabilitiesForRoles` the only source of `permissions[]` on
+  `UserRoles`; stop unioning legacy rows once an audit confirms no live
+  participant holds a permission their roles don't imply
+  (see Pre-drain audit below).
+- Stop all writers: invitation fulfillment (FR-1), any admin permission-editor
+  endpoints/UI (`/api/permissions`, checklist editor) get removed or rebuilt
+  on roles; remove the `00065` forward-sync triggers.
+
+### FR-3 — Unify RLS
+
+- Migrate every policy using `has_permission()` / `is_admin_or_owner()` onto
+  `is_admin()` / `is_owner()` / `current_participant_id()` (+ membership
+  predicates), one migration that re-creates the affected policies.
+- Then drop `has_permission()`, `is_admin_or_owner()`, and finally the
+  `participant_permissions` and `user_roles` tables (after FR-1/FR-2 have
+  removed all writers/readers; update `delete_participant` accordingly).
+
+### FR-4 — Single seam hygiene (carryover, still worth enforcing)
+
+- Every authorization *decision* goes through `lib/auth/` (`isAdmin`,
+  `isOwner`, `requireLabAccess`, `requireModeratorForPod`, `isProjectDri`,
+  membership checks); no route re-derives authority from raw tables.
+- Service-role mutations are each guarded by *something* (route wrapper,
+  session identity, CRON_SECRET, invitation-state) — the standing exceptions
+  (`registrations`, `registrations/short`, `auth/callback`, crons) are
+  legitimate and stay.
+
+## Pre-drain audit (run before FR-2/FR-3 cutovers)
+
+Confirm no production participant has a live `participant_permissions` set
+that their `participant_roles` don't already imply:
+
+    SELECT p.id, p.email, pp.permission
+    FROM participant_permissions pp
+    JOIN participants p ON p.id = pp.participant_id
+    WHERE pp.revoked_at IS NULL
+      AND pp.permission NOT IN (
+        SELECT cap FROM (
+          -- expand capabilitiesForRoles for the participant's active roles
+          SELECT unnest(role_capabilities(pr.role)) AS cap
+          FROM participant_roles pr
+          WHERE pr.participant_id = p.id AND pr.revoked_at IS NULL
+        ) caps
+      );
+
+(Implement `role_capabilities` as a fixture mirroring
+`lib/auth/permissions.ts#ROLE_CAPABILITIES`, or run the equivalent check in a
+script against prod.) Non-empty ⇒ someone would lose a capability; grant the
+covering role (or add the capability to a role) before draining.
+
+## Acceptance criteria
+
+- A participant with only memberships does exactly what they do today.
+- Accepting an invitation produces `participant_roles` (+ membership/
+  enrollment) rows only; no new `participant_permissions` or `user_roles`
+  rows anywhere.
+- `resolveUserRoles` produces identical `permissions[]` for every live
+  participant before and after the drain (snapshot comparison).
+- No migration or code references `has_permission`, `is_admin_or_owner`,
+  `ROLE_PRESETS`, or `participant_permissions` when done.
+- Grants/attenuation behavior unchanged (`lib/auth/grants.ts` tests pass).
+
+## Decisions log
+
+- **2026-06-17** — (original) PBAC → relationship-based (role, scope) model.
+  **Destination shipped 2026-07 as `participant_roles` + grants path**
+  (different names: no `role_assignments`, no `isSuperAdmin`/`with*AdminAuth`;
+  typed scope columns instead of polymorphic `scope_type`/`scope_id`).
+- **2026-06-17** — observer→admin backfill concern. **Moot** — `00065` ran the
+  actual backfill (role-preserving; observers stayed observers).
+- **2026-07-12** — Re-scoped this doc to the remaining work: invitations →
+  (role, scope); drain `participant_permissions`; unify RLS; then drop legacy
+  tables. Cycle-admin tier explicitly not pursued (single-HQ-cycle model).
+
+## Open decisions
+
+- **P-1** — Does any *pending* invitation carry a permission set that doesn't
+  match its preset? (Determines translate-vs-drain in FR-1.)
+- **P-2** — Keep `observer` as a read-only role with its own capability set in
+  `ROLE_CAPABILITIES`, or retire it? (It has a capability mapping today;
+  retiring is a separate product call.)
+- **P-3** — Order of FR-3 vs FR-2 completion: RLS unification can land before
+  the table drop but after writers stop; confirm no external tooling reads
+  `user_roles`/`participant_permissions` (scripts under `scripts/ops/`).

--- a/docs/requirements/pod-registration.md
+++ b/docs/requirements/pod-registration.md
@@ -1,0 +1,230 @@
+# Requirements — Pod Registration
+
+| | |
+|---|---|
+| **Status** | Draft — for review (**re-baselined 2026-07-12** against the reconciler + rewritten revocation cron; original 2026-06-17) |
+| **Related code** | `app/api/pods/[pod_id]/register/route.ts`, `lib/enrollment/reconciler.ts`, `lib/auth/windows.ts`, `app/api/cron/revocation-check/route.ts`, `lib/cycle/closeout.ts`, `app/(dashboard)/cycles/[cycle_id]/register-pods/` |
+| **Related docs** | [`cycle-timeline.md`](./cycle-timeline.md) (**prerequisite** — defines the two windows as phases), `SCHEMA.md` (Pod Layer) |
+
+## Overview
+
+Pod registration is being restructured to **separate two things that are
+currently fused**:
+
+1. **The ability to register** is split into **two windows keyed to pod
+   status** — a *forming* window (help assemble a pod) and a later *active*
+   window (join a pod that has already formed).
+2. **Pod membership stops driving cycle participation.** Joining a pod no
+   longer promotes a participant's `cycle_enrollments`; being an "active
+   participant" becomes its own phase-dependent rule.
+
+This is the surviving core of the June 2026 doc. Several of its premises have
+since been overtaken by shipped code — the re-baseline below states what is
+still true, what already changed, and what the redesign still has to do.
+
+## Current state (as-is, July 2026)
+
+- **Still one window.** Registration is gated on the single `pod_registration`
+  window via `checkWindow` (`register/route.ts`), for pods in
+  `forming`/`active` status alike.
+- **Join still drives enrollment — but through one seam now.** The old inline
+  side effects were centralized into `lib/enrollment/reconciler.ts`:
+  `reconcileEnrollmentActivation` (joiner/leaver), `reconcilePodMembers` (on
+  pod activation), `ensureActivePodMembership` (invite/co-lead path). The
+  *coupling* this doc removes still exists, but it now lives in exactly one
+  place — the redesign is a **policy change inside the reconciler**, not a
+  scavenger hunt for side effects.
+- **forming→active still flips at `pod_min`** inside the register route when a
+  forming pod reaches threshold.
+- **The pod cap is config, not code.** `cycle_config.pod_limit` (default
+  **1**, `00043`) — the June doc's "hardcoded 2" is gone; see D-4 (revised).
+- **Pods are metro-fenced.** `pods.lab_id` is the pod's sub-cohort; a trigger
+  (`00068_pods_local`) requires `participants.metro_id = pods.lab_id` for
+  active open-mode lab pods. Any new join path must respect the fence.
+- **Dissolution exists, but only at cycle close-out.** `00063` added the
+  terminal `dissolved` status, written by `lib/cycle/closeout.ts` when a cycle
+  is archived/closed. Nothing dissolves a sub-`pod_min` pod at the end of
+  forming.
+- **The revocation cron was rewritten — and unscheduled.**
+  `cron/revocation-check` is now phase-gated (its "in no pods" arm only fires
+  after `pod_registration_close`), two-stage (warn → 3-day grace → revoke,
+  `00030`), reconciler-driven, admin/owner-exempt, and cycle-scoped. But it is
+  **absent from `vercel.json`** (removed in PR #108); today it only runs if
+  invoked manually. Re-scheduling it is part of this work.
+- Org-mode cycles (`mode='org'`) have no formation windows at all
+  (`checkWindow` rejects them); everything here concerns open-mode.
+
+## Goals
+
+- Registration availability is governed by **explicit per-status windows**, not
+  by a single window plus a status side-channel.
+- A participant's cycle-participation status does **not** depend on whether
+  their pod formed.
+- The forming → active transition is an explicit, well-defined event (not a
+  side effect of an individual registration).
+
+## Non-goals
+
+- Changing how pods are created (voting finalize still seeds `forming` pods).
+- The project layer — `projects/[id]/register` already never touches
+  enrollment and requires active pod membership, so this change makes the two
+  layers *consistent*. One interaction to accept: with `pod_active_join`
+  overlapping project registration, a last-day pod joiner can immediately
+  register a project.
+- The metro fence (`00068`) — it stays exactly as is in both windows.
+
+> **Sequencing:** this change **depends on
+> [`cycle-timeline.md`](./cycle-timeline.md)** — the two windows are
+> `cycle_phases` rows, and the revocation gate reads the `pod_active_join`
+> boundary. Build order: timeline → pod-registration (see
+> [`implementation-plan.md`](./implementation-plan.md)).
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **forming** | A pod still assembling its initial membership. |
+| **active** | A pod that has formed (met the threshold) and is running. |
+| **inactive / dissolved** | Never formed (dissolved at forming-close), or ended with its cycle (close-out, `00063`). |
+| **forming window** | `pod_forming` phase — participants may join `forming` pods. |
+| **active window** | `pod_active_join` overlay phase — participants may join `active` pods (late/secondary joins). |
+
+## Target model
+
+### Pod lifecycle
+
+```
+forming ──(forming window closes; ≥ pod_min)──▶ active ──(cycle close-out)──▶ dissolved
+   └─────────────(< pod_min at forming close)──▶ dissolved (never formed)
+```
+
+- The **forming → active transition fires at the `pod_forming` phase
+  boundary** (D-1), not per-registration. The `pod_min` check moves out of the
+  register route into that boundary event.
+- Pods under `pod_min` at forming-close are **dissolved** — reusing `00063`'s
+  terminal status with a new trigger point (today only close-out writes it).
+  Members are freed and notified (D-6).
+
+### Two registration windows
+
+Registration is allowed when the window matching the pod's **current status**
+is open:
+
+| Pod status | Window required | Purpose |
+|---|---|---|
+| `forming` | `pod_forming` open | Assemble the pod toward `pod_min` (no per-pod max — D-3). |
+| `active` | `pod_active_join` open | Late/secondary joins into a formed pod. |
+| `inactive`/`dissolved` | — | Refused. |
+
+Both windows are **phases in the cycle timeline** (`pod_forming` spine,
+`pod_active_join` overlay — the overlay deliberately spans the project stage).
+`checkWindow`/its successor resolves both; the metro fence and
+`cycle_config.pod_limit` apply identically in both windows.
+
+### Cycle enrollment — phase-dependent (D-2)
+
+Pod joins/leaves **no longer promote or demote `cycle_enrollments`**.
+Concretely: the reconciler's activation policy changes from "in an active pod
+⇒ active" to:
+
+- **Before pods form** (through `pod_active_join` close): active = enrolled in
+  the open cycle. Enrollment paths (`interest`, `registrations`,
+  `registrations/short`, invite fulfillment) set/keep `status='active'`
+  directly — enrollment *is* activation pre-pods.
+- **After `pod_active_join` closes:** a participant must be in an active pod
+  to stay active; pod-less enrollees are handled by the revocation cron's
+  "in no pods" arm.
+
+### Revocation cron (delta from today)
+
+The cron's structure survives as-is (two-stage warn→grace→revoke,
+reconciler-driven, exemptions). Two changes:
+
+1. **Move the "in no pods" gate** from `pod_registration_close` to
+   **`pod_active_join.ends_at`** (read from `cycle_phases`). This closes the
+   orphan dead-zone: members freed by a forming-close dissolution have the
+   whole active-join window to land somewhere before any revocation.
+2. **Re-schedule it.** Add the cron back to `vercel.json` (it has been
+   unscheduled since PR #108); cadence and hour per
+   [`cycle-timeline.md`](./cycle-timeline.md) FR-15 (cycle-local morning).
+
+A participant revoked earlier must be reactivatable if they join a pod during
+`pod_active_join` (the reconciler already handles revoked→active transitions;
+verify this path).
+
+### Caps & constraints
+
+- Per-participant cap = **`cycle_config.pod_limit`** (default 1), enforced the
+  same in both windows (D-4, revised).
+- `UNIQUE(participant_id, pod_id)` still prevents double-joining; soft-delete
+  reactivation (`inactive_at`) stays.
+- **No per-pod maximum** (D-3) — only `pod_min` matters.
+- Metro fence (`00068`) applies in both windows.
+
+### Leave / switch
+
+Leaving (`DELETE`) is allowed whenever a window the participant qualifies for
+is open. Leaving no longer demotes enrollment (D-2). **Once a pod is active it
+stays active** even if a departure drops it below `pod_min` (D-5).
+
+## Functional requirements
+
+- **FR-1** Define `pod_forming` and `pod_active_join` phases in the timeline
+  (per [`cycle-timeline.md`](./cycle-timeline.md)); the window resolver gains
+  both keys, replacing `pod_registration`.
+- **FR-2** `POST /api/pods/[pod_id]/register` checks the window **matching the
+  pod's status** (`forming`→`pod_forming`; `active`→`pod_active_join`;
+  otherwise refuse). Metro fence and `pod_limit` unchanged.
+- **FR-3** Remove the register-route side effects: no `pod_min` flip, no
+  enrollment promotion. The reconciler's policy becomes phase-dependent (D-2);
+  enrollment paths set `active` at enrollment time.
+- **FR-4** A `pod_forming`-close boundary event activates pods ≥ `pod_min`
+  (via `reconcilePodMembers` semantics) and **dissolves** the rest, freeing
+  members (net-new trigger point for `00063`'s status).
+- **FR-5** Orphan notification: members of a dissolved pod are notified they
+  can join an active pod until `pod_active_join` closes. (Notification
+  mechanism is net-new — email via `lib/email/` is the available channel.)
+- **FR-6** Revocation cron: gate moves to `pod_active_join.ends_at`; cron
+  re-registered in `vercel.json`.
+- **FR-7** `register-pods/` UI shows the correct window state per pod status
+  and a clear message when neither window is open.
+
+## Acceptance criteria
+
+- During `pod_forming`, a participant can join a `forming` pod but not an
+  `active` one; vice-versa during `pod_active_join`.
+- Joining or leaving a pod never changes `cycle_enrollments.status`.
+- At forming-close, pods ≥ `pod_min` become active; the rest are `dissolved`,
+  their members freed and notified.
+- No pod-less enrollee is warned or revoked before `pod_active_join` closes;
+  after it closes, the two-stage warn→grace→revoke behavior applies as today.
+- A previously revoked participant who joins during `pod_active_join` is
+  reactivated.
+- The metro fence and `pod_limit` behave identically in both windows.
+
+## Decisions log
+
+- **2026-06-17** — Two status-keyed windows; decouple pod membership from
+  cycle participation; forming→active as an explicit boundary event.
+- **2026-06-17 (decision sweep)** — D-1 flip at forming close; D-2
+  phase-dependent activation; D-3 no per-pod max; D-5 active pods stay active;
+  D-6 orphans freed + notified; D-7 first-come self-serve (`preference_rank`
+  legacy-only).
+- **2026-07-12 (re-baseline)** — D-4 **revised**: the cap is
+  `cycle_config.pod_limit` (shipped `00043`, default **1**) — the June "2 pods
+  per cycle" decision is superseded; raising it is a config change, not code.
+- **2026-07-12 (re-baseline)** — The June stress-test's "rewrite the cron /
+  add an activation trigger" corrections are **partially shipped**: the cron
+  is already phase-gated + two-stage + reconciler-driven (but unscheduled);
+  activation policy lives in the reconciler. Remaining deltas are FR-3/FR-6.
+- **2026-07-12** — Dissolution reuses `00063`'s `dissolved` status with a new
+  forming-close trigger point (close-out dissolution unchanged).
+
+## Open decisions
+
+- **D-8** — Notification channel for dissolved-pod orphans: email only, or
+  also an in-app banner on `register-pods/`? (Email exists via `lib/email/`;
+  in-app is net-new.)
+- **D-9** — Should enrollment paths retroactively activate existing
+  `inactive` enrollees at cutover, or only apply the new rule to new
+  enrollments? (Affects the FR-3 migration moment mid-cycle.)

--- a/docs/requirements/pr231-evaluation.md
+++ b/docs/requirements/pr231-evaluation.md
@@ -56,7 +56,11 @@ indicator). A fourth model — hardcoded anchor events
 (`lib/cycles/anchor-events.ts`, interim pending the Luma cache `00035`) — must
 also fold into `cycle_events`. The rewrite keeps the June prescription and
 adds the fold-in plan for all four models, plus the timing note that Cycle 3
-(Jul 14) runs on manual columns and the derived timeline targets Cycle 4.
+(Jul 14) opens on manual columns; per the owner's 2026-07-12 decision the
+overhaul targets **Cycle 3, staged inside the cycle** (schema + resolver
+before the Jul 28 Sprint; pod windows before Aug 18 Meet the Pods). The
+June draft's Cycle-3 dates were themselves stale — the real calendar lives
+in `lib/cycles/anchor-events.ts` (all-Tuesday cadence, evening events).
 
 ### Pod registration partially overtaken (→ `pod-registration.md` re-baselined, core kept)
 
@@ -91,7 +95,7 @@ unbuilt and is still the core ask.
 |---|---|
 | `local-labs.md` | Superseded record (shipped inverted); timezone remnant moved to timeline doc |
 | `permissions-redesign.md` | Re-scoped to "finish the unification": invitations → (role, scope); drain `participant_permissions`; unify RLS |
-| `cycle-timeline.md` | Kept (highest value); re-baselined on the four coexisting time models; targets Cycle 4 |
+| `cycle-timeline.md` | Kept (highest value); re-baselined on the four coexisting time models; targets Cycle 3, staged (owner decision 2026-07-12) |
 | `pod-registration.md` | Core kept (two windows, decoupling); rewritten around the reconciler + rewritten/unscheduled cron |
 | `per-lab-configuration.md` | Still deferred; retargeted labs→metros |
 | `implementation-plan.md` | Rewritten: Phase 0 cleanups → timeline → pod-registration → auth completion |

--- a/docs/requirements/pr231-evaluation.md
+++ b/docs/requirements/pr231-evaluation.md
@@ -1,0 +1,97 @@
+# PR #231 Evaluation — why these docs were re-baselined (2026-07-12)
+
+The six requirement docs in this folder were originally drafted **2026-06-17**
+(PR #231), against a codebase whose migrations ended at `00019`. By the time
+they came up for review, prod stood at migration `00077` (`00081` on `dev`) and
+had independently answered several of the questions the docs posed — twice in
+ways that contradict them. This note records the audit that drove the rewrite,
+so reviewers don't need to diff against #231.
+
+## What the audit checked
+
+Prod code (`main`, 2026-07-11) — all migrations `00001`–`00077`, `lib/auth/*`,
+`lib/cycle/*`, `lib/enrollment/reconciler.ts`, `lib/auth/windows.ts`, the
+window-checking UI pages, cron routes + `vercel.json`, `SCHEMA.md`.
+
+## Findings that changed the docs
+
+### Multi-tenancy shipped **inverted** (→ `local-labs.md` superseded)
+
+The June docs put labs *above* cycles (every cycle gets a `NOT NULL lab_id`).
+What shipped is the opposite: no `labs` table — `metros` was promoted
+(`00062`); open-mode is a **single HQ cycle with labs as sub-cohorts**
+(`00067` adds a CHECK forbidding a live open cycle from having a `lab_id`;
+`pods.lab_id` carries the sub-cohort; `00068` fences pod membership by
+participant metro). Only `mode='org'` cycles are per-lab. The one live remnant
+is the missing **timezone home**, moved to `cycle-timeline.md` as
+`metros.timezone`.
+
+### The auth redesign ~70% shipped under different names (→ `permissions-redesign.md` re-scoped)
+
+The proposed `role_assignments(role, scope_type, scope_id)` landed as
+**`participant_roles`** with typed scope FKs (`cycle_id`/`pod_id`/`lab_id`/
+`project_id`), provenance, and revocation history (`00054`/`00058`/`00064`/
+`00065`/`00066`), read by both `resolveUserRoles` and the RLS helpers
+`is_admin()`/`is_owner()` — plus a governed grants path
+(`lib/auth/grants.ts`, `guard_owner_grant`, rooted owner tree) the June doc
+didn't specify. Still genuinely open, now the doc's whole scope:
+**invitations still carry `permissions[]` + `role_preset`** (and fulfillment
+still writes `participant_permissions` + `user_roles`); granular capabilities
+still read `participant_permissions`; **RLS is split-brained** between the
+legacy `has_permission()`/`is_admin_or_owner()` family (~15 migrations) and
+the new helpers. The June backfill/observer-escalation machinery is moot —
+`00065` already ran a role-preserving backfill.
+
+### The timeline scaffolding was never built — and a fourth time model appeared (→ `cycle-timeline.md` re-baselined, kept)
+
+No `cycle_phases`, `cycle_events`, `cycles.start_at`, schedule service, or
+timezone column exists. The June complaints all still hold (12 naive window
+columns; `checkWindow` naive with 6 keys; inline `now >= open && now <= close`
+in the UI — now ~131 `_open`/`_close` hits across ~22 files; `advance-phase`
+still hardcodes 24h). But two June claims were already false at merge time:
+`cycles.start_date`/`end_date` **are** read (they drive the shipped 12-week
+calendar — `lib/cycle/week.ts` + `00047` milestone weeks + `00048`), and
+`phase_2_start`/`phase_3_start` are **not dead** (they drive the phase
+indicator). A fourth model — hardcoded anchor events
+(`lib/cycles/anchor-events.ts`, interim pending the Luma cache `00035`) — must
+also fold into `cycle_events`. The rewrite keeps the June prescription and
+adds the fold-in plan for all four models, plus the timing note that Cycle 3
+(Jul 14) runs on manual columns and the derived timeline targets Cycle 4.
+
+### Pod registration partially overtaken (→ `pod-registration.md` re-baselined, core kept)
+
+Still true: one `pod_registration` window; joining still drives enrollment and
+still flips forming→active at `pod_min` — but through one seam now
+(`lib/enrollment/reconciler.ts`), which turns the June "hunt down side
+effects + build an activation trigger" into a contained policy change.
+Overtaken: the "hardcoded 2-pod cap" is `cycle_config.pod_limit` (default
+**1**, `00043`); pod **dissolution exists** (`00063`) but only fires at cycle
+close-out; the revocation cron was **rewritten** (phase-gated after
+`pod_registration_close`, two-stage warn→grace→revoke, reconciler-driven) —
+and is **unscheduled** (absent from `vercel.json` since PR #108), which is a
+standalone operational gap. The two-window forming/active-join split remains
+unbuilt and is still the core ask.
+
+### Stale specifics corrected across the set
+
+- Duplicate migration `00015` — renumbered to `00028` on 2026-06-02; the next
+  free number is `00082`, not `00020`.
+- The `testing-controls.tsx` `>`-vs-`>=` "bound bug" — current code is
+  internally consistent; dropped from the plan.
+- "No test infra exists" — `dev` carries unit tests under `lib/owner/`;
+  extend, don't invent.
+- The June dependency order (`labs → timeline → pod-registration → auth`)
+  collapses to **timeline → pod-registration → auth-completion** (labs phase
+  dropped; auth storage done), with an ops-only Phase 0 (re-schedule the
+  revocation cron).
+
+## Disposition summary
+
+| Doc | Disposition |
+|---|---|
+| `local-labs.md` | Superseded record (shipped inverted); timezone remnant moved to timeline doc |
+| `permissions-redesign.md` | Re-scoped to "finish the unification": invitations → (role, scope); drain `participant_permissions`; unify RLS |
+| `cycle-timeline.md` | Kept (highest value); re-baselined on the four coexisting time models; targets Cycle 4 |
+| `pod-registration.md` | Core kept (two windows, decoupling); rewritten around the reconciler + rewritten/unscheduled cron |
+| `per-lab-configuration.md` | Still deferred; retargeted labs→metros |
+| `implementation-plan.md` | Rewritten: Phase 0 cleanups → timeline → pod-registration → auth completion |


### PR DESCRIPTION
The 2026-06-17 requirement docs from PR #231, updated after auditing them
against prod (migrations 00001-00077):

- local-labs.md: marked superseded — multi-tenancy shipped inverted
  (metros + HQ-cycle sub-cohorts, 00060/00062/00067/00068); timezone
  remnant moved to cycle-timeline.md as metros.timezone.
- permissions-redesign.md: re-scoped to finishing the participant_roles
  unification — invitations to (role, scope), drain participant_permissions,
  unify the split-brained RLS helper families.
- cycle-timeline.md: prescription kept; current-state rewritten around the
  four coexisting time models (window columns, phase_2/3_start, week grid +
  milestone weeks, anchor-events/Luma) with a fold-in plan for each;
  targets Cycle 4.
- pod-registration.md: two-window split kept; enrollment decoupling
  rewritten as a reconciler policy change; cap corrected to
  cycle_config.pod_limit (default 1); notes the rewritten-but-unscheduled
  revocation cron.
- per-lab-configuration.md: still deferred; retargeted labs -> metros.
- implementation-plan.md: rewritten — Phase 0 cleanups (re-schedule
  revocation cron) -> timeline -> pod-registration -> auth completion.
- pr231-evaluation.md (new): audit record of what shipped differently and
  why each doc changed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LCufPv3hZS3wKK2xwZEDdp