### PR TITLE
Redesign landing page: cycles, curriculum, and messaging

### DIFF
--- a/app/components/chrome/public-nav.tsx
+++ b/app/components/chrome/public-nav.tsx
@@ -19,6 +19,8 @@ import { DONATE_URL } from "@/lib/donate";
 
 const DESTS = [
   { key: "events", label: "Events", href: "/events" },
+  { key: "about", label: "About", href: "/about" },
+  { key: "get-involved", label: "Get Involved", href: "/get-involved" },
 ];
 
 export default function PublicNav({
@@ -123,7 +125,6 @@ export default function PublicNav({
             {d.label}
           </Link>
         ))}
-        <Link className="nav-link" href="/about">About</Link>
         {!signedIn && (
           <Link className="nav-link" href="/login">Log in</Link>
         )}

--- a/app/components/chrome/site-footers.tsx
+++ b/app/components/chrome/site-footers.tsx
@@ -49,8 +49,9 @@ export function OsFooter() {
               />
             </Link>
             <p className="t-body">
-              A commons for upskilling — learn by doing, in the open. Projects,
-              playbooks, and lessons, built like open source.
+              The systems we&rsquo;ve relied on are breaking. Here you&rsquo;re
+              invited to turn that disruption into resilience&mdash;rooted in
+              your local library and powered by you and your neighbors.
             </p>
             <Link className="btn btn-ghost-teal btn-sm" href="/donate">
               Support The Labs

--- a/app/globals.css
+++ b/app/globals.css
@@ -893,8 +893,8 @@ button:focus-visible {
   @media (min-width: 1024px) {
     /* Capped on desktop — a full-viewport hero on a large monitor towers over
        the content; mobile keeps 100svh where it fits. */
-    .hero-band { align-items: center; min-height: calc(min(100svh, 720px) + 3 * var(--r)); }
-    .hero-inner { padding: 148px var(--pad) 104px; display: grid; grid-template-columns: repeat(7, 1fr); column-gap: var(--pad); row-gap: 40px; align-items: start; }
+    .hero-band { align-items: center; min-height: calc(min(100svh, 600px) + 3 * var(--r)); }
+    .hero-inner { padding: 120px var(--pad) 72px; display: grid; grid-template-columns: repeat(7, 1fr); column-gap: var(--pad); row-gap: 40px; align-items: start; }
     .hero-band .hero-inner .t-display { grid-column: 1 / -1; font-size: 96px; line-height: 100px; letter-spacing: -0.05em; }
     .hero-cta { grid-column: 5 / -1; align-items: flex-start; margin-top: 0; }
     .hero-login { display: none !important; } /* the nav carries Log in on desktop */

--- a/app/globals.css
+++ b/app/globals.css
@@ -891,7 +891,9 @@ button:focus-visible {
   .hero-login { display: inline-flex; }
   .sec-after-hero { padding-top: calc(56px + 3 * var(--r)); }
   @media (min-width: 1024px) {
-    .hero-band { align-items: center; }
+    /* Capped on desktop — a full-viewport hero on a large monitor towers over
+       the content; mobile keeps 100svh where it fits. */
+    .hero-band { align-items: center; min-height: calc(min(100svh, 720px) + 3 * var(--r)); }
     .hero-inner { padding: 148px var(--pad) 104px; display: grid; grid-template-columns: repeat(7, 1fr); column-gap: var(--pad); row-gap: 40px; align-items: start; }
     .hero-band .hero-inner .t-display { grid-column: 1 / -1; font-size: 96px; line-height: 100px; letter-spacing: -0.05em; }
     .hero-cta { grid-column: 5 / -1; align-items: flex-start; margin-top: 0; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -181,10 +181,10 @@ export default async function LandingPage() {
             </h1>
             <div className="hero-cta">
               <p className="t-lede" style={{ marginBottom: 24, maxWidth: "54ch" }}>
-                Nobody gets good at the hard stuff alone. So we help you find
-                your crew — a handful of people near you who meet up for a few
-                months, build something real, and keep each other going. Sign in
-                with Google to jump in.
+                AI is rewriting how we work, and it&rsquo;s easier to learn
+                together than alone. So we help you find people near you to learn
+                with, build something real with AI, and grow more confident
+                together. Sign in with Google to jump in.
               </p>
               {signedIn ? (
                 <Link className="btn btn-teal btn-lg" href="/dashboard">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,23 +68,39 @@ function SectionHead({
   );
 }
 
+// The three strands of the workshop curriculum, shown under the events row.
+const WHAT_YOU_LEARN: [string, string][] = [
+  [
+    "Durable skills",
+    "The human skills the future of work runs on—communication, storytelling, problem framing, rapid iteration. AI means anyone can build; these are how you find the problems worth solving.",
+  ],
+  [
+    "AI skills",
+    "The technical side of working with AI—prompt engineering, vibe coding, working with agents, and more.",
+  ],
+  [
+    "Supports the cycle",
+    "Workshops track the Build Cycle, so each session gives you what your pod needs next—from framing a problem, to prototyping, to telling the story of what you built.",
+  ],
+];
+
 // The three-month arc shown under the cycle banner. Copy moves to the
 // `cycles` table if months ever become data-driven.
 const CYCLE_ANATOMY: [string, string, string][] = [
   [
     "Month 1",
     "Problem Discovery",
-    "You’ll explore challenges that matter to you and your industry. Through community voting, the most compelling problems rise to the top—and small teams called “pods” form around them.",
+    "You’ll explore challenges that matter to you and to an entire industry, from real-world surveys to AI-assisted research. Through community voting, the most compelling problems rise to the top—and small teams called “pods” form around them.",
   ],
   [
     "Month 2",
     "Experimentation",
-    "Pods dig deeper into solutions via projects. You’ll research, prototype, test ideas, and learn by doing. Mentors and peers support you along the way.",
+    "As your pod explores your problem spaces, you come up with projects—proposed solutions to the challenges you’ve deeply understood. You’ll research, prototype, and test ideas: learning AI by doing, supported by peers and mentors along the way.",
   ],
   [
     "Month 3",
     "Synthesis",
-    "Pods turn experiments into working prototypes—tools, workflows, templates—that you can use in your job and share with others. Every cycle ends with a public showcase, so your work has visibility and impact beyond the Lab.",
+    "Projects turn experiments into working prototypes—tools, workflows, templates—that you can use and share with others. Every cycle ends with a public showcase, so your work has visibility and impact beyond the Lab. Projects can keep going at the end of the cycle as open-source efforts within the Labs.",
   ],
 ];
 
@@ -303,6 +319,32 @@ export default async function LandingPage() {
               <EventTeaser key={e.slug} event={e} />
             ))}
           </div>
+
+          {/* What you learn — the three strands of the curriculum */}
+          <div style={{ marginTop: 48 }}>
+            <div className="lbl lbl-teal" style={{ marginBottom: 20 }}>
+              What you learn
+            </div>
+            <div
+              style={{
+                display: "grid",
+                gap: 32,
+                gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+                alignItems: "start",
+              }}
+            >
+              {WHAT_YOU_LEARN.map(([title, body]) => (
+                <div key={title}>
+                  <h3 className="t-h3" style={{ marginBottom: 8 }}>
+                    {title}
+                  </h3>
+                  <p className="t-body" style={{ maxWidth: "44ch" }}>
+                    {body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </section>
 
@@ -364,10 +406,6 @@ export default async function LandingPage() {
           >
             <div>
               <p className="t-lede" style={{ marginBottom: 16, maxWidth: "60ch" }}>
-                An Open Lab is how we learn together&mdash;openly, practically,
-                and as a community.
-              </p>
-              <p className="t-body" style={{ marginBottom: 16, maxWidth: "60ch" }}>
                 Unlike traditional courses with fixed enrollment and passive
                 instruction, Open Labs are peer-powered and project-based. You
                 don&rsquo;t need a technical background to get

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,11 @@ import HeroFade from "@/app/components/chrome/hero-fade";
 import OrbDefs from "@/app/components/chrome/orb-defs";
 import Orb from "@/app/components/chrome/orb";
 import { OsFooter } from "@/app/components/chrome/site-footers";
-import MetroSearch from "@/app/components/content/metro-search";
 import HomeSpotlights from "@/app/components/content/home-spotlights";
 import {
   EventTeaser,
   ResourceTeaser,
+  LabTeaser,
 } from "@/app/components/content/teasers";
 import { getEvents, getResources, getMetros } from "@/lib/content/queries";
 import { publicSession } from "@/lib/auth/public-session";
@@ -67,6 +67,26 @@ function SectionHead({
     </div>
   );
 }
+
+// The three-month arc shown under the cycle banner. Copy moves to the
+// `cycles` table if months ever become data-driven.
+const CYCLE_ANATOMY: [string, string, string][] = [
+  [
+    "Month 1",
+    "Problem Discovery",
+    "You’ll explore challenges that matter to you and your industry. Through community voting, the most compelling problems rise to the top—and small teams called “pods” form around them.",
+  ],
+  [
+    "Month 2",
+    "Experimentation",
+    "Pods dig deeper into solutions via projects. You’ll research, prototype, test ideas, and learn by doing. Mentors and peers support you along the way.",
+  ],
+  [
+    "Month 3",
+    "Synthesis",
+    "Pods turn experiments into working prototypes—tools, workflows, templates—that you can use in your job and share with others. Every cycle ends with a public showcase, so your work has visibility and impact beyond the Lab.",
+  ],
+];
 
 /* The public landing — onboarding-proto's view-landing: dark hero over
    photography, then browse-free sections (cycles · workshops · library ·
@@ -179,8 +199,8 @@ export default async function LandingPage() {
       >
         <div className="container">
           <SectionHead
-            eyebrow="Build Cycles · 4 a year"
-            heading="Join a cohort, ship something real"
+            eyebrow="Build Cycles · 4 per year"
+            heading="Join a Build Cycle, solve a real problem"
           />
           {recruitingCycle ? (
             <div className="cycle-banner s-cover grain on-dark">
@@ -189,7 +209,7 @@ export default async function LandingPage() {
                 <span className="cb-status">
                   {recruitingCycle.status === "upcoming"
                     ? "Registration open now"
-                    : "Cohort in progress"}
+                    : "Cycle in progress"}
                 </span>
                 {bannerSeason && (
                   <div className="lbl lbl-teal" style={{ margin: "14px 0 6px" }}>
@@ -236,6 +256,35 @@ export default async function LandingPage() {
               </div>
             </div>
           )}
+
+          {/* Anatomy of a Build Cycle — the three-month arc */}
+          <div style={{ marginTop: 48 }}>
+            <div className="lbl lbl-teal" style={{ marginBottom: 20 }}>
+              Anatomy of a Build Cycle
+            </div>
+            <div
+              style={{
+                display: "grid",
+                gap: 32,
+                gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+                alignItems: "start",
+              }}
+            >
+              {CYCLE_ANATOMY.map(([month, title, body]) => (
+                <div key={month}>
+                  <div className="lbl" style={{ marginBottom: 8 }}>
+                    {month}
+                  </div>
+                  <h3 className="t-h3" style={{ marginBottom: 8 }}>
+                    {title}
+                  </h3>
+                  <p className="t-body" style={{ maxWidth: "44ch" }}>
+                    {body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </section>
 
@@ -284,7 +333,13 @@ export default async function LandingPage() {
             eyebrow="Local labs"
             heading="Find your city"
           />
-          <MetroSearch metros={metros} initial={landingLabs} signedIn={signedIn} />
+          {/* Just the lab cards — the search bar waits until there are more
+              than two cities (it lives on /local-labs). */}
+          <div className="cards">
+            {landingLabs.map((m) => (
+              <LabTeaser key={m.slug} metro={m} />
+            ))}
+          </div>
         </div>
       </section>
 
@@ -308,18 +363,30 @@ export default async function LandingPage() {
           >
             <div>
               <p className="t-lede" style={{ marginBottom: 16, maxWidth: "60ch" }}>
-                The Upskilling Labs is a network of local communities of
-                practice — people navigating career change who learn by doing
-                and keep leveling up for life. OLOS (Open Labs OS) is the
-                platform that runs it: you sign in to join your local lab, form
-                a cohort in a twelve-week Build Cycle, ship a real project, drop
-                into workshops, and keep a Learning Log — alongside people who
-                notice your work.
+                An Open Lab is how we learn together&mdash;openly, practically,
+                and as a community.
+              </p>
+              <p className="t-body" style={{ marginBottom: 16, maxWidth: "60ch" }}>
+                Unlike traditional courses with fixed enrollment and passive
+                instruction, Open Labs are peer-powered and project-based. You
+                don&rsquo;t need a technical background to get
+                started&mdash;just a willingness to learn by doing alongside
+                others.
+              </p>
+              <p className="t-body" style={{ marginBottom: 16, maxWidth: "60ch" }}>
+                Inside an Open Lab, you&rsquo;ll find weekly workshops and
+                quarterly Build Cycles. Workshops support you in building the
+                skills you need to master the future of work: from durable
+                skills like problem framing to AI-specific skills like
+                prompt-engineering.
               </p>
               <p className="t-body" style={{ maxWidth: "60ch" }}>
-                Membership is free. Browse cycles, workshops, the Learning
-                Library, and local labs above — no account needed. You only sign
-                in when you&rsquo;re ready to join.
+                Build Cycles are a twelve-week program where you go from deeply
+                exploring a problem space, to forming a pod with peers, to
+                rapidly prototyping solutions. Each month is anchored by a
+                meetup where you present your progress, culminating in a demo at
+                our Summit. And everything you create is open-source by default
+                so others can learn from and build on your work.
               </p>
             </div>
             <div className="lcard" style={{ padding: 28 }}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,7 +72,7 @@ function SectionHead({
 const WHAT_YOU_LEARN: [string, string][] = [
   [
     "Durable skills",
-    "The human skills the future of work runs on—skills like communication, collaboration, storytelling, and problem framing.",
+    "The human skills the future of work runs on—skills like communication, storytelling, and framing problems well.",
   ],
   [
     "AI skills",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -100,7 +100,7 @@ const CYCLE_ANATOMY: [string, string, string][] = [
   [
     "Month 3",
     "Synthesis",
-    "Projects turn experiments into working prototypes—tools, workflows, templates—that you can use and share with others. Every cycle ends with a public showcase, so your work has visibility and impact beyond the Lab. Projects can keep going at the end of the cycle as open-source efforts within the Labs.",
+    "Projects turn experiments into working prototypes—tools, workflows, templates. Every cycle ends with a public showcase, so your work has visibility and impact beyond the twelve weeks. Projects can keep going at the end of the cycle as open-source efforts in the Labs.",
   ],
 ];
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -219,8 +219,9 @@ export default async function LandingPage() {
                 <h3 className="t-h2">{recruitingCycle.name}</h3>
                 {bannerKickoff && (
                   <p className="t-body" style={{ marginTop: 8, maxWidth: "52ch" }}>
-                    Kicks off {bannerKickoff} — twelve weeks, one real project,
-                    with people who notice.
+                    Kicks off {bannerKickoff} — twelve weeks, a group of curious
+                    peers learning AI by tackling problems worth caring about
+                    with solutions worth building.
                   </p>
                 )}
                 {recruitingCycle.mode === "open" && (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -352,7 +352,7 @@ export default async function LandingPage() {
         <div className="container">
           <SectionHead
             eyebrow="What this is"
-            heading="Local communities of practice, powered by OLOS"
+            heading="A new way to learn, together"
           />
           <div
             style={{

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -84,6 +84,23 @@ const WHAT_YOU_LEARN: [string, string][] = [
   ],
 ];
 
+// The story arc under "Find your city" — where the Labs came from, how they
+// scale, and where they're headed.
+const OUR_STORY: [string, string][] = [
+  [
+    "Founded in DC",
+    "The Upskilling Labs started as a pilot in Washington, DC at the DC Public Library in fall of 2025—a small group of ex-feds proving that people navigating career change and new technologies learn faster together. Now, DC is home to our first chapter and our mission has expanded to all professionals.",
+  ],
+  [
+    "Built to scale",
+    "We run our own Build Cycle process on ourselves, turning what works into an operating system and playbooks—so a new lab can stand up anywhere without reinventing how it works. Every cycle makes it better, and we’re building it all for the community, open-source.",
+  ],
+  [
+    "Expanding nationally",
+    "We’re just getting started—and the impacts of AI are far from local. From DC, we’re heading to cities across the country. We aim to build a more resilient future of work for all of us by bringing the Labs to wherever people are ready to learn by doing alongside their neighbors.",
+  ],
+];
+
 // The three-month arc shown under the cycle banner. Copy moves to the
 // `cycles` table if months ever become data-driven.
 const CYCLE_ANATOMY: [string, string, string][] = [
@@ -382,6 +399,32 @@ export default async function LandingPage() {
             {landingLabs.map((m) => (
               <LabTeaser key={m.slug} metro={m} />
             ))}
+          </div>
+
+          {/* Our story — founded in DC, built to scale, expanding nationally */}
+          <div style={{ marginTop: 48 }}>
+            <div className="lbl lbl-teal" style={{ marginBottom: 20 }}>
+              Our story
+            </div>
+            <div
+              style={{
+                display: "grid",
+                gap: 32,
+                gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+                alignItems: "start",
+              }}
+            >
+              {OUR_STORY.map(([title, body]) => (
+                <div key={title}>
+                  <h3 className="t-h3" style={{ marginBottom: 8 }}>
+                    {title}
+                  </h3>
+                  <p className="t-body" style={{ maxWidth: "44ch" }}>
+                    {body}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,7 +76,7 @@ const WHAT_YOU_LEARN: [string, string][] = [
   ],
   [
     "AI skills",
-    "The technical side of working with AI—prompt engineering, vibe coding, working with agents, and more.",
+    "The technical side of working with AI—prompt engineering, vibe coding, working with agents, and more. Hands-on practice with the tools that are reshaping how work gets done, so you can build alongside them instead of being left behind.",
   ],
   [
     "Supports the cycle",
@@ -405,7 +405,7 @@ export default async function LandingPage() {
             }}
           >
             <div>
-              <p className="t-lede" style={{ marginBottom: 16, maxWidth: "60ch" }}>
+              <p className="t-body" style={{ marginBottom: 16, maxWidth: "60ch" }}>
                 Unlike traditional courses with fixed enrollment and passive
                 instruction, Open Labs are peer-powered and project-based. You
                 don&rsquo;t need a technical background to get

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,15 +72,15 @@ function SectionHead({
 const WHAT_YOU_LEARN: [string, string][] = [
   [
     "Durable skills",
-    "The human skills the future of work runs on—communication, storytelling, problem framing, rapid iteration. AI means anyone can build; these are how you find the problems worth solving.",
+    "The human skills the future of work runs on—skills like communication, collaboration, storytelling, and problem framing.",
   ],
   [
     "AI skills",
-    "The technical side of working with AI—prompt engineering, vibe coding, working with agents, and more. Hands-on practice with the tools that are reshaping how work gets done, so you can build alongside them instead of being left behind.",
+    "The technical side of working with AI—understanding LLMs, prompt engineering, vibe coding, building agents, and more.",
   ],
   [
     "Supports the cycle",
-    "Workshops track the Build Cycle, so each session gives you what your pod needs next—from framing a problem, to prototyping, to telling the story of what you built.",
+    "You can drop in whenever, but workshops track the Build Cycle, so each session gives you what your pod needs next.",
   ],
 ];
 


### PR DESCRIPTION
## What

Redesigns the landing page to better communicate the Open Labs mission and program structure. Replaces the metro search component with lab cards, adds detailed sections explaining the Build Cycle anatomy and curriculum strands, updates messaging throughout to emphasize peer-powered learning and real-world problem-solving, and adjusts hero sizing on desktop.

## Changes

- **Build Cycles section**: Updated copy ("Join a Build Cycle, solve a real problem") and added "Anatomy of a Build Cycle" subsection showing the three-month arc (Problem Discovery, Experimentation, Synthesis) with detailed descriptions
- **Workshops section**: Added "What you learn" subsection highlighting three curriculum strands (Durable skills, AI skills, Supports the cycle)
- **Local labs section**: Replaced `MetroSearch` component with simple `LabTeaser` cards; search bar deferred to `/local-labs` page
- **About section**: Rewrote messaging to emphasize peer-powered, project-based learning and removed OLOS-specific language; updated footer tagline
- **Navigation**: Added "About" and "Get Involved" links to public nav (moved from hardcoded link)
- **Hero sizing**: Capped desktop hero height to `min(100svh, 600px)` to prevent oversized hero on large monitors; adjusted padding
- **Copy updates**: Changed "cohort" → "cycle", "4 a year" → "4 per year", and updated cycle banner description to focus on peer learning and problem-solving

## Verify

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Database

- [ ] No schema change

https://claude.ai/code/session_01R2DEqsRHJwm6WRhAPqStxU