### PR TITLE
docs(feedback): #11 out-of-city lab waitlist — what to collect

### DIFF
--- a/docs/feedback-running-list.md
+++ b/docs/feedback-running-list.md
@@ -16,6 +16,7 @@ Status legend: 🆕 new · 🔍 needs-dedupe · ✅ addressed · ❌ won't-do
 | 8 | 2026-07-12 | Dashboard | The "You're pre-registered" card is a dead end — it should link through to the cycle page. | 🆕 |
 | 9 | 2026-07-12 | Pages / admins | Adding page admins shouldn't happen from a page's "view" page — removed from the pod page for now; decide where page-admin management belongs. | 🆕 |
 | 10 | 2026-07-12 | Auth / login | The intro/welcome screen shows even when signing back in — it should only appear when creating an account, not on return login. | 🆕 |
+| 11 | 2026-07-12 | Labs / waitlist | Decide what additional information to collect when someone joins the waitlist for a lab in a city that doesn't have one yet. | 🆕 |
 
 ## Details
 
@@ -101,7 +102,10 @@ Once a cycle flips `upcoming` → `active` (which is also when the problem-state
 
 **To investigate:** the sign-in flow under `app/(auth)/` and `lib/auth/` — where the intro/welcome step is rendered and whether it can branch on new-account vs. existing-account (e.g. distinguish sign-up from sign-in, or skip the intro when the auth user already has a participant record). See `lib/auth/CLAUDE.md` for the sign-in/role-resolution flow.
 
-## July 11 triage (session snapshot)
+### 11 — What to collect when joining the waitlist for a lab in another city (2026-07-12)
+**Needs judgement:** When someone is in a city without a Local Lab and joins the waitlist, decide what else we should capture beyond the basics — e.g. specific city/metro, how many others they know who'd join, willingness to help start/lead a lab, sector interest, contact/notify preferences. The answers shape whether/when we stand up a new lab.
+
+**To figure out:** the intended data model + form for the no-lab / waitlist path (relates to the Local Labs model, `docs/LOCAL_LABS.md`, and the active-lab gate that currently holds lab-less members out of cycle registration). Define the fields, then wire the waitlist capture.
 
 Folded in from the earlier `testing-feedback-2026-07-11.md` so all hands-on feedback lives in one doc; the original triage structure is preserved. **✅ = fixed on a branch/PR (not necessarily merged yet)**, with the PR noted inline; ⏳ = partially addressed; unmarked = still open.
 


### PR DESCRIPTION
Adds running-feedback item #11: decide what additional information to capture when someone joins the waitlist for a lab in a city that doesn't have one yet (specific metro, others who'd join, willingness to help start/lead, sector interest, notify prefs). Needs-judgement item; relates to the Local Labs model and the active-lab gate.

Follow-up to #239 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)