### PR TITLE
docs(requirements): D-10 — cycle registration tracks the pod windows

### DIFF
--- a/docs/requirements/cycle-timeline.md
+++ b/docs/requirements/cycle-timeline.md
@@ -215,6 +215,11 @@ weekday strictly after X; project-stage transitions at midnight, end-of-day):
 | Project proposal | Hackathon (Thu) | Tuesday after Hackathon | Aug 13 → Aug 18 |
 | Project voting | Tuesday after Hackathon | Thursday after Hackathon | Aug 18 → Aug 20 |
 | Project registration | Thursday after Hackathon | 2nd Tuesday after Hackathon | Aug 20 → Aug 25 |
+| Cycle registration (D-10, [`pod-registration.md`](./pod-registration.md)) | cycle opens (`upcoming`) | Pod forming close; **reopens** with Pod active-join | open → Jul 28 EOD · closed Jul 29–Aug 10 · Aug 11 → Aug 25 |
+
+> Cycle registration is **derived** from the two pod phases (open ⇔ before
+> forming close, or active-join open) — a resolver rule, not a spine phase
+> row. The dead-zone closed state must name the reopen date.
 
 > **Timing decision (2026-07-12, owner): the calendar overhaul targets
 > Cycle 3, staged inside the cycle.** Day 1 (Jul 14) runs on the manual window

