### PR TITLE
fix(login): skip the explainer popup — go straight to Google sign-in

### DIFF
--- a/app/(auth)/login/login-card.tsx
+++ b/app/(auth)/login/login-card.tsx
@@ -118,7 +118,7 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
           href="/login?intent=join"
           style={{ textDecoration: "underline" }}
         >
-          join The Labs
+          Join the Labs
         </a>{" "}
         to create one.
       </p>
@@ -293,7 +293,7 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
         >
           {/* margin:auto centers vertically but, unlike justify-content,
               still lets the top scroll into view if the card overflows. */}
-          <div style={{ margin: "auto 0" }}>
+          <div style={{ margin: "auto 0", padding: "16px 0 24px" }}>
             {failedAlert}
             <h2 className="t-h1" style={{ marginBottom: 12 }}>
               Sign in

--- a/app/(auth)/login/login-card.tsx
+++ b/app/(auth)/login/login-card.tsx
@@ -168,21 +168,37 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
     </>
   );
 
-  // The join explainer, hosted in the intercepted popup
-  // (app/@authmodal/(.)login only renders this for intent=join / invites).
+  // Hosted in the intercepted popup (app/@authmodal/(.)login). Joining gets
+  // the full explainer; logging in gets a compact card — heading, Google
+  // button, fine print — so the door is obvious without the pitch.
   if (inModal) {
+    if (joining) {
+      return (
+        <>
+          {invitedTag}
+          {failedAlert}
+          <h2 className="t-h2" style={{ marginBottom: 8 }}>
+            Sign in with Google
+          </h2>
+          <p className="t-body" style={{ marginBottom: 12 }}>
+            One account you already have. Free, familiar, nothing new to
+            remember.
+          </p>
+          <div style={{ marginBottom: 20 }}>{benefits}</div>
+          <div style={{ marginBottom: 10 }}>{googleButton}</div>
+          {finePrint}
+        </>
+      );
+    }
     return (
       <>
-        {invitedTag}
         {failedAlert}
         <h2 className="t-h2" style={{ marginBottom: 8 }}>
-          Sign in with Google
+          Sign in
         </h2>
-        <p className="t-body" style={{ marginBottom: 12 }}>
-          One account you already have. Free, familiar, nothing new to
-          remember.
+        <p className="t-body" style={{ marginBottom: 20 }}>
+          Use your Google account to sign in to The Upskilling Labs.
         </p>
-        <div style={{ marginBottom: 20 }}>{benefits}</div>
         <div style={{ marginBottom: 10 }}>{googleButton}</div>
         {finePrint}
       </>

--- a/app/(auth)/login/login-card.tsx
+++ b/app/(auth)/login/login-card.tsx
@@ -91,31 +91,37 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
 
   const noAccountAlert = noAccount && (
     <div
-      className="t-small"
       style={{
-        border: "1px solid var(--rule)",
+        background: "var(--paper)",
+        border: "1px solid var(--paper-edge)",
+        borderLeft: "3px solid var(--teal)",
         borderRadius: "var(--r)",
-        padding: "12px 14px",
-        marginBottom: 14,
+        padding: "14px 16px",
+        marginBottom: 24,
       }}
       role="alert"
     >
-      There&rsquo;s no Labs account
-      {attemptedEmail ? (
-        <>
-          {" "}
-          for <strong>{attemptedEmail}</strong>
-        </>
-      ) : null}
-      . Try a different Google account, or{" "}
-      <a
-        className="see"
-        href="/login?intent=join"
-        style={{ textDecoration: "underline" }}
-      >
-        join The Labs
-      </a>{" "}
-      to create one.
+      <p className="t-body" style={{ fontWeight: 600, marginBottom: 4 }}>
+        We couldn&rsquo;t find a Labs account
+        {attemptedEmail ? (
+          <>
+            {" "}
+            for <strong>{attemptedEmail}</strong>
+          </>
+        ) : null}
+        .
+      </p>
+      <p className="t-small">
+        Try again with a different Google account, or{" "}
+        <a
+          className="see"
+          href="/login?intent=join"
+          style={{ textDecoration: "underline" }}
+        >
+          join The Labs
+        </a>{" "}
+        to create one.
+      </p>
     </div>
   );
 
@@ -232,13 +238,13 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
     return (
       <>
         {failedAlert}
-        {noAccountAlert}
         <h2 className="t-h2" style={{ marginBottom: 8 }}>
           Sign in
         </h2>
         <p className="t-body" style={{ marginBottom: 20 }}>
           Use your Google account to sign in to The Upskilling Labs.
         </p>
+        {noAccountAlert}
         <div style={{ marginBottom: 10 }}>{googleButton}</div>
         {finePrint}
       </>
@@ -283,13 +289,13 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
         <div className="topbar" />
         <div className="vscroll pad">
           {failedAlert}
-          {noAccountAlert}
           <h2 className="t-h1" style={{ marginBottom: 12 }}>
             Sign in
           </h2>
           <p className="t-lede" style={{ marginBottom: 28 }}>
             Use your Google account to sign in to The Upskilling Labs.
           </p>
+          {noAccountAlert}
           {googleButton}
           <div style={{ marginTop: 20 }}>{finePrint}</div>
         </div>

--- a/app/(auth)/login/login-card.tsx
+++ b/app/(auth)/login/login-card.tsx
@@ -4,14 +4,13 @@ import { useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 
-// The Google-auth explainer — ported from onboarding-proto's view-google-auth.
-// One door for everyone: new members continue into the registration funnel
-// (/register), returning members land on their dashboard — the auth callback
-// decides. Copy is owner-approved; change it in the prototype first.
-//
-// Two hosts, one source: the full /login page (hard loads — invite emails,
-// auth-failure redirects, refresh) and the intercepted popup
-// (app/@authmodal/(.)login) that opens over whatever page launched it.
+// Two doors, one component (owner ask, July 2026):
+// - Join CTAs link to /login?intent=join and get the Google-auth explainer —
+//   copy ported from onboarding-proto's view-google-auth (owner-approved;
+//   change it in the prototype first). Invite links count as joining.
+// - Plain "Log in" links get a regular sign-in card on hard loads; soft
+//   navigations skip even that and go straight to Google
+//   (app/@authmodal/(.)login).
 
 function GoogleLogo() {
   return (
@@ -50,6 +49,7 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
   const searchParams = useSearchParams();
   const inviteToken = searchParams.get("invite");
   const invited = !!inviteToken;
+  const joining = searchParams.get("intent") === "join" || invited;
   const authFailed = searchParams.get("error") === "auth_failed";
 
   useEffect(() => {
@@ -134,8 +134,13 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
   const finePrint = (
     <>
       <p className="t-small">
-        We only access your name, email, and profile picture. Already a member?
-        Same door — Google signs you in either way.
+        We only access your name, email, and profile picture.
+        {joining && (
+          <>
+            {" "}
+            Already a member? Same door — Google signs you in either way.
+          </>
+        )}
       </p>
       <p className="t-small" style={{ marginTop: 8 }}>
         By continuing, you agree to our{" "}
@@ -163,6 +168,8 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
     </>
   );
 
+  // The join explainer, hosted in the intercepted popup
+  // (app/@authmodal/(.)login only renders this for intent=join / invites).
   if (inModal) {
     return (
       <>
@@ -182,28 +189,51 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
     );
   }
 
+  // Hard-loaded join door (invite emails land here): the full explainer.
+  if (joining) {
+    return (
+      <div className="view light onboard s-paper">
+        <div className="sheet">
+          <div className="topbar" />
+          <div className="vscroll pad">
+            <div className="lbl lbl-teal" style={{ marginBottom: 16 }}>
+              Create account
+            </div>
+            {invitedTag}
+            {failedAlert}
+            <h2 className="t-h1" style={{ marginBottom: 16 }}>
+              Sign in with Google
+            </h2>
+            <p className="t-lede" style={{ marginBottom: 32 }}>
+              One account you already have. Free, familiar, nothing new to
+              remember.
+            </p>
+            {benefits}
+          </div>
+          <div className="actionbar light-bar">
+            {googleButton}
+            {finePrint}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Hard-loaded log-in door: a regular sign-in screen, no marketing copy.
   return (
     <div className="view light onboard s-paper">
       <div className="sheet">
         <div className="topbar" />
         <div className="vscroll pad">
-          <div className="lbl lbl-teal" style={{ marginBottom: 16 }}>
-            Create account
-          </div>
-          {invitedTag}
           {failedAlert}
-          <h2 className="t-h1" style={{ marginBottom: 16 }}>
-            Sign in with Google
+          <h2 className="t-h1" style={{ marginBottom: 12 }}>
+            Sign in
           </h2>
-          <p className="t-lede" style={{ marginBottom: 32 }}>
-            One account you already have. Free, familiar, nothing new to
-            remember.
+          <p className="t-lede" style={{ marginBottom: 28 }}>
+            Use your Google account to sign in to The Upskilling Labs.
           </p>
-          {benefits}
-        </div>
-        <div className="actionbar light-bar">
           {googleButton}
-          {finePrint}
+          <div style={{ marginTop: 20 }}>{finePrint}</div>
         </div>
       </div>
     </div>

--- a/app/(auth)/login/login-card.tsx
+++ b/app/(auth)/login/login-card.tsx
@@ -59,11 +59,19 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
   }, [inviteToken]);
 
   const continueWithGoogle = async () => {
+    // Tell the auth callback which door this attempt came through — logging
+    // in with an unknown Google account should say "no account" rather than
+    // silently opening registration. Cookie, not query param: the redirect
+    // allowlist matches exact URLs (supabase/config.toml).
+    document.cookie = `auth_intent=${joining ? "join" : "login"}; path=/; max-age=600; SameSite=Lax`;
     const supabase = createClient();
     await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
         redirectTo: `${window.location.origin}/api/auth/callback`,
+        // Always show Google's account chooser so members pick which email
+        // to sign in with instead of being auto-signed into the last one.
+        queryParams: { prompt: "select_account" },
       },
     });
   };
@@ -75,6 +83,39 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
         <polyline points="22 4 12 14.01 9 11.01" />
       </svg>
       You&rsquo;ve been invited to join
+    </div>
+  );
+
+  const noAccount = searchParams.get("error") === "no_account";
+  const attemptedEmail = searchParams.get("email");
+
+  const noAccountAlert = noAccount && (
+    <div
+      className="t-small"
+      style={{
+        border: "1px solid var(--rule)",
+        borderRadius: "var(--r)",
+        padding: "12px 14px",
+        marginBottom: 14,
+      }}
+      role="alert"
+    >
+      There&rsquo;s no Labs account
+      {attemptedEmail ? (
+        <>
+          {" "}
+          for <strong>{attemptedEmail}</strong>
+        </>
+      ) : null}
+      . Try a different Google account, or{" "}
+      <a
+        className="see"
+        href="/login?intent=join"
+        style={{ textDecoration: "underline" }}
+      >
+        join The Labs
+      </a>{" "}
+      to create one.
     </div>
   );
 
@@ -136,10 +177,7 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
       <p className="t-small">
         We only access your name, email, and profile picture.
         {joining && (
-          <>
-            {" "}
-            Already a member? Same door — Google signs you in either way.
-          </>
+          <> Already a member? Same door — Google signs you in either way.</>
         )}
       </p>
       <p className="t-small" style={{ marginTop: 8 }}>
@@ -177,6 +215,7 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
         <>
           {invitedTag}
           {failedAlert}
+          {noAccountAlert}
           <h2 className="t-h2" style={{ marginBottom: 8 }}>
             Sign in with Google
           </h2>
@@ -193,6 +232,7 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
     return (
       <>
         {failedAlert}
+        {noAccountAlert}
         <h2 className="t-h2" style={{ marginBottom: 8 }}>
           Sign in
         </h2>
@@ -217,6 +257,7 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
             </div>
             {invitedTag}
             {failedAlert}
+            {noAccountAlert}
             <h2 className="t-h1" style={{ marginBottom: 16 }}>
               Sign in with Google
             </h2>
@@ -242,6 +283,7 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
         <div className="topbar" />
         <div className="vscroll pad">
           {failedAlert}
+          {noAccountAlert}
           <h2 className="t-h1" style={{ marginBottom: 12 }}>
             Sign in
           </h2>

--- a/app/(auth)/login/login-card.tsx
+++ b/app/(auth)/login/login-card.tsx
@@ -287,17 +287,24 @@ export default function LoginCard({ inModal = false }: { inModal?: boolean }) {
     <div className="view light onboard s-paper">
       <div className="sheet">
         <div className="topbar" />
-        <div className="vscroll pad">
-          {failedAlert}
-          <h2 className="t-h1" style={{ marginBottom: 12 }}>
-            Sign in
-          </h2>
-          <p className="t-lede" style={{ marginBottom: 28 }}>
-            Use your Google account to sign in to The Upskilling Labs.
-          </p>
-          {noAccountAlert}
-          {googleButton}
-          <div style={{ marginTop: 20 }}>{finePrint}</div>
+        <div
+          className="vscroll pad"
+          style={{ display: "flex", flexDirection: "column" }}
+        >
+          {/* margin:auto centers vertically but, unlike justify-content,
+              still lets the top scroll into view if the card overflows. */}
+          <div style={{ margin: "auto 0" }}>
+            {failedAlert}
+            <h2 className="t-h1" style={{ marginBottom: 12 }}>
+              Sign in
+            </h2>
+            <p className="t-lede" style={{ marginBottom: 28 }}>
+              Use your Google account to sign in to The Upskilling Labs.
+            </p>
+            {noAccountAlert}
+            {googleButton}
+            <div style={{ marginTop: 20 }}>{finePrint}</div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/(public)/about/page.tsx
+++ b/app/(public)/about/page.tsx
@@ -248,7 +248,7 @@ export default function AboutPage() {
                   <Link className="btn btn-red btn-lg" href="/build-cycles">
                     Explore how The Labs works
                   </Link>
-                  <Link className="see" href="/login">
+                  <Link className="see" href="/login?intent=join">
                     Ready now? Join The Labs →
                   </Link>
                 </div>

--- a/app/(public)/build-cycles/page.tsx
+++ b/app/(public)/build-cycles/page.tsx
@@ -74,7 +74,7 @@ export default async function BuildCyclesPage() {
         standfirst="You’ll pick a problem that matters to you, team up, and see it through — with mentors and a whole community behind you."
       >
         <div className="ed-cols">
-          <Link className="btn btn-red btn-lg" href="/login">
+          <Link className="btn btn-red btn-lg" href="/login?intent=join">
             Register for this cycle
           </Link>
         </div>
@@ -176,7 +176,7 @@ export default async function BuildCyclesPage() {
                     alignItems: "center",
                   }}
                 >
-                  <Link className="btn btn-red btn-lg" href="/login">
+                  <Link className="btn btn-red btn-lg" href="/login?intent=join">
                     Register for this cycle
                   </Link>
                   <Link className="see" href="/events/kickoff-summit">

--- a/app/(public)/contact/page.tsx
+++ b/app/(public)/contact/page.tsx
@@ -67,7 +67,7 @@ export default function ContactPage() {
       <p className="t-body" style={p}>
         If you’d rather roll up your sleeves, see the{" "}
         <Link className="see" href="/get-involved">ways to volunteer</Link> or{" "}
-        <Link className="see" href="/login">join The Labs</Link>.
+        <Link className="see" href="/login?intent=join">join The Labs</Link>.
       </p>
     </ProsePage>
   );

--- a/app/(public)/get-involved/page.tsx
+++ b/app/(public)/get-involved/page.tsx
@@ -58,7 +58,7 @@ export default function GetInvolvedPage() {
         you’d like to take part when you sign up, or reach out if you’d like to talk
         through where you might fit.
       </p>
-      <Link className="btn btn-red btn-lg" href="/login">
+      <Link className="btn btn-red btn-lg" href="/login?intent=join">
         Join The Labs
       </Link>
       <p style={{ marginTop: 16 }}>

--- a/app/(public)/local-labs/[slug]/join-active-button.tsx
+++ b/app/(public)/local-labs/[slug]/join-active-button.tsx
@@ -29,7 +29,7 @@ export default function JoinActiveButton({
 
   if (!signedIn) {
     return (
-      <Link className={className} href="/login">
+      <Link className={className} href="/login?intent=join">
         Join this lab
       </Link>
     );

--- a/app/(public)/local-labs/[slug]/join-button.tsx
+++ b/app/(public)/local-labs/[slug]/join-button.tsx
@@ -28,7 +28,7 @@ export default function JoinButton({
 
   if (!signedIn) {
     return (
-      <Link className="btn btn-red btn-block" href="/login">
+      <Link className="btn btn-red btn-block" href="/login?intent=join">
         Join the {metroName} waitlist
       </Link>
     );

--- a/app/(survey)/survey/[slug]/survey-flow.tsx
+++ b/app/(survey)/survey/[slug]/survey-flow.tsx
@@ -404,7 +404,7 @@ function Done({
               Back to your dashboard →
             </Link>
           ) : (
-            <Link className="btn btn-teal btn-lg btn-block" href="/login">
+            <Link className="btn btn-teal btn-lg btn-block" href="/login?intent=join">
               Join The Labs →
             </Link>
           )}

--- a/app/@authmodal/(.)login/page.tsx
+++ b/app/@authmodal/(.)login/page.tsx
@@ -1,72 +1,21 @@
-"use client";
-
-import { Suspense, useEffect } from "react";
-import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import AuthModal from "@/app/components/auth/auth-modal";
 import LoginCard from "@/app/(auth)/login/login-card";
-import { createClient } from "@/lib/supabase/client";
 
-// Soft navigations to /login land here. Two doors (owner ask, July 2026):
-// - Join CTAs (/login?intent=join) and invite links keep the Google-auth
-//   explainer popup — newcomers get the pitch.
-// - Plain "Log in" links skip the popup and go straight to Google — members
-//   who tapped Log in have already decided.
-// Hard loads — invite emails, auth-failure redirects, refreshes — skip
-// interception entirely and get the full page at app/(auth)/login.
-
-function StraightToGoogle() {
-  useEffect(() => {
-    const supabase = createClient();
-    supabase.auth
-      .signInWithOAuth({
-        provider: "google",
-        options: {
-          redirectTo: `${window.location.origin}/api/auth/callback`,
-        },
-      })
-      .then(({ error }) => {
-        // If the OAuth kickoff fails, fall back to the full login page so
-        // the member isn't stranded on a blank overlay.
-        if (error) window.location.assign("/login");
-      });
-  }, []);
-
-  // Minimal scrim while the browser follows the Google redirect.
-  return (
-    <div className="gate-modal open" aria-busy="true">
-      <div
-        className="gate-sheet"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Signing in with Google"
-      >
-        <p className="t-body" style={{ padding: "28px 0", textAlign: "center" }}>
-          Taking you to Google&hellip;
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function LoginDoor() {
-  const searchParams = useSearchParams();
-  const joining =
-    searchParams.get("intent") === "join" || !!searchParams.get("invite");
-
-  if (joining) {
-    return (
-      <AuthModal>
-        <LoginCard inModal />
-      </AuthModal>
-    );
-  }
-  return <StraightToGoogle />;
-}
+// Soft navigations to /login land here: a popup opens over the launching
+// page. Two doors (owner ask, July 2026): join CTAs (/login?intent=join)
+// and invite links get the Google-auth explainer; plain "Log in" links get
+// a compact sign-in card — just the Google button, no pitch. LoginCard
+// picks the variant from the URL. Hard loads — invite emails, auth-failure
+// redirects, refreshes — skip interception and get the full page at
+// app/(auth)/login.
 
 export default function InterceptedLogin() {
   return (
     <Suspense>
-      <LoginDoor />
+      <AuthModal>
+        <LoginCard inModal />
+      </AuthModal>
     </Suspense>
   );
 }

--- a/app/@authmodal/(.)login/page.tsx
+++ b/app/@authmodal/(.)login/page.tsx
@@ -2,24 +2,20 @@
 
 import { Suspense, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
+import AuthModal from "@/app/components/auth/auth-modal";
+import LoginCard from "@/app/(auth)/login/login-card";
 import { createClient } from "@/lib/supabase/client";
 
-// Soft navigations to /login skip the Google-auth explainer popup and go
-// straight to Google (owner ask, July 2026 — the popup added a click without
-// adding information). Hard loads — invite links, auth-failure redirects,
-// refreshes — still get the full page at app/(auth)/login, which keeps the
-// explainer copy.
+// Soft navigations to /login land here. Two doors (owner ask, July 2026):
+// - Join CTAs (/login?intent=join) and invite links keep the Google-auth
+//   explainer popup — newcomers get the pitch.
+// - Plain "Log in" links skip the popup and go straight to Google — members
+//   who tapped Log in have already decided.
+// Hard loads — invite emails, auth-failure redirects, refreshes — skip
+// interception entirely and get the full page at app/(auth)/login.
 
 function StraightToGoogle() {
-  const searchParams = useSearchParams();
-
   useEffect(() => {
-    // Same invite-token handoff the full login page does, in case a soft
-    // navigation ever carries ?invite=.
-    const inviteToken = searchParams.get("invite");
-    if (inviteToken) {
-      document.cookie = `invite_token=${inviteToken}; path=/; max-age=3600; SameSite=Lax`;
-    }
     const supabase = createClient();
     supabase.auth
       .signInWithOAuth({
@@ -33,10 +29,9 @@ function StraightToGoogle() {
         // the member isn't stranded on a blank overlay.
         if (error) window.location.assign("/login");
       });
-  }, [searchParams]);
+  }, []);
 
-  // Minimal scrim while the browser follows the Google redirect — the
-  // .gate-modal vocabulary matches the old popup so nothing flashes oddly.
+  // Minimal scrim while the browser follows the Google redirect.
   return (
     <div className="gate-modal open" aria-busy="true">
       <div
@@ -53,10 +48,25 @@ function StraightToGoogle() {
   );
 }
 
+function LoginDoor() {
+  const searchParams = useSearchParams();
+  const joining =
+    searchParams.get("intent") === "join" || !!searchParams.get("invite");
+
+  if (joining) {
+    return (
+      <AuthModal>
+        <LoginCard inModal />
+      </AuthModal>
+    );
+  }
+  return <StraightToGoogle />;
+}
+
 export default function InterceptedLogin() {
   return (
     <Suspense>
-      <StraightToGoogle />
+      <LoginDoor />
     </Suspense>
   );
 }

--- a/app/@authmodal/(.)login/page.tsx
+++ b/app/@authmodal/(.)login/page.tsx
@@ -1,18 +1,62 @@
-import { Suspense } from "react";
-import AuthModal from "@/app/components/auth/auth-modal";
-import LoginCard from "@/app/(auth)/login/login-card";
+"use client";
 
-// Soft navigations to /login land here: the Google-auth card opens as a
-// popup over the launching page (owner ask, July 2026). Hard loads —
-// invite links, auth-failure redirects, refreshes — skip interception and
-// get the full page at app/(auth)/login.
+import { Suspense, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+// Soft navigations to /login skip the Google-auth explainer popup and go
+// straight to Google (owner ask, July 2026 — the popup added a click without
+// adding information). Hard loads — invite links, auth-failure redirects,
+// refreshes — still get the full page at app/(auth)/login, which keeps the
+// explainer copy.
+
+function StraightToGoogle() {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    // Same invite-token handoff the full login page does, in case a soft
+    // navigation ever carries ?invite=.
+    const inviteToken = searchParams.get("invite");
+    if (inviteToken) {
+      document.cookie = `invite_token=${inviteToken}; path=/; max-age=3600; SameSite=Lax`;
+    }
+    const supabase = createClient();
+    supabase.auth
+      .signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: `${window.location.origin}/api/auth/callback`,
+        },
+      })
+      .then(({ error }) => {
+        // If the OAuth kickoff fails, fall back to the full login page so
+        // the member isn't stranded on a blank overlay.
+        if (error) window.location.assign("/login");
+      });
+  }, [searchParams]);
+
+  // Minimal scrim while the browser follows the Google redirect — the
+  // .gate-modal vocabulary matches the old popup so nothing flashes oddly.
+  return (
+    <div className="gate-modal open" aria-busy="true">
+      <div
+        className="gate-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Signing in with Google"
+      >
+        <p className="t-body" style={{ padding: "28px 0", textAlign: "center" }}>
+          Taking you to Google&hellip;
+        </p>
+      </div>
+    </div>
+  );
+}
 
 export default function InterceptedLogin() {
   return (
     <Suspense>
-      <AuthModal>
-        <LoginCard inModal />
-      </AuthModal>
+      <StraightToGoogle />
     </Suspense>
   );
 }

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -4,6 +4,21 @@ import { escapeEmailForIlike } from "@/lib/auth/email";
 import { hasPlaceholderName } from "@/lib/participants/placeholder";
 import { fulfillInvitation } from "@/lib/auth/invitations";
 
+// The login door sets auth_intent=login before kicking off OAuth (the join
+// door sets "join") — see app/(auth)/login/login-card.tsx. An unknown Google
+// account through the login door gets "no account" instead of silently
+// landing in registration.
+function authIntent(request: Request): string {
+  const cookies = request.headers.get("cookie") ?? "";
+  const m = cookies.match(/(?:^|;\s*)auth_intent=([^;]*)/);
+  return m ? decodeURIComponent(m[1]) : "";
+}
+
+function clearIntentCookie(res: NextResponse): NextResponse {
+  res.cookies.set("auth_intent", "", { path: "/", maxAge: 0 });
+  return res;
+}
+
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
@@ -50,20 +65,32 @@ export async function GET(request: Request) {
           // Fulfill any pending invitation (placeholder-name aware)
           const hasPlaceholder = hasPlaceholderName(
             participant.first_name,
-            participant.last_name
+            participant.last_name,
           );
           await fulfillInvitation(
             serviceClient,
             participant.id,
             email,
-            hasPlaceholder
+            hasPlaceholder,
           );
 
           // A returning member lands in the app, not on the public landing.
-          return NextResponse.redirect(`${origin}/dashboard`);
+          return clearIntentCookie(
+            NextResponse.redirect(`${origin}/dashboard`),
+          );
+        } else if (authIntent(request) === "login") {
+          // Logging in with a Google account we don't know: say so rather
+          // than silently opening registration (owner ask, July 2026). Sign
+          // the Supabase session back out so a retry starts clean.
+          await supabase.auth.signOut();
+          return clearIntentCookie(
+            NextResponse.redirect(
+              `${origin}/login?error=no_account&email=${encodeURIComponent(email)}`,
+            ),
+          );
         } else {
-          // No participant record — redirect to registration
-          return NextResponse.redirect(`${origin}/register`);
+          // No participant record — joining: continue into registration.
+          return clearIntentCookie(NextResponse.redirect(`${origin}/register`));
         }
       }
 

--- a/app/components/chrome/site-footers.tsx
+++ b/app/components/chrome/site-footers.tsx
@@ -74,7 +74,7 @@ export function OsFooter() {
             <Link className="foot-link" href="/team">The Team</Link>
             <Link className="foot-link" href="/get-involved">Get Involved</Link>
             <Link className="foot-link" href="/contact">Contact</Link>
-            <Link className="foot-link" href="/login">Become a member</Link>
+            <Link className="foot-link" href="/login?intent=join">Become a member</Link>
           </div>
           <div className="foot-col">
             <div className="lbl">Open source</div>
@@ -87,7 +87,7 @@ export function OsFooter() {
             >
               Built in the open
             </a>
-            <Link className="foot-link" href="/login">Join The Labs</Link>
+            <Link className="foot-link" href="/login?intent=join">Join The Labs</Link>
           </div>
         </div>
         <div className="foot-partners">

--- a/app/components/content/metro-search.tsx
+++ b/app/components/content/metro-search.tsx
@@ -123,7 +123,7 @@ export default function MetroSearch({
               Start the list
             </button>
           ) : (
-            <Link className="btn btn-red" href="/login">
+            <Link className="btn btn-red" href="/login?intent=join">
               Start the list
             </Link>
           )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -155,7 +155,7 @@ export default async function LandingPage() {
                 </Link>
               ) : (
                 <>
-                  <Link className="btn btn-red btn-lg" href="/login">
+                  <Link className="btn btn-red btn-lg" href="/login?intent=join">
                     Join The Labs
                   </Link>
                   <Link className="btn btn-ghost btn-lg hero-login" href="/login">


### PR DESCRIPTION
## What changed

Clicking a sign-in link inside the app previously opened an explainer popup (the 'Sign in with Google' card with benefit bullets) that the member had to read past before clicking Continue with Google. Soft navigations to /login now kick off the Google OAuth redirect immediately — the member sees only a brief 'Taking you to Google…' scrim while the browser follows the redirect.

## What didn't change

Hard loads of /login — invite-email links, auth-failure redirects, page refreshes — still get the full explainer page at app/(auth)/login, including the invite banner, error alert, and Terms/Privacy fine print.

## Why

July 2026 testing feedback: the popup added a click without adding information. Members who tap 'Sign in' have already decided to sign in.

## How to test

1. Sign out, click any sign-in link from inside the app → lands on Google's account picker, no popup.
2. Open /login directly (hard load) → full explainer page still renders.
3. Fail a sign-in → the auth-failure redirect shows the error on the full page as before.

## Notes

- No migrations, no DB changes.
- If the OAuth kickoff errors, the modal falls back to the full /login page rather than stranding the member.