### PR TITLE
content: cohort→cycle copy + learning-log check-in wording

### DIFF
--- a/app/(auth)/register/funnel.tsx
+++ b/app/(auth)/register/funnel.tsx
@@ -63,7 +63,7 @@ const PARTICIPANT_AGREEMENT: { h: string; p: string }[] = [
   },
   {
     h: "Updates",
-    p: "We’ll email you about your cohort and Labs news. Unsubscribe anytime; account-critical messages still arrive.",
+    p: "We’ll email you about your cycle and Labs news. Unsubscribe anytime; account-critical messages still arrive.",
   },
   {
     h: "Leaving",

--- a/app/(dashboard)/dashboard/learning-log-card.tsx
+++ b/app/(dashboard)/dashboard/learning-log-card.tsx
@@ -369,8 +369,8 @@ export default function LearningLogCard({
       {journal && (
         <p className="mt-2 text-sm text-charcoal">
           A running record of what you&apos;re learning — yours to keep and look
-          back on anytime. Join a Build Cycle and this becomes your weekly
-          check-in.
+          back on anytime. When you join a Build Cycle this becomes your
+          required weekly check-in.
         </p>
       )}
 

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -590,7 +590,7 @@ export default async function DashboardPage() {
         )}
         <p className="mt-3 text-sm text-meta">
           {upcoming
-            ? "Pre-register now to claim your spot for the next cohort."
+            ? "Pre-register now to claim your spot for the next cycle."
             : "Complete this form to join the cycle."}
         </p>
       </div>
@@ -611,7 +611,7 @@ export default async function DashboardPage() {
       <div className="lbl lbl-teal mb-2">You&apos;re pre-registered</div>
       <h2 className="t-h3 text-ink">{cycle.name}</h2>
       <p className="mt-2 text-sm text-meta">
-        You&apos;re all set for the next cohort
+        You&apos;re all set for the next cycle
         {cycle.start_date
           ? ` — it kicks off ${new Date(cycle.start_date).toLocaleDateString(
               "en-US",

--- a/app/components/owner-lifecycle.tsx
+++ b/app/components/owner-lifecycle.tsx
@@ -33,7 +33,7 @@ const COPY: Record<EntityKey, Record<Action, { title: string; blurb: string; con
     reset: {
       title: "Reset this cycle",
       blurb:
-        "Wipes the cohort back to a pristine draft: removes every enrollment, pod, project, submission, vote, and engagement log, and resets the config to defaults. Field-survey research and the revocation audit log are kept. This cannot be undone.",
+        "Wipes the cycle back to a pristine draft: removes every enrollment, pod, project, submission, vote, and engagement log, and resets the config to defaults. Field-survey research and the revocation audit log are kept. This cannot be undone.",
       confirmLabel: "Reset cycle",
       typed: true,
       variant: "destructive",


### PR DESCRIPTION
Copy pass, mostly dashboard.

## Changes
- **Dashboard** (`page.tsx`): "Pre-register now to claim your spot for the next **cycle**" and "You're all set for the next **cycle**" (both said "cohort").
- **Learning Log** (`learning-log-card.tsx`, journal mode): "…When you join a Build Cycle this becomes your **required weekly check-in**."
- **Register funnel** (`funnel.tsx`): "We'll email you about your **cycle** and Labs news" (was "cohort").
- **Owner reset** (`owner-lifecycle.tsx`): "Wipes the **cycle** back to a pristine draft…" (was "cohort").

## Deliberately left as "cohort" (distinct meaning)
Homepage "form a cohort", API "sub-cohort" descriptions, admin "Participant cohort" label. The survey line ("the problems your cohort picks") was left as a judgment call.

## Verify
- Lint clean. Copy-only, no logic changes.

## Database
- [x] No change

🤖 Generated with [Claude Code](https://claude.com/claude-code)