--- a/docs/requirements/cycle3-testing-plan.md
+++ b/docs/requirements/cycle3-testing-plan.md
@@ -123,6 +123,8 @@ The riskiest untested moment happens **before** anyone joins anything.
 | S3.5 | P7 variant | Abandon funnel mid-way, return next day | Resumes/restarts cleanly; no half-created rows blocking re-entry |
 | S3.6 | P1/P2 | Kickoff-day dates audit (Jul 14) | Every surface that renders dates — ceremony, dashboard Key-dates card, cycle page, `.ics` download, phase indicator — shows the **owner-confirmed calendar** (Sprint Jul 25, Pods Aug 11, Hackathon Aug 13, Projects Sep 8). Prerequisites: the `anchor-events.ts` correction (#233) is deployed, AND prod's `cycle_config` windows + `phase_2_start`/`phase_3_start` + the Luma-synced events all match the same calendar — audit all three, they are separate sources |
 | S3.7 | P9 | Observer signs in | Sees read-only surfaces; **no pulse aggregates on the public pod page** (#225) |
+| S3.8 | P7 variant | Self-serve cycle registration **during the dead zone** (Jul 29–Aug 10, once D-10 ships) | Join surface closed with a message naming the **Aug 11 reopen**; agreement API refuses; invite path still works (S2.6) |
+| S3.9 | P7 variant | Self-serve cycle registration **during active-join** (Aug 11–25) and **after** it (Aug 26+) | In-window: enrolls, active per D-2, can join a pod immediately. After: closed; surface points at the next `upcoming` cycle if any |
 
 ## S4 — Joining a pod (G2; run the whole suite before Jul 25)
 

--- a/docs/requirements/implementation-plan.md
+++ b/docs/requirements/implementation-plan.md
@@ -100,6 +100,13 @@ Per [`cycle-timeline.md`](./cycle-timeline.md), minus the deferred items above.
    register-pods, propose, vote (the Sprint surface).
 4. `advance-phase`: keep gated as-is; do not use on the live cycle (testing
    tool only). Full override/recompute UX is Cycle-4 polish.
+5. **Cycle-registration gate (D-10, owner 2026-07-12)** — the join ceremony,
+   agreement route, and Register CTAs read the derived registration window
+   (open through `pod_forming` close; closed across the dead zone with the
+   reopen date named; open during `pod_active_join`; closed after). Ships
+   with Stage 1 because the first enforcement moment is **Jul 29** (dead-zone
+   open) — days after Stage 1's Jul 23 target. Invite path exempt. Tests
+   S3.8–S3.9.
 
 Gate: [`cycle3-testing-plan.md`](./cycle3-testing-plan.md) G2 (S4, S5.2–5.4,
 S6) green on staging against a prod clone before deploy; deploy in the quiet

--- a/docs/requirements/pod-registration.md
+++ b/docs/requirements/pod-registration.md
@@ -135,6 +135,28 @@ Concretely: the reconciler's activation policy changes from "in an active pod
   to stay active; pod-less enrollees are handled by the revocation cron's
   "in no pods" arm.
 
+### Cycle registration window — D-10 (owner, 2026-07-12)
+
+Self-serve **cycle** registration (the `/cycles/[id]/join` ceremony + the
+agreement route) stops being status-only and tracks the pod windows — open
+exactly when a new member can still land somewhere:
+
+- **Open** from the moment the cycle opens for registration (`upcoming`)
+  **through `pod_forming` close** (Cycle 3: through **Tue Jul 28 EOD**).
+- **Closed during the dead zone** between forming close and active-join
+  open (Cycle 3: **Jul 29 – Aug 10**) — the closed state names the reopen
+  date ("Registration reopens Aug 11 at Meet the Pods").
+- **Open again for the whole `pod_active_join` window** (Cycle 3:
+  **Aug 11 – Aug 25**).
+- **Closed after `pod_active_join` closes** for the running cycle; the join
+  surface points at the next `upcoming` cycle when one exists.
+
+Derived, not a new phase: registration-open ⇔ *(now ≤ `pod_forming.ends_at`)
+∨ (`pod_active_join` open)*, resolved from `cycle_phases` like any window.
+Invites are exempt (the invite path is admin-intent; S2.6 already covers a
+mid-cycle accept). This closes the D-2 orphan seam: no one can newly enroll
+"active" at a moment when no pod path will ever open for them.
+
 ### Revocation cron (delta from today)
 
 The cron's structure survives as-is (two-stage warn→grace→revoke,
@@ -188,6 +210,11 @@ stays active** even if a departure drops it below `pod_min` (D-5).
   re-registered in `vercel.json`.
 - **FR-7** `register-pods/` UI shows the correct window state per pod status
   and a clear message when neither window is open.
+- **FR-8** Cycle registration (join ceremony + agreement route + the
+  dashboard/cycles-page Register CTAs) is gated per D-10: open through
+  `pod_forming` close, closed in the dead zone (message names the reopen
+  date), open during `pod_active_join`, closed after — with the invite path
+  exempt.
 
 ## Acceptance criteria
 
@@ -219,6 +246,12 @@ stays active** even if a departure drops it below `pod_min` (D-5).
   activation policy lives in the reconciler. Remaining deltas are FR-3/FR-6.
 - **2026-07-12** — Dissolution reuses `00063`'s `dissolved` status with a new
   forming-close trigger point (close-out dissolution unchanged).
+- **2026-07-12 (owner)** — **D-10**: cycle registration is open from cycle
+  open through `pod_forming` close, closed across the dead zone, reopens for
+  `pod_active_join`, and closes with it. Derived from the pod phases — no new
+  phase row. (Previously undefined: registration was status-gated and never
+  closed, which would have fed late enrollees straight into the revocation
+  cron.)
 
 ## Open decisions
 


### PR DESCRIPTION
## What

Codifies the owner decision (2026-07-12) on when **cycle registration** is open, closing the gap left in the #233 specs where registration was status-gated and never closed — which would have fed post-Aug-25 registrants straight into the revocation cron's "in no pods" arm.

(Follow-up to #233 — this commit was pushed to its branch minutes after the merge, so it rides a fresh branch.)

## Changes

**The rule (D-10):** self-serve cycle registration is open exactly when a new member can still land in a pod —

| Period | Cycle 3 | Registration |
|---|---|---|
| Cycle opens → `pod_forming` close | now → **Jul 28 EOD** | **Open** |
| Dead zone | **Jul 29 – Aug 10** | **Closed** — message names the Aug 11 reopen |
| `pod_active_join` window | **Aug 11 – Aug 25** | **Open** |
| After active-join close | Aug 26+ | **Closed** — points at the next `upcoming` cycle |

Derived from the two pod phases (open ⇔ before forming close ∨ active-join open) — a resolver rule, not a new phase row. Invite path exempt.

- `pod-registration.md` — D-10 section, **FR-8** (gate on the join ceremony, agreement route, Register CTAs), decisions-log entry
- `cycle-timeline.md` — Cycle-registration row in the window table + derived-rule note
- `cycle3-testing-plan.md` — **S3.8** (dead-zone attempt → clean closed state, API refuses, invites work) and **S3.9** (active-join registration → active + can join a pod; post-Aug-25 → closed)
- `implementation-plan.md` — the gate ships in **Stage 1** (first enforcement moment is Jul 29, after Stage 1's Jul 23 target); nothing changes in prod before then

## Verify

- Docs-only; all cross-doc links and Cycle 3 dates match the owner-confirmed calendar in `cycle-timeline.md`.

- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] `npm run build` — docs only, no code paths touched

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX)_