### PR TITLE
Promote dev → main: Upskiller Spotlights CTA card copy

### DIFF
--- a/app/components/content/home-spotlights.tsx
+++ b/app/components/content/home-spotlights.tsx
@@ -64,11 +64,8 @@ export default function HomeSpotlights({ spotlights }: { spotlights: Spotlight[]
               className="card-body"
               style={{ display: "flex", flexDirection: "column", height: "100%" }}
             >
-              <div className="lbl lbl-teal" style={{ marginBottom: 10 }}>
-                Your turn
-              </div>
               <div className="t-h3" style={{ marginBottom: 10 }}>
-                Share your story
+                Upskiller Spotlights
               </div>
               <p className="t-body" style={{ marginBottom: 18 }}>
                 Spotlights are public — the Labs team edits it with you before

--- a/app/globals.css
+++ b/app/globals.css
@@ -600,6 +600,10 @@ button:focus-visible {
   .story-media .m-orb { position: absolute; left: 10%; top: 16%; width: 80%; height: 80%; opacity: 0.95; }
   .story-card .card-body { display: flex; flex-direction: column; flex: 1; min-width: 0; }
   .story-quote { display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; }
+  /* Keep the pull-quote clear of the bottom-pinned name/role block — the name
+     uses margin-top:auto, so without this the two collapse together on a
+     tall (5-line) quote. 16px == 4× the 4px baseline grid. */
+  .story-card .story-quote { margin-bottom: 16px; }
 
   /* ── Spotlight detail (/stories/[slug]) hero ── */
   .spot-hero { display: grid; gap: 28px; align-items: center; }


### PR DESCRIPTION
Promotes `dev` to `main` so the homepage change deploys to production.

## Included since the last promotion (#251)
- **Spotlights CTA card copy** (#252): the "Share your story" card is retitled to **"Upskiller Spotlights"** and the "Your turn" eyebrow is removed; the `Share your story →` action link is unchanged.
- A small, scoped spacing guard on `.story-card .story-quote` (16px margin-bottom, 4× the site's baseline grid) that keeps the pull-quote clear of the name/role block once the shorter card ships. No-op at the current spacing.

## Notes
- No schema changes. Spotlight data is already published in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Z6c211dcDJTTvedVLApJj

---
_Generated by [Claude Code](https://claude.ai/code/session_016Z6c211dcDJTTvedVLApJj)_