### PR TITLE
Prod: remove DC Public Library footer logo + "What this cycle is working on" section

### DIFF
--- a/app/(public)/build-cycles/page.tsx
+++ b/app/(public)/build-cycles/page.tsx
@@ -25,8 +25,8 @@ export const metadata = {
 };
 
 // The current cycle's public shape, inlined from the prototype's
-// cycles/data.js (CYCLE_PUBLIC + SITUATIONS). These constants move to the
-// `cycles` and `problem_situations` tables when the public cycle API lands
+// cycles/data.js (CYCLE_PUBLIC). These constants move to the
+// `cycles` table when the public cycle API lands
 // (docs/OLOS_BACKEND_CHANGES.md §2/§8).
 const CYCLE = {
   name: "Summer 2026",
@@ -54,11 +54,6 @@ const PHASES = [
   },
 ];
 
-const SITUATIONS = [
-  { title: "Benefits navigation dead-ends", owner: "DC Public Library" },
-  { title: "First-time voter information gap", owner: "League of Women Voters DC" },
-  { title: "Volunteer knowledge walks out the door", owner: "Civic Tech DC" },
-];
 
 const PROMISES: [string, string][] = [
   [
@@ -170,28 +165,6 @@ export default async function BuildCyclesPage() {
                       {ph.title} · {ph.when}
                     </div>
                     <p className="t-body ed-text">{ph.body}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </EdSection>
-
-          {/* What this cycle is working on — partner problems, a single-hierarchy list */}
-          <EdSection
-            eyebrow="What this cycle is working on"
-            heading="Real problems, brought by real partners."
-          >
-            <div className="ed-cols">
-              <div>
-                {SITUATIONS.map((si) => (
-                  <div className="kv" key={si.title}>
-                    <span className="t-body">
-                      {si.title}
-                      <span className="t-small" style={{ color: "var(--meta)" }}>
-                        {" "}
-                        · Brought by {si.owner}
-                      </span>
-                    </span>
                   </div>
                 ))}
               </div>

--- a/app/components/chrome/site-footers.tsx
+++ b/app/components/chrome/site-footers.tsx
@@ -95,8 +95,6 @@ export function OsFooter() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img className="p-levy" src="/assets/levy-strategic-design-white.png" alt="Levy Strategic Design" />
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img className="p-dcpl" src="/assets/dcpl-knockout-logo.png" alt="DC Public Library" />
-          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img className="p-superbloom" src="/assets/superbloom-white.png" alt="Superbloom Design" />
         </div>
         <p className="foot-fineprint">

--- a/app/globals.css
+++ b/app/globals.css
@@ -948,7 +948,6 @@ button:focus-visible {
   .foot-partners .lbl { color: var(--od3); margin-right: 4px; }
   .foot-partners img { width: auto; opacity: 0.8; }
   .foot-partners .p-levy { height: 36px; }
-  .foot-partners .p-dcpl { height: 44px; }
   .foot-partners .p-superbloom { height: 27px; }
   @media (max-width: 399px) { .foot-partners { gap: 16px 20px; } }
   .foot-fineprint { color: var(--od3); font-size: 13px; line-height: 20px; max-width: 80ch; margin-top: 28px; }


### PR DESCRIPTION
## What

Ships two changes straight to production (`main`) without the rest of `dev`'s pending work:

1. Removes the DC Public Library partner logo from the site footer.
2. Removes the "What this cycle is working on" section from the build-cycles page.

## Changes

- Cherry-picked the footer logo removal (`OsFooter` `p-dcpl` `<img>` + its `.foot-partners .p-dcpl` CSS rule) from `dev` — `app/components/chrome/site-footers.tsx`, `app/globals.css`.
- Removed the "What this cycle is working on" `EdSection` ("Real problems, brought by real partners.") and the now-unused `SITUATIONS` constant from `app/(public)/build-cycles/page.tsx`; updated the stale provenance comment.

## Verify

- [x] `npm run lint` passes (0 errors)
- [ ] `npm run test` — not run locally
- [x] `npm run build` passes

## Database

- [x] No schema change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WGGezrntbhXRjH9VqjgKZF)_