### PR TITLE
Remove DC Public Library logo from footer

### DIFF
--- a/app/components/chrome/site-footers.tsx
+++ b/app/components/chrome/site-footers.tsx
@@ -95,8 +95,6 @@ export function OsFooter() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img className="p-levy" src="/assets/levy-strategic-design-white.png" alt="Levy Strategic Design" />
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img className="p-dcpl" src="/assets/dcpl-knockout-logo.png" alt="DC Public Library" />
-          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img className="p-superbloom" src="/assets/superbloom-white.png" alt="Superbloom Design" />
         </div>
         <p className="foot-fineprint">

--- a/app/globals.css
+++ b/app/globals.css
@@ -948,7 +948,6 @@ button:focus-visible {
   .foot-partners .lbl { color: var(--od3); margin-right: 4px; }
   .foot-partners img { width: auto; opacity: 0.8; }
   .foot-partners .p-levy { height: 36px; }
-  .foot-partners .p-dcpl { height: 44px; }
   .foot-partners .p-superbloom { height: 27px; }
   @media (max-width: 399px) { .foot-partners { gap: 16px 20px; } }
   .foot-fineprint { color: var(--od3); font-size: 13px; line-height: 20px; max-width: 80ch; margin-top: 28px; }


### PR DESCRIPTION
## What

Removes the DC Public Library partner logo from the site footer, so it no longer appears on any page.

## Changes

- Drop the `<img className="p-dcpl" ... alt="DC Public Library" />` partner logo from `OsFooter` in `app/components/chrome/site-footers.tsx` (the open-source footer rendered across public pages).
- Remove the now-unused `.foot-partners .p-dcpl` sizing rule from `app/globals.css`.
- Levy Strategic Design and Superbloom Design partner logos are left in place.

## Verify

<!-- How you checked it works — commands run, pages exercised, tests added. -->

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Database

- [x] No schema change, **or** a migration was added under `supabase/migrations/`
      (new number, `SCHEMA.md` updated). Prod migrations are applied by a maintainer.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WGGezrntbhXRjH9VqjgKZF)_