### PR TITLE
feat(cycles): Stage 1 calendar — cycle_phases/cycle_events + D-10 registration gate

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -52,6 +52,8 @@ flowchart TD
 
 > **Sector model — Phase A (migration `00049`, `docs/SECTOR_MODEL.md`).** `sectors` is the durable, cross-cohort home for a theme's projects + field research (public commons; `status` active/dormant). A cycle is a *run under a sector*: `cycles.sector_id` FK + `cycles.mode` (`open`/`closed`/`org` — `org` added by migration `00060`, see below). The lifecycle extends to **draft → upcoming → active → closing → archived** (`closed` kept as a legacy terminal), with a sibling `one_upcoming_cycle` partial unique index (≤1 `upcoming`) — since rescoped per mode by `00060` (previous paragraph). `cycle_enrollments.tier` (`member`/`contributor`) is the cohort authority tier; `projects.sector_id` + `projects.governance` (`cycle`→`sector` at graduation) give a project its durable home. Reads split via `lib/cycle/active.ts`: `getOperatingCycle()` (the `active` cohort) vs `getRecruitingCycle()` (the `upcoming` cohort, else active). Phases B–D (windows/tiers UI, graduation, living sector) are still design-only.
 
+> **Cycle calendar — Stage 1 (migration `00085`, `docs/requirements/cycle-timeline.md`).** `cycle_phases` and `cycle_events` are the tz-aware **read model** for the cycle schedule: phases are born `TIMESTAMPTZ` rows (`[starts_at, ends_at)` semantics), so gating no longer depends on the naive-column-as-UTC convention. The seven `phase_key`s are the six spine phases (`problem_statement`, `voting`, `pod_forming`, `solution_proposal`, `solution_voting`, `project_registration` — `pod_forming` is seeded from the legacy `pod_registration_*` pair per the two-window split in `docs/requirements/pod-registration.md`) plus the `pod_active_join` **overlay**, which is *derived*, not entered: `cycle_config.phase_2_start` (the Meet-the-Pods marker) → `project_registration_close`. For Stage 1 the **write model stays `cycle_config`** — the admin schedule PATCH writes the legacy naive columns and calls `syncPhasesFromConfig()` (`lib/cycles/schedule.ts`) so phase rows always mirror them; Stage 2 flips write authority and retires the columns. `cycle_events` holds the cohort's anchor events (kickoff, Problem Sprint, Meet the Pods, hackathon, Meet the Projects, summit) with an optional `luma_api_id` for Luma sync. Same migration: `cycles.start_at TIMESTAMPTZ` (backfilled from `start_date` at lab-local midnight) and `metros.timezone` (default `America/New_York`). The window resolver (`lib/auth/windows.ts`) and the D-10 cycle-registration gate (`registrationWindow()`) read phases first and fall back to the legacy columns for cycles without rows.
+
 > **Org cycles (migration `00060`, `docs/ORG_CYCLES.md`).** The org (HQ + Core Contributors) runs quarterly cycles on internal workstreams — `cycles.mode='org'`, dogfooding the participant cycle machinery instead of forking it — under a seeded `sectors` row (`slug='the-upskilling-labs-hq'`). `workstreams` is the durable, cross-cycle unit of internal work; each org cycle spins up a per-workstream "run", which is an ordinary `pods` row (`pods.workstream_id` FK, `problem_statement_id` now nullable — a run is chartered, not voted into existence from a ballot). Co-leads on a run are `moderator_assignments` + `pod_memberships`; core contributors are invite-only `pod_memberships` (`invitations.pod_role` — `co_lead` fulfills into `moderator_assignments` + `pod_memberships`, `member` into `pod_memberships` only; `NULL` = legacy poderator-only invite). Org *projects* are chartered by a run's co-leads rather than voted out of a `solution_proposals` ballot, so `projects.solution_proposal_id` is now nullable too; `projects.forked_from_project_id` is a fork-lineage pointer (no endpoint/UI yet). ICs join a project via `project_subscriptions` (self-serve follow) and, once promoted by a DRI, `project_roles` (`dri`/`contributor`) — the open-source-style ladder SECTOR_MODEL §5/§7 describes, reused for both org and participant projects.
 
 ```mermaid
@@ -62,10 +64,32 @@ erDiagram
         varchar slug UK
         timestamp start_date
         timestamp end_date
+        timestamptz start_at "real instant; backfilled from start_date at lab-local midnight (00085)"
         varchar status
         int sector_id FK "→ sectors(id) (00049)"
         int lab_id FK "→ metros(id), NULL = HQ/global (00062)"
         varchar mode "open/closed/org (00049; org added 00060)"
+    }
+
+    cycle_phases {
+        int id PK
+        int cycle_id FK "→ cycles(id) CASCADE (00085)"
+        text phase_key "UK with cycle_id; 6 spine keys + pod_active_join"
+        text kind "spine/overlay"
+        smallint position "spine order; NULL for overlays"
+        text anchor "informational in v1"
+        interval duration "informational in v1"
+        timestamptz starts_at
+        timestamptz ends_at "CHECK starts_at < ends_at"
+    }
+
+    cycle_events {
+        int id PK
+        int cycle_id FK "→ cycles(id) CASCADE (00085)"
+        text key "UK with cycle_id; kickoff/problem_sprint/…"
+        text label
+        timestamptz occurs_at
+        text luma_api_id "nullable — Luma sync hook"
     }
 
     cycle_config {
@@ -166,6 +190,8 @@ erDiagram
     }
 
     cycles ||--|| cycle_config : "configures"
+    cycles ||--o{ cycle_phases : "schedules (00085)"
+    cycles ||--o{ cycle_events : "anchors (00085)"
     participants ||--o{ participant_options : "selects"
     option_lists ||--o{ participant_options : "defines"
 ```
@@ -513,6 +539,7 @@ erDiagram
         int waiting_baseline
         text blurb
         text_array zip_prefixes
