### PR TITLE
Update Spotlights section heading and remove call-to-action label

### DIFF
--- a/app/components/content/home-spotlights.tsx
+++ b/app/components/content/home-spotlights.tsx
@@ -64,11 +64,8 @@ export default function HomeSpotlights({ spotlights }: { spotlights: Spotlight[]
               className="card-body"
               style={{ display: "flex", flexDirection: "column", height: "100%" }}
             >
-              <div className="lbl lbl-teal" style={{ marginBottom: 10 }}>
-                Your turn
-              </div>
               <div className="t-h3" style={{ marginBottom: 10 }}>
-                Share your story
+                Upskiller Spotlights
               </div>
               <p className="t-body" style={{ marginBottom: 18 }}>
                 Spotlights are public — the Labs team edits it with you before

--- a/app/globals.css
+++ b/app/globals.css
@@ -600,6 +600,10 @@ button:focus-visible {
   .story-media .m-orb { position: absolute; left: 10%; top: 16%; width: 80%; height: 80%; opacity: 0.95; }
   .story-card .card-body { display: flex; flex-direction: column; flex: 1; min-width: 0; }
   .story-quote { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; }
+  /* Keep the pull-quote clear of the bottom-pinned name/role block — the name
+     uses margin-top:auto, so without this the two collapse together on a
+     tall (5-line) quote. 16px == 4× the 4px baseline grid. */
+  .story-card .story-quote { margin-bottom: 16px; }
 
   /* ── Spotlight detail (/stories/[slug]) hero ── */
   .spot-hero { display: grid; gap: 28px; align-items: center; }


### PR DESCRIPTION
## What

Updates the Spotlights card heading from "Share your story" to "Upskiller Spotlights" and removes the "Your turn" label, clarifying the section's purpose as a showcase of community spotlights rather than a call-to-action for users to submit their own stories.

## Changes

- Changed heading text from "Share your story" to "Upskiller Spotlights"
- Removed the teal label badge displaying "Your turn"

## Verify

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Database

- [ ] No schema change, **or** a migration was added under `supabase/migrations/`
      (new number, `SCHEMA.md` updated). Prod migrations are applied by a maintainer.

https://claude.ai/code/session_016Z6c211dcDJTTvedVLApJj