### PR TITLE
feat(windows): enter and display cycle windows in the lab's local time (ET)

### DIFF
--- a/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { toLabInput, fromLabInput, LAB_TZ_LABEL } from "@/lib/cycles/lab-time";
 
 type Config = {
   cycle_id: number;
@@ -34,14 +35,16 @@ type Config = {
   project_registration_close: string | null;
 };
 
+// Window timestamps are stored as naive-UTC instants (S5.1 convention,
+// docs/requirements/cycle3-testing-plan.md) but ENTERED and DISPLAYED in the
+// lab's local time — America/New_York for the DC lab — so an admin types
+// "Jul 25, 9:00 AM" and the gate opens at 9:00 AM Eastern, EDT or EST alike.
 function toLocal(iso: string | null): string {
-  if (!iso) return "";
-  return iso.replace(" ", "T").slice(0, 16);
+  return toLabInput(iso);
 }
 
 function fromLocal(val: string): string | null {
-  if (!val) return null;
-  return `${val}:00`;
+  return fromLabInput(val);
 }
 
 // ─── Schedule form ────────────────────────────────────────────────────────────
@@ -136,6 +139,9 @@ export function CycleScheduleForm({
       <div className="mb-6 rounded-card border border-ink/10 bg-white p-4 shadow-card">
         <h3 className="mb-3 text-sm font-semibold tracking-tight text-ink">
           Cycle Phases
+          <span className="ml-2 text-xs font-normal text-meta">
+            all times Eastern ({LAB_TZ_LABEL})
+          </span>
         </h3>
         <div className="grid gap-4 sm:grid-cols-2">
           <div>
@@ -171,10 +177,10 @@ export function CycleScheduleForm({
                 Phase
               </th>
               <th className="lbl px-4 py-3 text-left">
-                Opens (UTC)
+                Opens ({LAB_TZ_LABEL})
               </th>
               <th className="lbl px-4 py-3 text-left">
-                Closes (UTC)
+                Closes ({LAB_TZ_LABEL})
               </th>
             </tr>
           </thead>

--- a/app/(dashboard)/cycles/[cycle_id]/join/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/join/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { windowOpen } from "@/lib/cycles/lab-time";
 import CycleCeremony from "./ceremony";
 
 // The cycle registration ceremony (onboarding-proto: view-cycle-threshold →
@@ -88,12 +89,11 @@ export default async function JoinCyclePage({
     .eq("cycle_id", cycleId)
     .maybeSingle();
 
-  const now = new Date();
-  const podRegistrationOpen =
-    !!config?.pod_registration_open &&
-    !!config?.pod_registration_close &&
-    now >= new Date(config.pod_registration_open) &&
-    now <= new Date(config.pod_registration_close);
+  // Naive window columns are UTC instants (lib/cycles/lab-time.ts).
+  const podRegistrationOpen = windowOpen(
+    config?.pod_registration_open,
+    config?.pod_registration_close
+  );
 
   const fullName = `${participant.first_name} ${participant.last_name}`.trim();
 

--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { windowOpen, fmtLabDate } from "@/lib/cycles/lab-time";
 import { BookOpen, ArrowRight, ChevronLeft } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
@@ -83,7 +84,7 @@ export default async function CycleDetailPage({
       const configRecord = config as Record<string, string | null>;
       const openVal = configRecord[`${w.field}_open`];
       const closeVal = configRecord[`${w.field}_close`];
-      if (openVal && closeVal && now >= new Date(openVal) && now <= new Date(closeVal)) {
+      if (openVal && closeVal && windowOpen(openVal, closeVal, now)) {
         activeWindows.push({ label: w.label, route: w.route, closesAt: closeVal });
       }
     }
@@ -135,10 +136,7 @@ export default async function CycleDetailPage({
               <div className="flex items-center gap-2 text-sm text-slate">
                 <span className="tabular-nums">
                   closes{" "}
-                  {new Date(w.closesAt).toLocaleDateString("en-US", {
-                    month: "short",
-                    day: "numeric",
-                  })}
+                  {fmtLabDate(w.closesAt)}
                 </span>
                 <ArrowRight
                   className="h-4 w-4 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"

--- a/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { windowOpen, parseWindow, fmtLabDateTime } from "@/lib/cycles/lab-time";
 import { ChevronLeft } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
@@ -32,12 +33,14 @@ export default async function ProposePage({
     .eq("cycle_id", cycleId)
     .maybeSingle();
 
+  // Naive window columns are UTC instants; entry + display are lab-local
+  // (lib/cycles/lab-time.ts).
   const now = new Date();
-  const isOpen =
-    config?.problem_statement_open &&
-    config?.problem_statement_close &&
-    now >= new Date(config.problem_statement_open) &&
-    now <= new Date(config.problem_statement_close);
+  const isOpen = windowOpen(
+    config?.problem_statement_open,
+    config?.problem_statement_close,
+    now
+  );
 
   // Get user's name for pre-filling
   const {
@@ -92,18 +95,9 @@ export default async function ProposePage({
               : "This cycle isn't fully configured yet — the submission window hasn't been scheduled. If you expected it to be open, let an organizer know."}
           </p>
           {config?.problem_statement_open &&
-            now < new Date(config.problem_statement_open) && (
+            now < (parseWindow(config.problem_statement_open) as Date) && (
               <p className="mt-2 text-sm text-meta tabular-nums">
-                Opens{" "}
-                {new Date(config.problem_statement_open).toLocaleDateString(
-                  "en-US",
-                  {
-                    month: "short",
-                    day: "numeric",
-                    hour: "numeric",
-                    minute: "2-digit",
-                  }
-                )}
+                Opens {fmtLabDateTime(config.problem_statement_open)}
               </p>
             )}
         </div>

--- a/app/(dashboard)/cycles/[cycle_id]/register-pods/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-pods/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { windowOpen, parseWindow, fmtLabDateTime } from "@/lib/cycles/lab-time";
 import { ArrowRight } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
@@ -21,12 +22,14 @@ export default async function RegisterPodsPage({
 
   if (!cycle) notFound();
 
+  // Naive window columns are UTC instants; entry + display are lab-local
+  // (lib/cycles/lab-time.ts).
   const now = new Date();
-  const isOpen =
-    config?.pod_registration_open &&
-    config?.pod_registration_close &&
-    now >= new Date(config.pod_registration_open) &&
-    now <= new Date(config.pod_registration_close);
+  const isOpen = windowOpen(
+    config?.pod_registration_open,
+    config?.pod_registration_close,
+    now
+  );
 
   const podLimit = config?.pod_limit ?? 1;
   const single = podLimit === 1;
@@ -93,13 +96,9 @@ export default async function RegisterPodsPage({
             Pod registration is not currently open.
           </p>
           {config?.pod_registration_open &&
-            now < new Date(config.pod_registration_open) && (
+            now < (parseWindow(config.pod_registration_open) as Date) && (
               <p className="mt-2 text-sm text-meta tabular-nums">
-                Opens{" "}
-                {new Date(config.pod_registration_open).toLocaleDateString(
-                  "en-US",
-                  { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
-                )}
+                Opens {fmtLabDateTime(config.pod_registration_open)}
               </p>
             )}
           <div className="mt-4">

--- a/app/(dashboard)/cycles/[cycle_id]/register-projects/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-projects/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { windowOpen, parseWindow, fmtLabDateTime } from "@/lib/cycles/lab-time";
 import { ChevronLeft } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
@@ -30,12 +31,13 @@ export default async function RegisterProjectsPage({
     .eq("cycle_id", cycleId)
     .single();
 
+  // Naive window columns are UTC instants (lib/cycles/lab-time.ts).
   const now = new Date();
-  const isOpen =
-    config?.project_registration_open &&
-    config?.project_registration_close &&
-    now >= new Date(config.project_registration_open) &&
-    now <= new Date(config.project_registration_close);
+  const isOpen = windowOpen(
+    config?.project_registration_open,
+    config?.project_registration_close,
+    now
+  );
 
   const {
     data: { user },
@@ -140,13 +142,9 @@ export default async function RegisterProjectsPage({
             Project registration is not currently open.
           </p>
           {config?.project_registration_open &&
-            now < new Date(config.project_registration_open) && (
+            now < (parseWindow(config.project_registration_open) as Date) && (
               <p className="mt-2 text-sm text-meta tabular-nums">
-                Opens{" "}
-                {new Date(config.project_registration_open).toLocaleDateString(
-                  "en-US",
-                  { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
-                )}
+                Opens {fmtLabDateTime(config.project_registration_open)}
               </p>
             )}
         </div>

--- a/app/(dashboard)/cycles/[cycle_id]/solution-vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solution-vote/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { parseWindow, fmtLabDateTime } from "@/lib/cycles/lab-time";
 import { ChevronLeft } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
@@ -30,9 +31,10 @@ export default async function SolutionVotePage({
     .eq("cycle_id", cycleId)
     .single();
 
+  // Naive window columns are UTC instants (lib/cycles/lab-time.ts).
   const now = new Date();
-  const openAt = config?.solution_voting_open ? new Date(config.solution_voting_open) : null;
-  const closeAt = config?.solution_voting_close ? new Date(config.solution_voting_close) : null;
+  const openAt = parseWindow(config?.solution_voting_open);
+  const closeAt = parseWindow(config?.solution_voting_close);
   const isOpen = openAt !== null && closeAt !== null && now >= openAt && now <= closeAt;
 
   const {
@@ -100,12 +102,7 @@ export default async function SolutionVotePage({
           {openAt && now < openAt && (
             <p className="mt-2 text-sm text-meta tabular-nums">
               Opens{" "}
-              {openAt.toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                hour: "numeric",
-                minute: "2-digit",
-              })}
+              {fmtLabDateTime(config?.solution_voting_open)}
             </p>
           )}
         </div>

--- a/app/(dashboard)/cycles/[cycle_id]/solutions/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solutions/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { parseWindow, fmtLabDateTime } from "@/lib/cycles/lab-time";
 import { ChevronLeft } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
@@ -31,8 +32,9 @@ export default async function SolutionsPage({
   if (!cycle) notFound();
 
   const now = new Date();
-  const openAt = config?.solution_proposal_open ? new Date(config.solution_proposal_open) : null;
-  const closeAt = config?.solution_proposal_close ? new Date(config.solution_proposal_close) : null;
+  // Naive window columns are UTC instants (lib/cycles/lab-time.ts).
+  const openAt = parseWindow(config?.solution_proposal_open);
+  const closeAt = parseWindow(config?.solution_proposal_close);
 
   const tabVisibleFrom = openAt ? new Date(openAt.getTime() - DAY_MS) : null;
   const tabVisibleUntil = closeAt ? new Date(closeAt.getTime() + DAY_MS) : null;
@@ -112,12 +114,7 @@ export default async function SolutionsPage({
           {openAt && now < openAt && (
             <p className="mt-2 text-sm text-meta tabular-nums">
               Opens{" "}
-              {openAt.toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                hour: "numeric",
-                minute: "2-digit",
-              })}
+              {fmtLabDateTime(config?.solution_proposal_open)}
             </p>
           )}
         </div>
@@ -143,12 +140,7 @@ export default async function SolutionsPage({
               <strong className="font-semibold">Heads up:</strong>{" "}if you don&apos;t
               submit a project by{" "}
               <span className="tabular-nums">
-                {closeAt.toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  hour: "numeric",
-                  minute: "2-digit",
-                })}
+                {fmtLabDateTime(config?.solution_proposal_close)}
               </span>
               , you won&apos;t be eligible to vote in the next phase.
             </div>

--- a/app/(dashboard)/cycles/[cycle_id]/solutions/proposal-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/solutions/proposal-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { fmtLabDateTime } from "@/lib/cycles/lab-time";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -120,12 +121,7 @@ export default function ProposalForm({
               {submissionOpen && closeAt && (
                 <p className="mt-2 text-xs text-meta tabular-nums">
                   You can edit until{" "}
-                  {new Date(closeAt).toLocaleDateString("en-US", {
-                    month: "short",
-                    day: "numeric",
-                    hour: "numeric",
-                    minute: "2-digit",
-                  })}
+                  {fmtLabDateTime(closeAt)}
                 </p>
               )}
             </div>

--- a/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { windowOpen, parseWindow, fmtLabDateTime } from "@/lib/cycles/lab-time";
 import { ChevronLeft } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
@@ -30,12 +31,10 @@ export default async function VotePage({
     .eq("cycle_id", cycleId)
     .maybeSingle();
 
+  // Naive window columns are UTC instants; entry + display are lab-local
+  // (lib/cycles/lab-time.ts).
   const now = new Date();
-  const isOpen =
-    config?.voting_open &&
-    config?.voting_close &&
-    now >= new Date(config.voting_open) &&
-    now <= new Date(config.voting_close);
+  const isOpen = windowOpen(config?.voting_open, config?.voting_close, now);
 
   // Whether the viewer submitted a proposal in this cycle decides their vote
   // budget (cycle_config.submitter_votes vs non_submitter_votes). The API
@@ -97,17 +96,12 @@ export default async function VotePage({
               ? "Voting is not currently open."
               : "This cycle isn't fully configured yet — the voting window hasn't been scheduled. If you expected it to be open, let an organizer know."}
           </p>
-          {config?.voting_open && now < new Date(config.voting_open) && (
-            <p className="mt-2 text-sm text-meta tabular-nums">
-              Opens{" "}
-              {new Date(config.voting_open).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                hour: "numeric",
-                minute: "2-digit",
-              })}
-            </p>
-          )}
+          {config?.voting_open &&
+            now < (parseWindow(config.voting_open) as Date) && (
+              <p className="mt-2 text-sm text-meta tabular-nums">
+                Opens {fmtLabDateTime(config.voting_open)}
+              </p>
+            )}
         </div>
       )}
     </div>

--- a/app/(dashboard)/cycles/cycle-phase-indicator.tsx
+++ b/app/(dashboard)/cycles/cycle-phase-indicator.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { parseWindow, fmtLabDate } from "@/lib/cycles/lab-time";
 import { getCycleWeek } from "@/lib/cycle/week";
 
 type CycleConfig = {
@@ -68,10 +69,9 @@ const OPERATIONAL_WINDOWS = [
 ] as const;
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+  // Window timestamps are naive-UTC instants; render lab-local dates
+  // (lib/cycles/lab-time.ts).
+  return fmtLabDate(iso);
 }
 
 function daysUntil(from: Date, to: Date): number {
@@ -89,7 +89,10 @@ function getActiveWindows(
     const openVal = config[openKey];
     const closeVal = config[closeKey];
     if (openVal && closeVal) {
-      if (now >= new Date(openVal) && now <= new Date(closeVal)) {
+      if (
+        now >= (parseWindow(openVal) as Date) &&
+        now <= (parseWindow(closeVal) as Date)
+      ) {
         active.push({ label: w.label, closesAt: closeVal, route: w.route });
       }
     }
@@ -104,7 +107,7 @@ function getUpcomingWindow(
   for (const w of OPERATIONAL_WINDOWS) {
     const openKey = `${w.field}_open` as keyof CycleConfig;
     const openVal = config[openKey];
-    if (openVal && new Date(openVal) > now) {
+    if (openVal && (parseWindow(openVal) as Date) > now) {
       return { label: w.label, opensAt: openVal };
     }
   }

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { windowOpen, parseWindow, fmtLabDateTime } from "@/lib/cycles/lab-time";
 import { redirect } from "next/navigation";
 import { ArrowRight, Calendar } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
@@ -231,16 +232,12 @@ export default async function DashboardPage() {
     preRegisteredUpcoming = (count ?? 0) > 0;
   }
 
-  // Determine pod registration window status
-  let podWindowOpen = false;
-  if (activeCycleConfig) {
-    const now = new Date();
-    const open = activeCycleConfig.pod_registration_open;
-    const close = activeCycleConfig.pod_registration_close;
-    if (open && close) {
-      podWindowOpen = now >= new Date(open) && now <= new Date(close);
-    }
-  }
+  // Determine pod registration window status. Naive window columns are UTC
+  // instants; entry + display are lab-local (lib/cycles/lab-time.ts).
+  const podWindowOpen = windowOpen(
+    activeCycleConfig?.pod_registration_open,
+    activeCycleConfig?.pod_registration_close
+  );
 
   // "Past cycles" = finished cohorts only (closed/archived); the upcoming
   // recruiting cohort and drafts don't belong in an archive (SECTOR_MODEL Phase A).
@@ -896,13 +893,13 @@ export default async function DashboardPage() {
   // dismissible cards (the rail shows timing; this gives the button).
   const cfg = (activeCycleConfig ?? {}) as Record<string, string | null>;
   const nowMs = new Date().getTime();
-  const windowClose = (k: string): Date | null => {
+  const windowClose = (k: string): string | null => {
     const o = cfg[`${k}_open`];
     const c = cfg[`${k}_close`];
     if (!o || !c) return null;
-    return nowMs >= new Date(o).getTime() && nowMs <= new Date(c).getTime()
-      ? new Date(c)
-      : null;
+    const open = parseWindow(o) as Date;
+    const close = parseWindow(c) as Date;
+    return nowMs >= open.getTime() && nowMs <= close.getTime() ? c : null;
   };
   const WINDOW_TODOS = [
     { k: "problem_statement", title: "Submit a problem statement", cta: "Propose", sub: "propose" },
@@ -920,7 +917,7 @@ export default async function DashboardPage() {
           {
             id: w.k,
             title: w.title,
-            detail: `Open now — closes ${close.toLocaleDateString("en-US", { month: "long", day: "numeric" })}`,
+            detail: `Open now — closes ${fmtLabDateTime(close)}`,
             href: `/cycles/${activeCycle.id}/${w.sub}`,
             cta: w.cta,
           },
@@ -1001,12 +998,7 @@ export default async function DashboardPage() {
               <p className="mt-1 text-sm text-meta">
                 Pod registration opens{" "}
                 {activeCycleConfig.pod_registration_open
-                  ? new Date(
-                      activeCycleConfig.pod_registration_open
-                    ).toLocaleDateString("en-US", {
-                      month: "long",
-                      day: "numeric",
-                    })
+                  ? fmtLabDateTime(activeCycleConfig.pod_registration_open)
                   : "soon"}
                 . We&apos;ll let you know when it&apos;s time to choose your
                 pods.

--- a/app/(dashboard)/moderator/cycles/[cycle_id]/vote-progress/page.tsx
+++ b/app/(dashboard)/moderator/cycles/[cycle_id]/vote-progress/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { parseWindow } from "@/lib/cycles/lab-time";
 import { ChevronLeft } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound, redirect } from "next/navigation";
@@ -57,9 +58,10 @@ export default async function ModeratorVoteProgressPage({
     .eq("cycle_id", cycleId)
     .single();
 
+  // Naive window columns are UTC instants (lib/cycles/lab-time.ts).
   const now = new Date();
-  const openAt = config?.solution_voting_open ? new Date(config.solution_voting_open) : null;
-  const closeAt = config?.solution_voting_close ? new Date(config.solution_voting_close) : null;
+  const openAt = parseWindow(config?.solution_voting_open);
+  const closeAt = parseWindow(config?.solution_voting_close);
   const isOpen = openAt !== null && closeAt !== null && now >= openAt && now <= closeAt;
 
   // Scope: admins see every pod; moderators see only their assigned pods.

--- a/app/(dashboard)/moderator/page.tsx
+++ b/app/(dashboard)/moderator/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { parseWindow } from "@/lib/cycles/lab-time";
 import { Users } from "lucide-react";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
@@ -398,8 +399,9 @@ function formatPhaseSuffix(
 ): string | null {
   if (!closeAt) return null;
   const now = Date.now();
-  const close = new Date(closeAt).getTime();
-  const open = openAt ? new Date(openAt).getTime() : null;
+  // Window strings are naive-UTC instants (lib/cycles/lab-time.ts).
+  const close = (parseWindow(closeAt) as Date).getTime();
+  const open = openAt ? (parseWindow(openAt) as Date).getTime() : null;
   const dayMs = 86_400_000;
 
   if (open !== null && now < open) {

--- a/app/api/cron/revocation-check/route.ts
+++ b/app/api/cron/revocation-check/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { parseWindow } from "@/lib/cycles/lab-time";
 import { createServiceClient } from "@/lib/supabase/server";
 import { getResendClient, FROM_EMAIL } from "@/lib/email";
 import {
@@ -135,9 +136,12 @@ export async function GET(request: NextRequest) {
       );
       continue;
     }
+    // parseWindow: naive column read explicitly as a UTC instant
+    // (lib/cycles/lab-time.ts) — server-tz-independent.
     const podRegistrationClosed =
       config.pod_registration_close !== null &&
-      new Date(config.pod_registration_close).getTime() < now.getTime();
+      (parseWindow(config.pod_registration_close) as Date).getTime() <
+        now.getTime();
     const missThreshold = config.at_risk_consecutive_misses ?? 2;
 
     // Active enrollments in this cycle, with the participant's identity,

--- a/app/api/registrations/funnel/route.ts
+++ b/app/api/registrations/funnel/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { windowOpen } from "@/lib/cycles/lab-time";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { dbError } from "@/lib/api/errors";
 import { parseBody, isErrorResponse } from "@/lib/api/request";
@@ -215,12 +216,11 @@ export async function POST(request: NextRequest) {
       .eq("cycle_id", recruitingCycle.id)
       .maybeSingle();
 
-    const now = new Date();
-    const isOpen =
-      !!config?.pod_registration_open &&
-      !!config?.pod_registration_close &&
-      now >= new Date(config.pod_registration_open) &&
-      now <= new Date(config.pod_registration_close);
+    // Naive window columns are UTC instants (lib/cycles/lab-time.ts).
+    const isOpen = windowOpen(
+      config?.pod_registration_open,
+      config?.pod_registration_close
+    );
 
     if (isOpen) {
       emailCycleName = recruitingCycle.name;

--- a/lib/auth/windows.ts
+++ b/lib/auth/windows.ts
@@ -1,5 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { one } from "@/lib/supabase/embed";
+import { windowOpen } from "@/lib/cycles/lab-time";
 
 type WindowField =
   | "problem_statement"
@@ -53,12 +54,11 @@ export async function checkWindow(
   const openTime = configRecord[`${field}_open`] as string | null;
   const closeTime = configRecord[`${field}_close`] as string | null;
 
-  if (!openTime || !closeTime) {
-    return { open: false, message: WINDOW_MESSAGES[field] };
-  }
-
-  const now = new Date();
-  if (now < new Date(openTime) || now > new Date(closeTime)) {
+  // windowOpen parses the naive columns explicitly as UTC instants (the
+  // storage convention) — a bare new Date(naive) would read them in the
+  // server's local zone, which diverges between Vercel (UTC) and a dev
+  // laptop. See lib/cycles/lab-time.ts.
+  if (!windowOpen(openTime, closeTime)) {
     return { open: false, message: WINDOW_MESSAGES[field] };
   }
 

--- a/lib/cycles/lab-time.test.ts
+++ b/lib/cycles/lab-time.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseWindow,
+  windowOpen,
+  toLabInput,
+  fromLabInput,
+  fmtLabDateTime,
+  fmtLabDate,
+} from "./lab-time";
+
+/* Cycle 3 runs Jul 14 – Oct 13, 2026 (EDT, UTC-4). US DST 2026:
+   spring forward Mar 8, fall back Nov 1. */
+
+describe("parseWindow", () => {
+  it("parses a naive stored value as UTC (space or T separator)", () => {
+    expect(parseWindow("2026-07-25 13:00:00")?.toISOString()).toBe(
+      "2026-07-25T13:00:00.000Z"
+    );
+    expect(parseWindow("2026-07-25T13:00:00")?.toISOString()).toBe(
+      "2026-07-25T13:00:00.000Z"
+    );
+  });
+  it("respects an explicit zone when present", () => {
+    expect(parseWindow("2026-07-25T13:00:00Z")?.toISOString()).toBe(
+      "2026-07-25T13:00:00.000Z"
+    );
+    expect(parseWindow("2026-07-25T09:00:00-04:00")?.toISOString()).toBe(
+      "2026-07-25T13:00:00.000Z"
+    );
+  });
+  it("handles null/empty/garbage", () => {
+    expect(parseWindow(null)).toBeNull();
+    expect(parseWindow("")).toBeNull();
+    expect(parseWindow("not a date")).toBeNull();
+  });
+});
+
+describe("windowOpen", () => {
+  const open = "2026-07-25T13:00:00"; // 9 AM EDT
+  const close = "2026-07-25T16:00:00"; // noon EDT
+  it("is open inside the window and closed outside", () => {
+    expect(windowOpen(open, close, new Date("2026-07-25T14:00:00Z"))).toBe(true);
+    expect(windowOpen(open, close, new Date("2026-07-25T12:59:00Z"))).toBe(false);
+    expect(windowOpen(open, close, new Date("2026-07-25T16:01:00Z"))).toBe(false);
+  });
+  it("bounds are inclusive", () => {
+    expect(windowOpen(open, close, new Date("2026-07-25T13:00:00Z"))).toBe(true);
+    expect(windowOpen(open, close, new Date("2026-07-25T16:00:00Z"))).toBe(true);
+  });
+  it("missing bounds mean closed", () => {
+    expect(windowOpen(null, close)).toBe(false);
+    expect(windowOpen(open, null)).toBe(false);
+  });
+});
+
+describe("fromLabInput (lab wall-clock → naive UTC)", () => {
+  it("EDT: 9:00 AM ET Jul 25 stores as 13:00 UTC", () => {
+    expect(fromLabInput("2026-07-25T09:00")).toBe("2026-07-25T13:00:00");
+  });
+  it("EST: 9:00 AM ET Dec 1 stores as 14:00 UTC", () => {
+    expect(fromLabInput("2026-12-01T09:00")).toBe("2026-12-01T14:00:00");
+  });
+  it("crosses the date line when late-evening ET lands next-day UTC", () => {
+    expect(fromLabInput("2026-07-28T23:59")).toBe("2026-07-29T03:59:00");
+  });
+  it("day after fall-back (Nov 2) uses EST, not a stale +4", () => {
+    expect(fromLabInput("2026-11-02T09:00")).toBe("2026-11-02T14:00:00");
+  });
+  it("rejects malformed input", () => {
+    expect(fromLabInput("")).toBeNull();
+    expect(fromLabInput("2026-07-25")).toBeNull();
+  });
+});
+
+describe("toLabInput (stored naive UTC → lab wall-clock input value)", () => {
+  it("EDT round-trip", () => {
+    expect(toLabInput("2026-07-25T13:00:00")).toBe("2026-07-25T09:00");
+  });
+  it("EST round-trip", () => {
+    expect(toLabInput("2026-12-01T14:00:00")).toBe("2026-12-01T09:00");
+  });
+  it("empty for null", () => {
+    expect(toLabInput(null)).toBe("");
+  });
+});
+
+describe("round-trip stability", () => {
+  const inputs = [
+    "2026-07-14T18:00", // Kickoff (EDT)
+    "2026-07-28T23:59", // forming close, crosses UTC midnight
+    "2026-10-13T21:00", // Summit end (EDT)
+    "2026-11-02T09:00", // post-fall-back (EST)
+    "2026-03-09T09:00", // post-spring-forward (EDT)
+  ];
+  for (const v of inputs) {
+    it(`toLabInput(fromLabInput(${v})) === ${v}`, () => {
+      expect(toLabInput(fromLabInput(v)!)).toBe(v);
+    });
+  }
+});
+
+describe("display formatting", () => {
+  it("renders the lab wall-clock with the ET label", () => {
+    expect(fmtLabDateTime("2026-07-25T13:00:00")).toBe("Jul 25, 9:00 AM ET");
+  });
+  it("renders EST values correctly too", () => {
+    expect(fmtLabDateTime("2026-12-01T14:00:00")).toBe("Dec 1, 9:00 AM ET");
+  });
+  it("date-only helper renders the lab-local date", () => {
+    // 03:59 UTC on Jul 29 is still Jul 28 in the lab.
+    expect(fmtLabDate("2026-07-29T03:59:00")).toBe("Jul 28");
+  });
+});

--- a/lib/cycles/lab-time.ts
+++ b/lib/cycles/lab-time.ts
@@ -1,0 +1,144 @@
+/* Lab-local time handling for the cycle window columns.
+ *
+ * The twelve cycle_config.*_open/_close columns (+ phase_2/3_start) are
+ * TIMESTAMP WITHOUT TIME ZONE. The storage convention is: **the stored
+ * wall-clock is the instant in UTC** (decided 2026-07-12; S5.1 in
+ * docs/requirements/cycle3-testing-plan.md). Admins THINK in the lab's
+ * local time — DC's America/New_York — so the admin form and every
+ * member-facing "Opens …" hint convert at the boundary:
+ *
+ *   entry  : lab wall-clock (datetime-local) ──fromLabInput──▶ naive UTC
+ *   gates  : naive UTC ──parseWindow──▶ Date (explicit Z, so a dev laptop
+ *            in ET computes the same instant Vercel's UTC runtime does)
+ *   display: naive UTC ──fmtLab*──▶ lab wall-clock, labeled "ET"
+ *
+ * DST is handled by real timezone math (Intl), not a fixed offset — the
+ * EDT→EST flip on Nov 1, 2026 needs no code or data change.
+ *
+ * LAB_TZ is a constant until metros.timezone ships with the Stage 1
+ * calendar overhaul (docs/requirements/cycle-timeline.md); the resolver
+ * that replaces this module reads the cycle's lab timezone from data.
+ */
+
+export const LAB_TZ = "America/New_York";
+
+/** Short label shown next to lab-local times. Correct for both EDT and EST. */
+export const LAB_TZ_LABEL = "ET";
+
+/**
+ * Parse a stored window timestamp into a Date. Naive values ("2026-07-25
+ * 13:00:00" or "2026-07-25T13:00:00") are the-instant-in-UTC by convention;
+ * values that already carry a zone (Z or ±hh[:mm]) parse as themselves.
+ */
+export function parseWindow(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const s = value.trim().replace(" ", "T");
+  const zoned = /(?:Z|[+-]\d{2}:?\d{2})$/.test(s);
+  const d = new Date(zoned ? s : `${s}Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** True when now ∈ [open, close]. False when either bound is missing. */
+export function windowOpen(
+  open: string | null | undefined,
+  close: string | null | undefined,
+  now: Date = new Date()
+): boolean {
+  const o = parseWindow(open);
+  const c = parseWindow(close);
+  return !!o && !!c && now >= o && now <= c;
+}
+
+/* ── Intl plumbing ─────────────────────────────────────────────────────── */
+
+const partsFmt = new Intl.DateTimeFormat("en-US", {
+  timeZone: LAB_TZ,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+function labParts(instant: Date): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const p of partsFmt.formatToParts(instant)) {
+    if (p.type !== "literal") out[p.type] = Number(p.value);
+  }
+  if (out.hour === 24) out.hour = 0; // hourCycle quirk guard
+  return out;
+}
+
+/** LAB_TZ's UTC offset (ms) at a given instant — 4h in EDT, 5h in EST. */
+function labOffsetMs(instant: Date): number {
+  const p = labParts(instant);
+  const asUtc = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
+  return asUtc - instant.getTime();
+}
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/* ── Admin form boundary ───────────────────────────────────────────────── */
+
+/**
+ * Stored naive-UTC timestamp → the "YYYY-MM-DDTHH:mm" value a
+ * datetime-local input needs, expressed in the lab's wall-clock.
+ */
+export function toLabInput(value: string | null): string {
+  const d = parseWindow(value);
+  if (!d) return "";
+  const p = labParts(d);
+  return `${p.year}-${pad(p.month)}-${pad(p.day)}T${pad(p.hour)}:${pad(p.minute)}`;
+}
+
+/**
+ * datetime-local input ("YYYY-MM-DDTHH:mm", lab wall-clock) → the naive
+ * UTC string to store. Two-pass offset lookup handles DST: the second
+ * pass corrects a first guess that landed on the wrong side of a
+ * transition (spring-forward gaps and fall-back ambiguities resolve to
+ * the post-transition offset).
+ */
+export function fromLabInput(val: string): string | null {
+  if (!val) return null;
+  const m = val.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/);
+  if (!m) return null;
+  const [, y, mo, d, hh, mm] = m.map(Number) as unknown as number[];
+  const guess = Date.UTC(y, mo - 1, d, hh, mm);
+  let utc = guess - labOffsetMs(new Date(guess));
+  const second = guess - labOffsetMs(new Date(utc));
+  if (second !== utc) utc = second;
+  const out = new Date(utc);
+  return (
+    `${out.getUTCFullYear()}-${pad(out.getUTCMonth() + 1)}-${pad(out.getUTCDate())}` +
+    `T${pad(out.getUTCHours())}:${pad(out.getUTCMinutes())}:00`
+  );
+}
+
+/* ── Member-facing display ─────────────────────────────────────────────── */
+
+/** "Jul 25, 9:00 AM ET" — a stored window timestamp in lab wall-clock. */
+export function fmtLabDateTime(value: string | null | undefined): string {
+  const d = parseWindow(value);
+  if (!d) return "";
+  const s = new Intl.DateTimeFormat("en-US", {
+    timeZone: LAB_TZ,
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(d);
+  return `${s} ${LAB_TZ_LABEL}`;
+}
+
+/** "Jul 25" — date-only, in lab wall-clock (no tz label; dates read as-is). */
+export function fmtLabDate(value: string | null | undefined): string {
+  const d = parseWindow(value);
+  if (!d) return "";
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: LAB_TZ,
+    month: "short",
+    day: "numeric",
+  }).format(d);
+}

--- a/lib/moderator/phase.ts
+++ b/lib/moderator/phase.ts
@@ -16,6 +16,8 @@
  * rather than an empty state. If the cycle is over, returns null.
  */
 
+import { parseWindow } from "@/lib/cycles/lab-time";
+
 export type PhaseNum = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface ResolvedPhase {
@@ -90,7 +92,10 @@ export function resolveCurrentPhase(
     const openAt = cfg[spec.openKey];
     const closeAt = cfg[spec.closeKey];
     if (!openAt || !closeAt) continue;
-    if (now >= new Date(openAt) && now <= new Date(closeAt)) {
+    if (
+      now >= (parseWindow(openAt) as Date) &&
+      now <= (parseWindow(closeAt) as Date)
+    ) {
       return toResolved(spec, openAt, closeAt, true);
     }
   }
@@ -101,7 +106,7 @@ export function resolveCurrentPhase(
   for (const spec of PHASES) {
     const openAt = cfg[spec.openKey];
     if (!openAt) continue;
-    const openMs = new Date(openAt).getTime();
+    const openMs = (parseWindow(openAt) as Date).getTime();
     if (openMs > now.getTime() && openMs < upcomingOpenMs) {
       upcoming = toResolved(spec, openAt, cfg[spec.closeKey], false);
       upcomingOpenMs = openMs;


### PR DESCRIPTION
## What

Owner decision (2026-07-12): admins and members should see and enter window times in the **lab's local timezone** — `America/New_York` for the DC lab, EDT or EST as the calendar dictates — not UTC. Draft until preview-tested; do not merge to `dev` before that.

## Design

**Storage unchanged, boundaries convert.** The naive `cycle_config` window columns keep holding the instant as UTC wall-clock (so all values already entered under the interim "type UTC" convention remain correct); conversion happens at entry and display:

- **`lib/cycles/lab-time.ts`** (new, +22 tests): `LAB_TZ` constant (interim until `metros.timezone` ships with Stage 1), `parseWindow` (reads naive values *explicitly* as UTC — a bare `new Date(naive)` diverged between Vercel's UTC runtime and an ET dev laptop), `windowOpen`, DST-correct wall-clock↔UTC via `Intl` two-pass offset (no fixed +4 — the Nov 1 EDT→EST flip needs no change), and lab-local formatters labeled "ET". Tests cover both DST boundaries, cross-midnight round-trips, EST dates.
- **Admin form**: `datetime-local` inputs now display/accept lab wall-clock; column headers read **Opens (ET) / Closes (ET)**. Type "Jul 25, 9:00 AM" → gate opens 9:00 AM Eastern.
- **All gate reads** go through `parseWindow`/`windowOpen`: `checkWindow`, propose, vote, register-pods, join ceremony, solutions, solution-vote, register-projects, dashboard `podWindowOpen` + Up-Next, registrations funnel route, revocation cron, moderator phase resolver, vote-progress.
- **All member-facing "Opens/Closes …" hints** render lab-local with an ET label (previously server-local, unlabeled).

## Interlocks

- **After merge**: the Cycle-3 entry sheet on #240 says "type UTC" — flip it to "type Eastern" (I'll do that once this lands; the two instructions must never coexist on dev).
- Any window values already stored (entered as UTC) will now *display* as their intended Eastern times — verify once on the preview.
- `log_due_at` is `TIMESTAMPTZ` and untouched. `cycles.start_date`/`end_date` are date-only and untouched.

## Verify (preview)

1. Admin → cycle config: stored `13:00` shows as `09:00` in the input; save round-trips unchanged; headers say ET.
2. Set a test window a few minutes ahead **typing Eastern wall-clock** — the gate flips at that Eastern minute.
3. A closed window's "Opens Jul 25, 9:00 AM ET" hint shows Eastern with the label, in both an ET and a PT browser (two-clock rule).

- [x] `npm run lint` passes (0 errors; 8 pre-existing warnings)
- [x] `npm run test` passes (303 — 22 new)
- [x] `npm run build` passes

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX)_