+        text timezone "IANA zone, default America/New_York (00085)"
     }
 
     metro_waitlist_signups {

--- a/app/(dashboard)/cycles/[cycle_id]/join/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/join/page.tsx
@@ -1,6 +1,9 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
+import { ArrowRight } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
-import { windowOpen } from "@/lib/cycles/lab-time";
+import { windowOpen, fmtLabDateTime } from "@/lib/cycles/lab-time";
+import { registrationWindow } from "@/lib/cycles/schedule";
 import CycleCeremony from "./ceremony";
 
 // The cycle registration ceremony (onboarding-proto: view-cycle-threshold →
@@ -81,6 +84,40 @@ export default async function JoinCyclePage({
     .eq("participant_id", participant.id)
     .eq("cycle_id", cycleId)
     .maybeSingle();
+
+  // D-10 gate (docs/requirements/pod-registration.md, owner 2026-07-12):
+  // self-serve registration is open only while a new member can still land
+  // in a pod — through pod-forming close, and again during the active-join
+  // window. Members who already signed pass through to their confirmation;
+  // the agreement API enforces the same rule server-side, this is the
+  // friendly surface for it.
+  if (!agreement) {
+    const regWindow = await registrationWindow(serviceClient, cycleId);
+    if (!regWindow.open) {
+      return (
+        <div className="mx-auto max-w-xl py-12">
+          <div className="rounded-card border border-ink/10 bg-white p-8 shadow-card">
+            <div className="lbl mb-2">Registration closed</div>
+            <h1 className="t-h2 text-ink">{cycle.name}</h1>
+            <p className="mt-3 text-meta">
+              {regWindow.state === "dead_zone" && regWindow.reopensAt
+                ? `Pods are forming right now, so registration is paused. It reopens ${fmtLabDateTime(
+                    regWindow.reopensAt.toISOString()
+                  )}, when pods open to new members — check back then.`
+                : "Registration for this cycle has closed. Keep an eye out for the next Build Cycle."}
+            </p>
+            <Link
+              href="/cycles"
+              className="mt-6 inline-flex items-center gap-1.5 text-sm font-semibold tracking-tight text-teal-deep hover:underline"
+            >
+              Back to cycles
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
+        </div>
+      );
+    }
+  }
 
   // Pod-registration window drives the confirmation's primary CTA.
   const { data: config } = await serviceClient

--- a/app/(dashboard)/cycles/page.tsx
+++ b/app/(dashboard)/cycles/page.tsx
@@ -64,22 +64,21 @@ export default async function CyclesPage() {
   // never another lab's internal cycle.
   const memberLabId: number | null = me?.metro_id ?? null;
   const cycles = (allCycles ?? []).filter(
-    (c) =>
-      c.lab_id === null || (c.mode === "org" && c.lab_id === memberLabId)
+    (c) => c.lab_id === null || (c.mode === "org" && c.lab_id === memberLabId),
   );
 
   // Fetch config for the active cycle to power the phase indicator — the
   // single HQ open cycle.
   const activeCycle =
     cycles.find(
-      (c) => c.status === "active" && c.mode === "open" && c.lab_id === null
+      (c) => c.status === "active" && c.mode === "open" && c.lab_id === null,
     ) ?? null;
   let activeCycleConfig = null;
   if (activeCycle) {
     const { data } = await serviceClient
       .from("cycle_config")
       .select(
-        "phase_2_start, phase_3_start, problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close"
+        "phase_2_start, phase_3_start, problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close",
       )
       .eq("cycle_id", activeCycle.id)
       .single();
@@ -97,7 +96,7 @@ export default async function CyclesPage() {
   // An upcoming (non-org) cohort is open for registration — surface it as
   // its own "Register" section, never buried under "Past cycles".
   const upcomingCycles = otherCycles.filter(
-    (c) => c.mode !== "org" && c.status === "upcoming"
+    (c) => c.mode !== "org" && c.status === "upcoming",
   );
 
   // D-10 (docs/requirements/pod-registration.md): cycle registration closes
@@ -161,9 +160,7 @@ export default async function CyclesPage() {
           className="group mb-8 flex items-center justify-between rounded-card border border-teal/30 bg-teal/10 p-5 transition-colors duration-150 ease-out hover:border-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
         >
           <div>
-            <h2 className="t-h3 text-ink">
-              {activeCycle.name}
-            </h2>
+            <h2 className="t-h3 text-ink">{activeCycle.name}</h2>
             <p className="mt-0.5 text-sm text-meta">
               {new Date(activeCycle.start_date).toLocaleDateString()} &ndash;{" "}
               {new Date(activeCycle.end_date).toLocaleDateString()}
@@ -227,15 +224,28 @@ export default async function CyclesPage() {
         </div>
       )}
 
-      {/* Upcoming — open for registration. The CTA goes to the registration
-          ceremony (/join), not the read-only info view. */}
+      {/* Upcoming — the next cohort(s). The CTA goes to the registration
+          ceremony (/join), not the read-only info view. The header only
+          claims "Open for registration" while at least one cycle's D-10
+          window actually is open (or the member is already registered);
+          otherwise it stays state-neutral — a gated cycle under an "open"
+          banner contradicts its own "Registration closed" CTA. */}
       {upcomingCycles.length > 0 && (
         <>
-          <h2 className="lbl mb-4">Open for registration</h2>
+          <h2 className="lbl mb-4">
+            {upcomingCycles.some(
+              (c) =>
+                registeredCycleIds.has(c.id) ||
+                (regWindows.get(c.id)?.open ?? true),
+            )
+              ? "Open for registration"
+              : "Next cohort"}
+          </h2>
           <div className="mb-8 autogrid">
             {upcomingCycles.map((cycle) => {
               const w = regWindows.get(cycle.id);
-              const regClosed = !registeredCycleIds.has(cycle.id) && w && !w.open;
+              const regClosed =
+                !registeredCycleIds.has(cycle.id) && w && !w.open;
               const cta = registeredCycleIds.has(cycle.id)
                 ? "You’re registered — view details"
                 : !regClosed
@@ -295,9 +305,7 @@ export default async function CyclesPage() {
                   className="rounded-card border border-ink/10 bg-white p-6 shadow-card transition-colors duration-150 ease-out hover:border-ink/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
                 >
                   <div className="flex items-start justify-between gap-3">
-                    <h3 className="t-h4 text-ink">
-                      {cycle.name}
-                    </h3>
+                    <h3 className="t-h4 text-ink">{cycle.name}</h3>
                     <StatusBadge variant={variant}>{cycle.status}</StatusBadge>
                   </div>
                   <p className="mt-2 text-sm text-meta">

--- a/app/(dashboard)/cycles/page.tsx
+++ b/app/(dashboard)/cycles/page.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
 import { BookOpen, ArrowRight } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { fmtLabDateTime } from "@/lib/cycles/lab-time";
+import {
+  registrationWindow,
+  type RegistrationWindow,
+} from "@/lib/cycles/schedule";
 import { StatusBadge } from "@/app/components/ui";
 import CyclePhaseIndicator from "./cycle-phase-indicator";
 
@@ -94,6 +99,15 @@ export default async function CyclesPage() {
   const upcomingCycles = otherCycles.filter(
     (c) => c.mode !== "org" && c.status === "upcoming"
   );
+
+  // D-10 (docs/requirements/pod-registration.md): cycle registration closes
+  // between pod-forming close and the active-join window, then again after
+  // active-join ends — the CTA must say so instead of "Register". At most a
+  // cohort or two is upcoming at once, so per-cycle lookups are fine.
+  const regWindows = new Map<number, RegistrationWindow>();
+  for (const c of upcomingCycles) {
+    regWindows.set(c.id, await registrationWindow(serviceClient, c.id));
+  }
   // Everything else, in the query's original start_date-descending order —
   // a single filter over `otherCycles` rather than two mode-partitioned
   // filters concatenated, so an archived org cycle sorts alongside past
@@ -219,32 +233,45 @@ export default async function CyclesPage() {
         <>
           <h2 className="lbl mb-4">Open for registration</h2>
           <div className="mb-8 autogrid">
-            {upcomingCycles.map((cycle) => (
-              <Link
-                key={cycle.id}
-                href={`/cycles/${cycle.id}/join`}
-                className="group rounded-card border border-teal/30 bg-teal/10 p-6 transition-colors duration-150 ease-out hover:border-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <h3 className="t-h4 text-ink">{cycle.name}</h3>
-                  <StatusBadge variant={STATUS_VARIANT.upcoming}>
-                    {cycle.status}
-                  </StatusBadge>
-                </div>
-                <p className="mt-2 text-sm text-meta">
-                  Starts {new Date(cycle.start_date).toLocaleDateString()}
-                </p>
-                <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold tracking-tight text-teal-deep">
-                  {registeredCycleIds.has(cycle.id)
-                    ? "You’re registered — view details"
-                    : "Register"}
-                  <ArrowRight
-                    className="h-4 w-4 transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
-                    aria-hidden
-                  />
-                </span>
-              </Link>
-            ))}
+            {upcomingCycles.map((cycle) => {
+              const w = regWindows.get(cycle.id);
+              const regClosed = !registeredCycleIds.has(cycle.id) && w && !w.open;
+              const cta = registeredCycleIds.has(cycle.id)
+                ? "You’re registered — view details"
+                : !regClosed
+                  ? "Register"
+                  : w?.state === "dead_zone" && w.reopensAt
+                    ? `Registration reopens ${fmtLabDateTime(w.reopensAt.toISOString())}`
+                    : "Registration closed";
+              return (
+                <Link
+                  key={cycle.id}
+                  href={`/cycles/${cycle.id}/join`}
+                  className="group rounded-card border border-teal/30 bg-teal/10 p-6 transition-colors duration-150 ease-out hover:border-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <h3 className="t-h4 text-ink">{cycle.name}</h3>
+                    <StatusBadge variant={STATUS_VARIANT.upcoming}>
+                      {cycle.status}
+                    </StatusBadge>
+                  </div>
+                  <p className="mt-2 text-sm text-meta">
+                    Starts {new Date(cycle.start_date).toLocaleDateString()}
+                  </p>
+                  <span
+                    className={`mt-4 inline-flex items-center gap-1.5 text-sm font-semibold tracking-tight ${
+                      regClosed ? "text-meta" : "text-teal-deep"
+                    }`}
+                  >
+                    {cta}
+                    <ArrowRight
+                      className="h-4 w-4 transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+                      aria-hidden
+                    />
+                  </span>
+                </Link>
+              );
+            })}
           </div>
         </>
       )}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { windowOpen, parseWindow, fmtLabDateTime } from "@/lib/cycles/lab-time";
+import { registrationWindow } from "@/lib/cycles/schedule";
 import { redirect } from "next/navigation";
 import { ArrowRight, Calendar } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
@@ -441,6 +442,17 @@ export default async function DashboardPage() {
       ? preRegisteredUpcoming
       : hasAgreement || enrollment?.status === "active";
 
+  // D-10 (docs/requirements/pod-registration.md): registration for a cohort
+  // closes between pod-forming close and the active-join window, and again
+  // after active-join ends. Gates the register checklist row and the join
+  // CTA card below — members who already signed keep their done row and
+  // confirmation regardless of the window.
+  const regWindow =
+    registerCycle && !registerDone
+      ? await registrationWindow(serviceClient, registerCycle.id)
+      : null;
+  const regOpen = registerDone || (regWindow?.open ?? false);
+
   // The field survey is the cohort's opening activity and the member's first
   // CTA (SENSEMAKING_FLOW §2, Stage 0–1). Surface the survey tied to the cohort
   // the member is engaged with (its cycle, else its sector commons). The
@@ -466,8 +478,10 @@ export default async function DashboardPage() {
   const checklistItems: ChecklistItem[] = [
     // Cycle registration leads the list — it's the reason most members are
     // here, and testers looked for it above the housekeeping rows (July 2026
-    // feedback: "civics/elections registration comes first").
-    ...(registerCycle
+    // feedback: "civics/elections registration comes first"). Hidden while
+    // the D-10 window is closed (nothing actionable); a signed member's done
+    // row always shows.
+    ...(registerCycle && regOpen
       ? [
           {
             key: "register",
@@ -619,6 +633,23 @@ export default async function DashboardPage() {
             )}`
           : ""}
         . We&apos;ll open your next steps here when it starts.
+      </p>
+    </div>
+  );
+
+  // Shown instead of the join card while the D-10 registration window is
+  // closed — names the reopen instant during the dead zone (pods forming),
+  // plain "closed" after active-join ends.
+  const registrationClosedCard = (cycle: CycleCardData) => (
+    <div className="rounded-card border border-ink/10 bg-white p-8 shadow-card">
+      <div className="lbl mb-2">Registration closed</div>
+      <h2 className="t-h3 text-ink">{cycle.name}</h2>
+      <p className="mt-2 text-sm text-meta">
+        {regWindow?.state === "dead_zone" && regWindow.reopensAt
+          ? `Pods are forming right now, so registration is paused. It reopens ${fmtLabDateTime(
+              regWindow.reopensAt.toISOString()
+            )}, when pods open to new members.`
+          : "Registration for this cycle has closed. The next Build Cycle will show up right here."}
       </p>
     </div>
   );
@@ -822,8 +853,12 @@ export default async function DashboardPage() {
               (upcomingCycle
                 ? preRegisteredUpcoming
                   ? preRegisteredCard(upcomingCycle)
-                  : joinCycleCard(upcomingCycle, true)
-                : joinCycleCard(activeCycle, false))}
+                  : regOpen
+                    ? joinCycleCard(upcomingCycle, true)
+                    : registrationClosedCard(upcomingCycle)
+                : regOpen
+                  ? joinCycleCard(activeCycle, false)
+                  : registrationClosedCard(activeCycle))}
             {logDueBanner}
             {leadershipSection}
             <div className="mt-8">{feedFor(!orgActive)}</div>
@@ -865,8 +900,10 @@ export default async function DashboardPage() {
               (upcomingCycle ? (
                 preRegisteredUpcoming ? (
                   preRegisteredCard(upcomingCycle)
-                ) : (
+                ) : regOpen ? (
                   joinCycleCard(upcomingCycle, true)
+                ) : (
+                  registrationClosedCard(upcomingCycle)
                 )
               ) : (
                 <EmptyState

--- a/app/api/cycles/[cycle_id]/agreement/route.ts
+++ b/app/api/cycles/[cycle_id]/agreement/route.ts
@@ -6,6 +6,8 @@ import { parseBody, isErrorResponse } from "@/lib/api/request";
 import { parseIntParam } from "@/lib/api/params";
 import { cycleAgreementSchema } from "@/lib/validations/cycle-agreement";
 import { requireActiveLabMembership } from "@/lib/labs/membership";
+import { registrationWindow } from "@/lib/cycles/schedule";
+import { fmtLabDateTime } from "@/lib/cycles/lab-time";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 
 // The Open Cycle Agreement signature (backend doc §2c) — the completion of
@@ -122,6 +124,26 @@ export const POST = withAuth(
       return NextResponse.json(
         { agreement: existing, already_signed: true },
         { status: 200 }
+      );
+    }
+
+    // D-10 (pod-registration.md, owner 2026-07-12): self-serve cycle
+    // registration is open through pod_forming close and again during
+    // pod_active_join. New signatures outside those windows are refused;
+    // already-signed members returned above are unaffected, and invite
+    // fulfillment never calls this route.
+    const regWindow = await registrationWindow(supabase, cycleId);
+    if (!regWindow.open) {
+      return NextResponse.json(
+        {
+          error:
+            regWindow.state === "dead_zone" && regWindow.reopensAt
+              ? `Cycle registration is paused until pods reopen on ${fmtLabDateTime(
+                  regWindow.reopensAt.toISOString()
+                )}.`
+              : "Cycle registration has closed for this cycle.",
+        },
+        { status: 403 }
       );
     }
 

--- a/app/api/cycles/[cycle_id]/config/route.ts
+++ b/app/api/cycles/[cycle_id]/config/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { syncPhasesFromConfig } from "@/lib/cycles/schedule";
 import { withAdminAuth } from "@/lib/auth/middleware";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 import { dbError } from "@/lib/api/errors";
@@ -62,6 +63,25 @@ export const PATCH = withAdminAuth(
 
     if (error) {
       return dbError(error);
+    }
+
+    // Stage 1 calendar overhaul: keep the cycle_phases read model in sync
+    // with the legacy columns (single write path — see
+    // lib/cycles/schedule.ts). A sync failure must be loud, not silent:
+    // divergent stores would gate members off the wrong clock.
+    if (cycle?.mode !== "org") {
+      try {
+        await syncPhasesFromConfig(cycleId);
+      } catch (e) {
+        return NextResponse.json(
+          {
+            error: `Saved, but the phase schedule failed to sync: ${
+              e instanceof Error ? e.message : "unknown error"
+            }. Re-save to retry.`,
+          },
+          { status: 500 }
+        );
+      }
     }
 
     return NextResponse.json(data);

--- a/lib/auth/windows.ts
+++ b/lib/auth/windows.ts
@@ -1,6 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { one } from "@/lib/supabase/embed";
-import { windowOpen } from "@/lib/cycles/lab-time";
+import { windowOpen, parseWindow } from "@/lib/cycles/lab-time";
 
 type WindowField =
   | "problem_statement"
@@ -9,6 +9,19 @@ type WindowField =
   | "solution_proposal"
   | "solution_voting"
   | "project_registration";
+
+// Stage 1 calendar overhaul (00085): cycle_phases is the tz-aware read
+// model. The legacy pod_registration field maps onto the pod_forming phase
+// (pod-registration.md two-window split); every other field key matches its
+// phase_key. Stage 2 adds pod_active_join-aware routing per pod status.
+const FIELD_TO_PHASE: Record<WindowField, string> = {
+  problem_statement: "problem_statement",
+  voting: "voting",
+  pod_registration: "pod_forming",
+  solution_proposal: "solution_proposal",
+  solution_voting: "solution_voting",
+  project_registration: "project_registration",
+};
 
 const WINDOW_MESSAGES: Record<WindowField, string> = {
   problem_statement: "Problem statement submission is not currently open.",
@@ -51,13 +64,36 @@ export async function checkWindow(
     };
   }
 
+  // Phases-first: when the cycle has phase rows (00085), they are the
+  // source for gating — [starts_at, ends_at), per cycle-timeline.md. The
+  // admin PATCH keeps them in sync with the legacy columns
+  // (lib/cycles/schedule.ts), so this and the fallback agree; the phases
+  // path simply wins once rows exist.
+  const { data: phase } = await supabase
+    .from("cycle_phases")
+    .select("starts_at, ends_at")
+    .eq("cycle_id", cycleId)
+    .eq("phase_key", FIELD_TO_PHASE[field])
+    .maybeSingle();
+
+  if (phase) {
+    const starts = parseWindow(phase.starts_at);
+    const ends = parseWindow(phase.ends_at);
+    const now = new Date();
+    if (starts && ends && now >= starts && now < ends) {
+      return { open: true, message: "" };
+    }
+    return { open: false, message: WINDOW_MESSAGES[field] };
+  }
+
   const openTime = configRecord[`${field}_open`] as string | null;
   const closeTime = configRecord[`${field}_close`] as string | null;
 
-  // windowOpen parses the naive columns explicitly as UTC instants (the
-  // storage convention) — a bare new Date(naive) would read them in the
-  // server's local zone, which diverges between Vercel (UTC) and a dev
-  // laptop. See lib/cycles/lab-time.ts.
+  // Legacy fallback (no phase rows yet — pre-00085 data or a cycle whose
+  // schedule was never synced). windowOpen parses the naive columns
+  // explicitly as UTC instants (the storage convention) — a bare
+  // new Date(naive) would read them in the server's local zone, which
+  // diverges between Vercel (UTC) and a dev laptop. See lib/cycles/lab-time.ts.
   if (!windowOpen(openTime, closeTime)) {
     return { open: false, message: WINDOW_MESSAGES[field] };
   }

--- a/lib/cycles/schedule.test.ts
+++ b/lib/cycles/schedule.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  phaseRowsFromConfig,
+  deriveRegistrationWindow,
+} from "./schedule";
+
+/* Cycle 3 shape (naive-UTC storage convention; ET intent in comments). */
+const CYCLE3 = {
+  problem_statement_open: "2026-07-25T13:00:00", // 9 AM ET
+  problem_statement_close: "2026-07-25T16:00:00", // noon ET
+  voting_open: "2026-07-25T16:00:00",
+  voting_close: "2026-07-25T17:00:00",
+  pod_registration_open: "2026-07-25T17:00:00", // forming
+  pod_registration_close: "2026-07-29T03:59:00", // Jul 28 11:59 PM ET
+  solution_proposal_open: "2026-08-13T13:00:00",
+  solution_proposal_close: "2026-08-19T03:59:00",
+  solution_voting_open: "2026-08-19T04:00:00",
+  solution_voting_close: "2026-08-21T03:59:00",
+  project_registration_open: "2026-08-21T04:00:00",
+  project_registration_close: "2026-08-26T03:59:00", // Aug 25 11:59 PM ET
+  phase_2_start: "2026-08-11T22:00:00", // Meet the Pods, 6 PM ET
+  phase_3_start: "2026-09-08T22:00:00",
+};
+
+describe("phaseRowsFromConfig", () => {
+  it("derives six spine phases + the active-join overlay from Cycle 3", () => {
+    const rows = phaseRowsFromConfig(CYCLE3);
+    expect(rows).toHaveLength(7);
+
+    const forming = rows.find((r) => r.phase_key === "pod_forming")!;
+    expect(forming.kind).toBe("spine");
+    expect(forming.position).toBe(3);
+    expect(forming.starts_at).toBe("2026-07-25T17:00:00.000Z");
+    expect(forming.ends_at).toBe("2026-07-29T03:59:00.000Z");
+
+    const aj = rows.find((r) => r.phase_key === "pod_active_join")!;
+    expect(aj.kind).toBe("overlay");
+    expect(aj.position).toBeNull();
+    expect(aj.starts_at).toBe("2026-08-11T22:00:00.000Z"); // = phase_2_start
+    expect(aj.ends_at).toBe("2026-08-26T03:59:00.000Z"); // = project reg close
+  });
+
+  it("skips pairs with a missing or inverted bound", () => {
+    const rows = phaseRowsFromConfig({
+      ...CYCLE3,
+      voting_open: null,
+      solution_voting_open: "2026-08-22T00:00:00", // after its close
+    });
+    const keys = rows.map((r) => r.phase_key);
+    expect(keys).not.toContain("voting");
+    expect(keys).not.toContain("solution_voting");
+    expect(keys).toContain("problem_statement");
+  });
+
+  it("omits the overlay when its anchors are absent", () => {
+    const rows = phaseRowsFromConfig({ ...CYCLE3, phase_2_start: null });
+    expect(rows.map((r) => r.phase_key)).not.toContain("pod_active_join");
+  });
+
+  it("yields nothing for an empty config (org cycles)", () => {
+    expect(phaseRowsFromConfig({})).toHaveLength(0);
+  });
+});
+
+describe("deriveRegistrationWindow (D-10)", () => {
+  const forming = Date.parse("2026-07-29T03:59:00Z"); // forming closes
+  const ajStart = Date.parse("2026-08-11T22:00:00Z"); // Meet the Pods
+  const ajEnd = Date.parse("2026-08-26T03:59:00Z"); // active-join closes
+  const bounds = {
+    formingEndMs: forming,
+    activeJoinStartMs: ajStart,
+    activeJoinEndMs: ajEnd,
+  };
+  const at = (iso: string) => Date.parse(iso);
+
+  it("open from cycle open through forming close", () => {
+    expect(deriveRegistrationWindow(bounds, at("2026-07-15T00:00:00Z"))).toEqual({
+      open: true,
+      state: "open",
+      reopensAt: null,
+    });
+    // inclusive at the boundary
+    expect(deriveRegistrationWindow(bounds, forming).open).toBe(true);
+  });
+
+  it("closed across the dead zone, naming the reopen instant", () => {
+    const w = deriveRegistrationWindow(bounds, at("2026-08-01T00:00:00Z"));
+    expect(w.open).toBe(false);
+    expect(w.state).toBe("dead_zone");
+    expect(w.reopensAt?.getTime()).toBe(ajStart);
+  });
+
+  it("open again for the whole active-join window", () => {
+    expect(
+      deriveRegistrationWindow(bounds, at("2026-08-15T00:00:00Z"))
+    ).toEqual({ open: true, state: "active_join", reopensAt: null });
+    expect(deriveRegistrationWindow(bounds, ajEnd).open).toBe(true);
+  });
+
+  it("closed after active-join ends", () => {
+    const w = deriveRegistrationWindow(bounds, at("2026-09-01T00:00:00Z"));
+    expect(w).toEqual({ open: false, state: "closed", reopensAt: null });
+  });
+
+  it("no forming bound configured → legacy open behavior", () => {
+    expect(
+      deriveRegistrationWindow(
+        { formingEndMs: null, activeJoinStartMs: null, activeJoinEndMs: null },
+        at("2026-09-01T00:00:00Z")
+      ).open
+    ).toBe(true);
+  });
+
+  it("forming closed with no active-join bounds → closed, no reopen date", () => {
+    const w = deriveRegistrationWindow(
+      { formingEndMs: forming, activeJoinStartMs: null, activeJoinEndMs: null },
+      at("2026-08-01T00:00:00Z")
+    );
+    expect(w).toEqual({ open: false, state: "closed", reopensAt: null });
+  });
+});

--- a/lib/cycles/schedule.ts
+++ b/lib/cycles/schedule.ts
@@ -1,0 +1,258 @@
+/* Cycle schedule service — Stage 1 of the calendar overhaul
+ * (docs/requirements/cycle-timeline.md + implementation-plan.md).
+ *
+ * cycle_phases / cycle_events (00085) are the tz-aware read model:
+ * the window resolver (lib/auth/windows.ts) and the D-10 cycle-registration
+ * gate read phase rows. For Stage 1 the WRITE model stays cycle_config —
+ * the admin schedule PATCH keeps writing the legacy naive columns (one
+ * write path, zero divergence risk mid-cycle) and calls
+ * syncPhasesFromConfig() so the phase rows always mirror them. Stage 2
+ * flips write authority to cycle_phases and retires the columns once the
+ * page sweep is done.
+ *
+ * pod_active_join is DERIVED, not entered: Meet-the-Pods marker
+ * (cycle_config.phase_2_start) → project_registration_close
+ * (cycle-timeline.md window table; pod-registration.md two-window split).
+ * Editing those two existing form fields moves the active-join window —
+ * no new admin UI, and the O-1 "re-enter pod_registration on Aug 11"
+ * fallback becomes unnecessary.
+ *
+ * All *_open/_close/phase_2_start values here follow the S5.1 storage
+ * convention: naive wall-clock that IS the instant in UTC
+ * (lib/cycles/lab-time.ts).
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServiceClient } from "@/lib/supabase/server";
+import { parseWindow } from "@/lib/cycles/lab-time";
+
+export type PhaseKey =
+  | "problem_statement"
+  | "voting"
+  | "pod_forming"
+  | "pod_active_join"
+  | "solution_proposal"
+  | "solution_voting"
+  | "project_registration";
+
+export interface PhaseRowInput {
+  phase_key: PhaseKey;
+  kind: "spine" | "overlay";
+  position: number | null;
+  starts_at: string; // ISO instant
+  ends_at: string; // ISO instant
+}
+
+/** The naive cycle_config columns the schedule derives from. */
+export interface ScheduleConfig {
+  problem_statement_open?: string | null;
+  problem_statement_close?: string | null;
+  voting_open?: string | null;
+  voting_close?: string | null;
+  pod_registration_open?: string | null;
+  pod_registration_close?: string | null;
+  solution_proposal_open?: string | null;
+  solution_proposal_close?: string | null;
+  solution_voting_open?: string | null;
+  solution_voting_close?: string | null;
+  project_registration_open?: string | null;
+  project_registration_close?: string | null;
+  phase_2_start?: string | null;
+  phase_3_start?: string | null;
+}
+
+const SPINE: { key: PhaseKey; position: number; open: keyof ScheduleConfig; close: keyof ScheduleConfig }[] = [
+  { key: "problem_statement", position: 1, open: "problem_statement_open", close: "problem_statement_close" },
+  { key: "voting", position: 2, open: "voting_open", close: "voting_close" },
+  { key: "pod_forming", position: 3, open: "pod_registration_open", close: "pod_registration_close" },
+  { key: "solution_proposal", position: 4, open: "solution_proposal_open", close: "solution_proposal_close" },
+  { key: "solution_voting", position: 5, open: "solution_voting_open", close: "solution_voting_close" },
+  { key: "project_registration", position: 6, open: "project_registration_open", close: "project_registration_close" },
+];
+
+/**
+ * Pure: derive the full phase-row set from a cycle_config shape. Pairs with
+ * a missing/invalid bound produce no row (matching the 00085 seed). The
+ * pod_active_join overlay derives from phase_2_start →
+ * project_registration_close.
+ */
+export function phaseRowsFromConfig(config: ScheduleConfig): PhaseRowInput[] {
+  const rows: PhaseRowInput[] = [];
+  for (const s of SPINE) {
+    const open = parseWindow(config[s.open] ?? null);
+    const close = parseWindow(config[s.close] ?? null);
+    if (!open || !close || open >= close) continue;
+    rows.push({
+      phase_key: s.key,
+      kind: "spine",
+      position: s.position,
+      starts_at: open.toISOString(),
+      ends_at: close.toISOString(),
+    });
+  }
+  const ajStart = parseWindow(config.phase_2_start ?? null);
+  const ajEnd = parseWindow(config.project_registration_close ?? null);
+  if (ajStart && ajEnd && ajStart < ajEnd) {
+    rows.push({
+      phase_key: "pod_active_join",
+      kind: "overlay",
+      position: null,
+      starts_at: ajStart.toISOString(),
+      ends_at: ajEnd.toISOString(),
+    });
+  }
+  return rows;
+}
+
+/**
+ * Re-derive and upsert a cycle's phase rows from its cycle_config row, and
+ * delete phase rows whose source pair was cleared. Called by the admin
+ * schedule PATCH after it writes cycle_config; also safe to call anywhere
+ * the config changes. Service client — phase writes are system writes.
+ */
+export async function syncPhasesFromConfig(cycleId: number): Promise<void> {
+  const client = createServiceClient();
+  const { data: config, error } = await client
+    .from("cycle_config")
+    .select(
+      "problem_statement_open, problem_statement_close, voting_open, voting_close, pod_registration_open, pod_registration_close, solution_proposal_open, solution_proposal_close, solution_voting_open, solution_voting_close, project_registration_open, project_registration_close, phase_2_start, phase_3_start"
+    )
+    .eq("cycle_id", cycleId)
+    .maybeSingle();
+  if (error) throw new Error(`syncPhasesFromConfig read: ${error.message}`);
+  if (!config) return;
+
+  const rows = phaseRowsFromConfig(config);
+  if (rows.length > 0) {
+    const { error: upsertErr } = await client
+      .from("cycle_phases")
+      .upsert(
+        rows.map((r) => ({ cycle_id: cycleId, ...r })),
+        { onConflict: "cycle_id,phase_key" }
+      );
+    if (upsertErr) throw new Error(`syncPhasesFromConfig upsert: ${upsertErr.message}`);
+  }
+
+  // Clear rows whose source pair no longer yields a window.
+  const present = rows.map((r) => r.phase_key);
+  const { error: delErr } = await client
+    .from("cycle_phases")
+    .delete()
+    .eq("cycle_id", cycleId)
+    .not(
+      "phase_key",
+      "in",
+      `(${present.length ? present.map((k) => `"${k}"`).join(",") : '""'})`
+    );
+  if (delErr) throw new Error(`syncPhasesFromConfig prune: ${delErr.message}`);
+}
+
+/* ── D-10: the derived cycle-registration window ─────────────────────────
+ * (docs/requirements/pod-registration.md D-10 / FR-8, owner 2026-07-12)
+ *
+ * Self-serve cycle registration is open exactly when a new member can
+ * still land in a pod: through pod_forming close, again during
+ * pod_active_join, closed otherwise. Invite fulfillment bypasses this
+ * (it never calls the gated route).
+ */
+
+export type RegistrationState =
+  | "open" // through pod_forming close (or no bounds configured yet)
+  | "dead_zone" // between forming close and active-join open
+  | "active_join" // second window
+  | "closed"; // after active-join close (or forming closed, no active-join)
+
+export interface RegistrationWindow {
+  open: boolean;
+  state: RegistrationState;
+  /** When state === 'dead_zone': the instant registration reopens. */
+  reopensAt: Date | null;
+}
+
+/** Pure D-10 derivation — bounds in ms (null = not configured). */
+export function deriveRegistrationWindow(
+  bounds: {
+    formingEndMs: number | null;
+    activeJoinStartMs: number | null;
+    activeJoinEndMs: number | null;
+  },
+  nowMs: number
+): RegistrationWindow {
+  const { formingEndMs, activeJoinStartMs, activeJoinEndMs } = bounds;
+
+  // No forming bound configured → the schedule isn't set; keep the legacy
+  // status-gated behavior (open whenever the cycle admits registration).
+  if (formingEndMs === null) {
+    return { open: true, state: "open", reopensAt: null };
+  }
+  if (nowMs <= formingEndMs) {
+    return { open: true, state: "open", reopensAt: null };
+  }
+  if (activeJoinStartMs !== null && activeJoinEndMs !== null) {
+    if (nowMs < activeJoinStartMs) {
+      return {
+        open: false,
+        state: "dead_zone",
+        reopensAt: new Date(activeJoinStartMs),
+      };
+    }
+    if (nowMs <= activeJoinEndMs) {
+      return { open: true, state: "active_join", reopensAt: null };
+    }
+  }
+  return { open: false, state: "closed", reopensAt: null };
+}
+
+/**
+ * Resolve the registration window for a cycle: cycle_phases first
+ * (pod_forming / pod_active_join), falling back to the legacy columns +
+ * the same phase_2_start → project_registration_close derivation for
+ * cycles without phase rows.
+ */
+export async function registrationWindow(
+  client: SupabaseClient,
+  cycleId: number,
+  now: Date = new Date()
+): Promise<RegistrationWindow> {
+  const { data: phases } = await client
+    .from("cycle_phases")
+    .select("phase_key, starts_at, ends_at")
+    .eq("cycle_id", cycleId)
+    .in("phase_key", ["pod_forming", "pod_active_join"]);
+
+  let formingEndMs: number | null = null;
+  let ajStartMs: number | null = null;
+  let ajEndMs: number | null = null;
+
+  if (phases && phases.length > 0) {
+    for (const p of phases) {
+      if (p.phase_key === "pod_forming") {
+        formingEndMs = parseWindow(p.ends_at)?.getTime() ?? null;
+      } else if (p.phase_key === "pod_active_join") {
+        ajStartMs = parseWindow(p.starts_at)?.getTime() ?? null;
+        ajEndMs = parseWindow(p.ends_at)?.getTime() ?? null;
+      }
+    }
+  } else {
+    const { data: config } = await client
+      .from("cycle_config")
+      .select(
+        "pod_registration_close, phase_2_start, project_registration_close"
+      )
+      .eq("cycle_id", cycleId)
+      .maybeSingle();
+    formingEndMs = parseWindow(config?.pod_registration_close)?.getTime() ?? null;
+    ajStartMs = parseWindow(config?.phase_2_start)?.getTime() ?? null;
+    ajEndMs =
+      parseWindow(config?.project_registration_close)?.getTime() ?? null;
+    if (ajStartMs !== null && ajEndMs !== null && ajStartMs >= ajEndMs) {
+      ajStartMs = null;
+      ajEndMs = null;
+    }
+  }
+
+  return deriveRegistrationWindow(
+    { formingEndMs, activeJoinStartMs: ajStartMs, activeJoinEndMs: ajEndMs },
+    now.getTime()
+  );
+}

--- a/lib/validations/cycles.ts
+++ b/lib/validations/cycles.ts
@@ -32,6 +32,13 @@ export const updateCycleConfigSchema = z.object({
   log_gate_paused: z.boolean().optional(),
   // Leadership Log pause — org cycles only (00069, docs/ORG_CYCLES.md §4a).
   leadership_log_gate_paused: z.boolean().optional(),
+  // Phase markers — the config form has always sent these, but they were
+  // missing here, so zod silently stripped them and Meet The Pods /
+  // Meet The Projects edits 200'd without writing (found testing #247;
+  // phase_2_start now drives the pod_active_join window, so a silent drop
+  // breaks the D-10 reopen gate).
+  phase_2_start: z.string().nullable().optional(),
+  phase_3_start: z.string().nullable().optional(),
   problem_statement_open: z.string().nullable().optional(),
   problem_statement_close: z.string().nullable().optional(),
   voting_open: z.string().nullable().optional(),

--- a/supabase/migrations/00085_cycle_phases_events.sql
+++ b/supabase/migrations/00085_cycle_phases_events.sql
@@ -1,0 +1,161 @@
+-- 00085_cycle_phases_events.sql — Stage 1 of the calendar overhaul
+-- (docs/requirements/cycle-timeline.md + implementation-plan.md, targeting
+-- Cycle 3 staged inside the live cycle; owner decision 2026-07-12).
+--
+-- WHY: cycle scheduling becomes first-class. Phases and events become rows
+-- (born TIMESTAMPTZ — real instants, no naive-column ambiguity), while the
+-- twelve legacy cycle_config window columns stay in place as a dual-write
+-- MIRROR maintained by lib/cycles/schedule.ts: cycle_phases is the source
+-- of truth, and every boundary edit writes the computed bounds back into
+-- the legacy columns so not-yet-migrated pages keep working unchanged
+-- (implementation-plan simplification 1). The columns drop only when the
+-- Stage 2 page sweep finishes — NOT here.
+--
+-- Seeding is generic, not Cycle-3-hardcoded:
+--   * spine phases migrate from each open-mode cycle's existing
+--     cycle_config values (naive columns hold the instant as UTC — the
+--     verified S5.1 convention — so conversion is AT TIME ZONE 'UTC');
+--     pod_registration_* seeds the pod_forming phase (pod-registration.md
+--     two-window split).
+--   * pod_active_join (overlay) derives from phase_2_start (the
+--     Meet-the-Pods marker) → project_registration_close, when both exist.
+--   * the six anchor events seed for the single live open HQ cycle from
+--     the owner-confirmed calendar (lib/cycles/anchor-events.ts values,
+--     ET → UTC) — Luma sync (00035) later upserts occurs_at/luma_api_id,
+--     fulfilling that file's "interim until the events cache lands" note.
+--
+-- Org-mode cycles get no phase rows (cycle-timeline.md: the resolver keeps
+-- its org-reject guard — the simpler invariant).
+--
+-- Idempotent: CREATE IF NOT EXISTS + ON CONFLICT DO NOTHING seeds.
+--
+-- DOWN:
+--   DROP TABLE IF EXISTS cycle_events;
+--   DROP TABLE IF EXISTS cycle_phases;
+--   ALTER TABLE cycles DROP COLUMN IF EXISTS start_at;
+--   ALTER TABLE metros DROP COLUMN IF EXISTS timezone;
+
+-- ── cycles.start_at + metros.timezone ────────────────────────────────────
+
+-- Cycle start as a real instant: start_date is a lab-local calendar date,
+-- so midnight in the lab's zone.
+ALTER TABLE cycles ADD COLUMN IF NOT EXISTS start_at TIMESTAMPTZ;
+UPDATE cycles
+SET start_at = (start_date::timestamp AT TIME ZONE 'America/New_York')
+WHERE start_at IS NULL AND start_date IS NOT NULL;
+
+ALTER TABLE metros
+  ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'America/New_York';
+
+-- ── cycle_phases ─────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS cycle_phases (
+  id        SERIAL PRIMARY KEY,
+  cycle_id  INT NOT NULL REFERENCES cycles(id) ON DELETE CASCADE,
+  phase_key TEXT NOT NULL CHECK (phase_key IN (
+    'problem_statement', 'voting', 'pod_forming', 'pod_active_join',
+    'solution_proposal', 'solution_voting', 'project_registration'
+  )),
+  kind      TEXT NOT NULL DEFAULT 'spine' CHECK (kind IN ('spine', 'overlay')),
+  position  SMALLINT,                -- order, for spine phases
+  anchor    TEXT,                    -- informational in v1 (seed, don't derive)
+  duration  INTERVAL,                -- informational in v1
+  starts_at TIMESTAMPTZ,
+  ends_at   TIMESTAMPTZ,
+  CHECK (starts_at IS NULL OR ends_at IS NULL OR starts_at < ends_at),
+  UNIQUE (cycle_id, phase_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cycle_phases_cycle ON cycle_phases (cycle_id);
+
+ALTER TABLE cycle_phases ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS cycle_phases_select ON cycle_phases;
+CREATE POLICY cycle_phases_select ON cycle_phases
+  FOR SELECT TO authenticated USING (true);
+DROP POLICY IF EXISTS cycle_phases_write ON cycle_phases;
+CREATE POLICY cycle_phases_write ON cycle_phases
+  FOR ALL TO authenticated USING (is_admin_or_owner());
+
+-- ── cycle_events ─────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS cycle_events (
+  id          SERIAL PRIMARY KEY,
+  cycle_id    INT NOT NULL REFERENCES cycles(id) ON DELETE CASCADE,
+  key         TEXT NOT NULL,   -- 'kickoff' | 'problem_sprint' | 'meet_the_pods' | …
+  label       TEXT NOT NULL,
+  occurs_at   TIMESTAMPTZ NOT NULL,
+  luma_api_id TEXT,
+  UNIQUE (cycle_id, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cycle_events_cycle ON cycle_events (cycle_id);
+
+ALTER TABLE cycle_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS cycle_events_select ON cycle_events;
+CREATE POLICY cycle_events_select ON cycle_events
+  FOR SELECT TO authenticated USING (true);
+DROP POLICY IF EXISTS cycle_events_write ON cycle_events;
+CREATE POLICY cycle_events_write ON cycle_events
+  FOR ALL TO authenticated USING (is_admin_or_owner());
+
+-- ── Seed: spine phases from existing cycle_config windows ────────────────
+-- Naive window columns hold the instant as UTC wall-clock (S5.1 convention)
+-- → AT TIME ZONE 'UTC' converts losslessly. Open-mode cycles only.
+
+INSERT INTO cycle_phases (cycle_id, phase_key, kind, position, starts_at, ends_at)
+SELECT c.id, w.phase_key, 'spine', w.position,
+       w.open_val AT TIME ZONE 'UTC',
+       w.close_val AT TIME ZONE 'UTC'
+FROM cycles c
+JOIN cycle_config cc ON cc.cycle_id = c.id
+CROSS JOIN LATERAL (
+  VALUES
+    ('problem_statement',    1::smallint, cc.problem_statement_open,    cc.problem_statement_close),
+    ('voting',               2::smallint, cc.voting_open,               cc.voting_close),
+    ('pod_forming',          3::smallint, cc.pod_registration_open,     cc.pod_registration_close),
+    ('solution_proposal',    4::smallint, cc.solution_proposal_open,    cc.solution_proposal_close),
+    ('solution_voting',      5::smallint, cc.solution_voting_open,      cc.solution_voting_close),
+    ('project_registration', 6::smallint, cc.project_registration_open, cc.project_registration_close)
+) AS w(phase_key, position, open_val, close_val)
+WHERE c.mode = 'open'
+  AND w.open_val IS NOT NULL
+  AND w.close_val IS NOT NULL
+  AND w.open_val < w.close_val
+ON CONFLICT (cycle_id, phase_key) DO NOTHING;
+
+-- pod_active_join (overlay): Meet-the-Pods marker → project registration
+-- close (pod-registration.md; cycle-timeline.md "Pod active-join" row).
+
+INSERT INTO cycle_phases (cycle_id, phase_key, kind, position, starts_at, ends_at)
+SELECT c.id, 'pod_active_join', 'overlay', NULL,
+       cc.phase_2_start AT TIME ZONE 'UTC',
+       cc.project_registration_close AT TIME ZONE 'UTC'
+FROM cycles c
+JOIN cycle_config cc ON cc.cycle_id = c.id
+WHERE c.mode = 'open'
+  AND cc.phase_2_start IS NOT NULL
+  AND cc.project_registration_close IS NOT NULL
+  AND cc.phase_2_start < cc.project_registration_close
+ON CONFLICT (cycle_id, phase_key) DO NOTHING;
+
+-- ── Seed: the six anchor events for the live open HQ cycle ───────────────
+-- Owner-confirmed Cycle 3 calendar (all ET; stored as instants). Applies to
+-- the single active-or-upcoming open cycle with lab_id NULL — a no-op on
+-- databases without one, and ON CONFLICT-safe on re-run.
+
+INSERT INTO cycle_events (cycle_id, key, label, occurs_at)
+SELECT c.id, e.key, e.label, e.occurs_at
+FROM cycles c
+CROSS JOIN (
+  VALUES
+    ('kickoff',           'Kickoff Summit',              '2026-07-14T18:00:00-04:00'::timestamptz),
+    ('problem_sprint',    'Problem Sprint',              '2026-07-25T09:00:00-04:00'::timestamptz),
+    ('meet_the_pods',     'Meet the Pods',               '2026-08-11T18:00:00-04:00'::timestamptz),
+    ('hackathon',         'Hackathon — the Frame Sprint','2026-08-13T09:00:00-04:00'::timestamptz),
+    ('meet_the_projects', 'Meet the Projects',           '2026-09-08T18:00:00-04:00'::timestamptz),
+    ('summit',            'Showcase Summit',             '2026-10-13T18:00:00-04:00'::timestamptz)
+) AS e(key, label, occurs_at)
+WHERE c.mode = 'open'
+  AND c.lab_id IS NULL
+  AND c.status IN ('active', 'upcoming')
+ON CONFLICT (cycle_id, key) DO NOTHING;


### PR DESCRIPTION
## Stage 1 of the calendar overhaul (`docs/requirements/implementation-plan.md`)

> **Stacked on #245** (`fix/lab-timezone-windows`) — this PR's base is that branch, so the diff here shows only Stage-1 changes. When #245 merges to `dev`, GitHub retargets this PR to `dev` automatically. **Do not merge this before #245 has been preview-tested and merged.**

### What's new

**Migration `00085_cycle_phases_events.sql`** (numbered 00085 because open PR #246 claims 00084):
- `cycle_phases` — the tz-aware **read model**: phase rows born `TIMESTAMPTZ`, `[starts_at, ends_at)` semantics, `UNIQUE(cycle_id, phase_key)`. Six spine phases + the `pod_active_join` overlay.
- `cycle_events` — anchor events (kickoff, Problem Sprint, Meet the Pods, hackathon, Meet the Projects, summit) with a `luma_api_id` hook for later Luma sync.
- `cycles.start_at TIMESTAMPTZ` (backfilled from `start_date` at lab-local midnight) and `metros.timezone` (default `America/New_York`).
- Seeds: spine phases from every open cycle's existing `cycle_config` windows (naive-as-UTC per the S5.1 convention); the overlay derived from `phase_2_start → project_registration_close`; the six owner-confirmed Cycle-3 anchor events (ET instants) for the live open HQ cycle. All idempotent.
- RLS: select for authenticated, writes admin/owner only.

**Write model stays `cycle_config` for Stage 1** — the admin schedule PATCH still writes the legacy columns and now calls `syncPhasesFromConfig()` so phase rows always mirror them (single write path, zero divergence risk mid-cycle). Stage 2 flips authority and retires the columns.

**`pod_active_join` is derived, not entered**: Meet-the-Pods marker (`phase_2_start`) → `project_registration_close`. Editing those two existing admin fields moves the active-join window — no new admin UI, and the O-1 "re-enter pod_registration on Aug 11" fallback becomes unnecessary.

### D-10 cycle-registration gate (owner decision 2026-07-12)

Self-serve registration is open exactly when a new member can still land in a pod: **open** through pod-forming close (Jul 28 EOD) → **closed** across the dead zone (message names the Aug 11 reopen) → **open** during active-join (Aug 11–25) → **closed** after. Wired into:

- `POST /api/cycles/[id]/agreement` — 403 with the reopen instant; **already-signed members are exempt** (re-sign passes), and invite fulfillment never hits this route.
- `/cycles/[id]/join` — closed-registration card instead of the ceremony (signed members still reach their confirmation).
- `/cycles` — the upcoming-cycle CTA reads "Registration reopens Aug 11, 6:00 PM ET" / "Registration closed" instead of "Register".
- Dashboard — the register checklist row hides while closed (done rows always show); the join CTA card swaps for a closed card.

**Phases-first window resolver**: `lib/auth/windows.ts` now reads `cycle_phases` (`pod_registration` field → `pod_forming` phase), falling back to the legacy columns for cycles without rows — the org-cycle reject and "configuration not found" behaviors are unchanged.

### Verification

- `npm run lint` — 0 errors (8 pre-existing warnings)
- `npm run test` — 313/313 (10 new in `lib/cycles/schedule.test.ts`: row derivation + full D-10 matrix incl. boundaries)
- `npm run build` — green
- `npm run check:migrations` — flags a **pre-existing** duplicate on `dev` (`00068_pods_local.sql` vs `00068_service_role_admin_paths.sql`), not introduced here; 00085 itself is uncontested.

Migration has been static-checked only (no DB access from this workspace) — apply to the shared dev Supabase before testing the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTS4ML6xMgNDmdhQLu1GxX)_