### PR TITLE
fix(labs): hide archived metros from getMetros/getMetro

### DIFF
--- a/lib/content/queries.ts
+++ b/lib/content/queries.ts
@@ -132,7 +132,11 @@ async function withMemberCounts(
 /** Active lab first, then waitlists by list size (the prototype's sort). */
 export async function getMetros(): Promise<MetroRow[]> {
   const supabase = createServiceClient();
-  const { data, error } = await supabase.from("metros").select("*");
+  // Archived labs (metros.archived_at, 00081) are soft-hidden — never list them.
+  const { data, error } = await supabase
+    .from("metros")
+    .select("*")
+    .is("archived_at", null);
   if (error) console.error("[content] getMetros:", error.message);
   const rows = await withMemberCounts((data as Record<string, unknown>[]) ?? []);
   return rows.sort((a, b) =>
@@ -146,6 +150,7 @@ export async function getMetro(slug: string): Promise<MetroRow | null> {
     .from("metros")
     .select("*")
     .eq("slug", slug)
+    .is("archived_at", null)
     .maybeSingle();
   if (!data) return null;
   const [row] = await withMemberCounts([data as Record<string, unknown>]);


### PR DESCRIPTION
Follow-up to #254 (merged). That commit landed after #254 merged, so it was stranded on the branch — this PR brings it into dev.

Archived labs (`metros.archived_at`, 00081) were still returned by the public content queries, so archiving a lab (e.g. Atlanta) didn't remove it from the homepage or `/local-labs`. `getMetros()` and `getMetro()` now filter `archived_at IS NULL`.

## Verify
- Archived Atlanta no longer appears on `/` or `/local-labs`; its `/local-labs/atlanta-ga` page 404s.
- Lint + typecheck clean.

## Database
- [x] No migration (reads existing `metros.archived_at`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)