### PR TITLE
Promote dev → main: live lab member counts, remove Flagship tag, hero height

### DIFF
--- a/app/components/content/teasers.tsx
+++ b/app/components/content/teasers.tsx
@@ -110,7 +110,7 @@ export function LabTeaser({ metro: m }: { metro: MetroRow }) {
       : `${m.waiting} ${m.waiting === 1 ? "person" : "people"} waiting`;
   return (
     <Link className="card tappable" href={`/local-labs/${m.slug}`}>
-      <MediaFrame grad={m.slug === "dc" ? "m-navy" : "m-forest"} tag={m.slug === "dc" ? "Flagship" : ""} />
+      <MediaFrame grad={m.slug === "dc" ? "m-navy" : "m-forest"} tag="" />
       <div className="card-body">
         <div className="card-row" style={{ marginBottom: 6 }}>
           {m.status === "active" ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -895,9 +895,7 @@ button:focus-visible {
   .hero-login { display: inline-flex; }
   .sec-after-hero { padding-top: calc(56px + 3 * var(--r)); }
   @media (min-width: 1024px) {
-    /* Capped on desktop — a full-viewport hero on a large monitor towers over
-       the content; mobile keeps 100svh where it fits. */
-    .hero-band { align-items: center; min-height: calc(min(80svh, 600px) + 3 * var(--r)); }
+    .hero-band { align-items: center; min-height: calc(80svh + 3 * var(--r)); }
     .hero-inner { padding: 120px var(--pad) 72px; display: grid; grid-template-columns: repeat(7, 1fr); column-gap: var(--pad); row-gap: 40px; align-items: start; }
     .hero-band .hero-inner .t-display { grid-column: 1 / -1; font-size: 96px; line-height: 100px; letter-spacing: -0.05em; }
     .hero-cta { grid-column: 5 / -1; align-items: flex-start; margin-top: 0; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -881,7 +881,7 @@ button:focus-visible {
      translucent bar, exactly as the old fixed nav did. */
   .hero-shell { position: relative; --hero-nav-h: 76px; }
   .hero-shell > .hero-band { margin-top: calc(-1 * var(--hero-nav-h)); }
-  .hero-band { position: relative; z-index: 2; overflow: hidden; border-radius: 0 0 calc(var(--r) * 3) calc(var(--r) * 3); margin-bottom: calc(-3 * var(--r)); min-height: calc(100svh + calc(var(--r) * 3)); display: flex; align-items: flex-end; background: none; }
+  .hero-band { position: relative; z-index: 2; overflow: hidden; border-radius: 0 0 calc(var(--r) * 3) calc(var(--r) * 3); margin-bottom: calc(-3 * var(--r)); min-height: calc(80svh + calc(var(--r) * 3)); display: flex; align-items: flex-end; background: none; }
   .hero-scrim { position: absolute; top: 0; left: 0; right: 0; height: 190px; z-index: 3; pointer-events: none; background: linear-gradient(to bottom, var(--ink) 0%, rgba(0, 20, 27, 0.55) 45%, transparent 100%); }
   .hero-band::before { z-index: 2; } /* grain sits over the tint */
   .hero-photo { position: absolute; inset: 0; z-index: 0; background: url(/assets/img_9531.jpg) center top/cover no-repeat; filter: grayscale(1); }
@@ -897,7 +897,7 @@ button:focus-visible {
   @media (min-width: 1024px) {
     /* Capped on desktop — a full-viewport hero on a large monitor towers over
        the content; mobile keeps 100svh where it fits. */
-    .hero-band { align-items: center; min-height: calc(min(100svh, 600px) + 3 * var(--r)); }
+    .hero-band { align-items: center; min-height: calc(min(80svh, 600px) + 3 * var(--r)); }
     .hero-inner { padding: 120px var(--pad) 72px; display: grid; grid-template-columns: repeat(7, 1fr); column-gap: var(--pad); row-gap: 40px; align-items: start; }
     .hero-band .hero-inner .t-display { grid-column: 1 / -1; font-size: 96px; line-height: 100px; letter-spacing: -0.05em; }
     .hero-cta { grid-column: 5 / -1; align-items: flex-start; margin-top: 0; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -881,7 +881,7 @@ button:focus-visible {
      translucent bar, exactly as the old fixed nav did. */
   .hero-shell { position: relative; --hero-nav-h: 76px; }
   .hero-shell > .hero-band { margin-top: calc(-1 * var(--hero-nav-h)); }
-  .hero-band { position: relative; z-index: 2; overflow: hidden; border-radius: 0 0 calc(var(--r) * 3) calc(var(--r) * 3); margin-bottom: calc(-3 * var(--r)); min-height: calc(80svh + calc(var(--r) * 3)); display: flex; align-items: flex-end; background: none; }
+  .hero-band { position: relative; z-index: 2; overflow: hidden; border-radius: 0 0 calc(var(--r) * 3) calc(var(--r) * 3); margin-bottom: calc(-3 * var(--r)); min-height: calc(90svh + calc(var(--r) * 3)); display: flex; align-items: flex-end; background: none; }
   .hero-scrim { position: absolute; top: 0; left: 0; right: 0; height: 190px; z-index: 3; pointer-events: none; background: linear-gradient(to bottom, var(--ink) 0%, rgba(0, 20, 27, 0.55) 45%, transparent 100%); }
   .hero-band::before { z-index: 2; } /* grain sits over the tint */
   .hero-photo { position: absolute; inset: 0; z-index: 0; background: url(/assets/img_9531.jpg) center top/cover no-repeat; filter: grayscale(1); }
@@ -895,7 +895,7 @@ button:focus-visible {
   .hero-login { display: inline-flex; }
   .sec-after-hero { padding-top: calc(56px + 3 * var(--r)); }
   @media (min-width: 1024px) {
-    .hero-band { align-items: center; min-height: calc(80svh + 3 * var(--r)); }
+    .hero-band { align-items: center; min-height: calc(90svh + 3 * var(--r)); }
     .hero-inner { padding: 120px var(--pad) 72px; display: grid; grid-template-columns: repeat(7, 1fr); column-gap: var(--pad); row-gap: 40px; align-items: start; }
     .hero-band .hero-inner .t-display { grid-column: 1 / -1; font-size: 96px; line-height: 100px; letter-spacing: -0.05em; }
     .hero-cta { grid-column: 5 / -1; align-items: flex-start; margin-top: 0; }

--- a/lib/content/queries.ts
+++ b/lib/content/queries.ts
@@ -53,7 +53,7 @@ export interface MetroRow {
   members: number | null;
   waiting_baseline: number;
   blurb: string | null;
-  waiting: number; // baseline + live signups
+  waiting: number; // live participant count for this lab (metro_id)
 }
 
 export async function getEvents(): Promise<EventRow[]> {
@@ -100,21 +100,33 @@ export async function getResource(slug: string): Promise<ResourceRow | null> {
   return (data as ResourceRow) ?? null;
 }
 
-async function withWaiting(rows: Record<string, unknown>[]): Promise<MetroRow[]> {
+// Live per-lab counts: how many participants are affiliated with each lab
+// (participants.metro_id). Drives both the active "N members" label and the
+// waitlist "N people waiting" label (a waitlisted member's metro_id points at
+// the waitlist lab). This replaces the old static metros.members column +
+// metro_waitlist_signups tally, which drifted from reality. Test accounts are
+// excluded so public counts aren't inflated.
+async function withMemberCounts(
+  rows: Record<string, unknown>[]
+): Promise<MetroRow[]> {
   const supabase = createServiceClient();
-  const { data: signups } = await supabase
-    .from("metro_waitlist_signups")
-    .select("metro_id");
+  const { data: parts } = await supabase
+    .from("participants")
+    .select("metro_id")
+    .not("metro_id", "is", null)
+    .not("is_test", "is", true);
   const counts = new Map<number, number>();
-  for (const s of (signups as { metro_id: number }[]) ?? []) {
-    counts.set(s.metro_id, (counts.get(s.metro_id) ?? 0) + 1);
+  for (const p of (parts as { metro_id: number }[]) ?? []) {
+    counts.set(p.metro_id, (counts.get(p.metro_id) ?? 0) + 1);
   }
-  return rows.map((m) => ({
-    ...(m as unknown as Omit<MetroRow, "waiting">),
-    waiting:
-      ((m as { waiting_baseline: number }).waiting_baseline ?? 0) +
-      (counts.get((m as { id: number }).id) ?? 0),
-  }));
+  return rows.map((m) => {
+    const n = counts.get((m as { id: number }).id) ?? 0;
+    return {
+      ...(m as unknown as Omit<MetroRow, "waiting" | "members">),
+      members: n,
+      waiting: n,
+    };
+  });
 }
 
 /** Active lab first, then waitlists by list size (the prototype's sort). */
@@ -122,7 +134,7 @@ export async function getMetros(): Promise<MetroRow[]> {
   const supabase = createServiceClient();
   const { data, error } = await supabase.from("metros").select("*");
   if (error) console.error("[content] getMetros:", error.message);
-  const rows = await withWaiting((data as Record<string, unknown>[]) ?? []);
+  const rows = await withMemberCounts((data as Record<string, unknown>[]) ?? []);
   return rows.sort((a, b) =>
     a.status === "active" ? -1 : b.status === "active" ? 1 : b.waiting - a.waiting
   );
@@ -136,6 +148,6 @@ export async function getMetro(slug: string): Promise<MetroRow | null> {
     .eq("slug", slug)
     .maybeSingle();
   if (!data) return null;
-  const [row] = await withWaiting([data as Record<string, unknown>]);
+  const [row] = await withMemberCounts([data as Record<string, unknown>]);
   return row ?? null;
 }


### PR DESCRIPTION
Promotes `dev` to `main`. Net content diff is 3 files (the rest of dev is already on main via #251/#253).

## What's included
- **Live lab member counts** (#254) — homepage lab numbers now come from `participants.metro_id` (test accounts excluded) instead of stale static `metros` columns. Active labs show real "N members"; waitlist labs show real "N people waiting" (no longer dependent on the wiped `metro_waitlist_signups` table). `lib/content/queries.ts`, `app/components/content/teasers.tsx`.
- **Removed the "Flagship" tag** from the DC lab card. `app/components/content/teasers.tsx`.
- **Hero band height** — `80svh` → `90svh`, removed the 600px desktop cap. `app/globals.css`.

## Verify
- `/` (logged out): real lab counts, no Flagship label, taller hero band.
- Lint + typecheck clean.

## Database
- [x] No migration — all read-only / CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)