### PR TITLE
docs: never push to dev/main directly (branch + PR by default)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 @AGENTS.md
 
+## Branch discipline
+
+**Never commit or push to `dev` or `main` directly.** Every change goes on a feature branch and into `dev` via a PR; promotion to `main` is its own `dev` → `main` PR. The only exception is when the user *explicitly* asks to push a specific change straight to `dev` or `main` in that moment — otherwise, always branch + PR. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+
 ## Orientation
 
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — how the codebase is organized (App Router, `lib/`, migrations, core concepts).


### PR DESCRIPTION
Adds a Branch discipline rule to CLAUDE.md: never commit/push to `dev` or `main` directly — always feature branch + PR into `dev`, and a separate `dev`→`main` PR to promote. Only exception is an explicit ask to push a specific change directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)