### PR TITLE
Make dashboard profile card a single link; consolidate profile actions

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -734,7 +734,6 @@ export default async function DashboardPage() {
         metroName={labName}
         avatarUrl={avatarUrl}
         initials={initials}
-        handle={participant.handle}
         followingCount={followingTotal ?? 0}
       />
       <MembershipsPanel

--- a/app/(dashboard)/dashboard/profile-mini-card.tsx
+++ b/app/(dashboard)/dashboard/profile-mini-card.tsx
@@ -2,9 +2,11 @@ import Link from "next/link";
 
 /**
  * The left-rail identity card — a compact profile summary (avatar, name,
- * headline, lab) with links to the public profile and the edit page. The heavy
- * MemberProfileView (max-w-3xl, owner PII sections) is the wrong fit for a 2/7
- * column, so this is a purpose-built mini card on the same tokens.
+ * headline, lab). The whole card is a single link to your profile (/profile,
+ * the owner view, where editing is started); the "Following" count is a
+ * separate footer link. The heavy MemberProfileView (max-w-3xl, owner PII
+ * sections) is the wrong fit for a 2/7 column, so this is a purpose-built mini
+ * card on the same tokens.
  */
 export default function ProfileMiniCard({
   displayName,
@@ -12,7 +14,6 @@ export default function ProfileMiniCard({
   metroName,
   avatarUrl,
   initials,
-  handle,
   followingCount = null,
 }: {
   displayName: string;
@@ -20,13 +21,16 @@ export default function ProfileMiniCard({
   metroName: string | null;
   avatarUrl: string | null;
   initials: string;
-  handle: string | null;
   /** People + pages followed — links to /network when provided. */
   followingCount?: number | null;
 }) {
   return (
-    <section className="rounded-card border border-ink/10 bg-white p-5 shadow-card">
-      <div className="flex flex-col items-center text-center">
+    <section className="overflow-hidden rounded-card border border-ink/10 bg-white shadow-card">
+      <Link
+        href="/profile"
+        aria-label="View your profile"
+        className="flex flex-col items-center p-5 text-center transition-colors duration-150 hover:bg-ink/[0.03]"
+      >
         {avatarUrl ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
@@ -42,32 +46,16 @@ export default function ProfileMiniCard({
         <h2 className="mt-3 t-h4 text-ink">{displayName}</h2>
         {headline && <p className="mt-1 text-sm text-teal-deep">{headline}</p>}
         {metroName && <p className="mt-1 text-xs text-meta">{metroName}</p>}
-        {followingCount != null && (
-          <Link
-            href="/network"
-            className="mt-2 text-xs font-semibold text-teal-deep transition-colors duration-150 hover:text-ink"
-          >
-            Following · {followingCount}
-          </Link>
-        )}
-      </div>
+      </Link>
 
-      <div className="mt-4 flex flex-col gap-2">
-        {handle && (
-          <Link
-            href={`/u/${handle}`}
-            className="btn btn-ghost min-h-11 w-full justify-center px-4 py-2 text-sm"
-          >
-            View profile
-          </Link>
-        )}
+      {followingCount != null && (
         <Link
-          href="/profile/edit"
-          className="btn btn-ghost min-h-11 w-full justify-center px-4 py-2 text-sm"
+          href="/network"
+          className="block border-t border-ink/10 px-5 py-3 text-center text-xs font-semibold text-teal-deep transition-colors duration-150 hover:bg-ink/[0.03] hover:text-ink"
         >
-          Edit profile
+          Following · {followingCount}
         </Link>
-      </div>
+      )}
     </section>
   );
 }

--- a/app/components/chrome/app-nav.tsx
+++ b/app/components/chrome/app-nav.tsx
@@ -396,15 +396,7 @@ function AvatarMenu({
             href="/profile"
             onClick={() => setOpen(false)}
           >
-            Profile
-          </Link>
-          <Link
-            className="menu-item"
-            role="menuitem"
-            href="/profile/edit"
-            onClick={() => setOpen(false)}
-          >
-            Edit profile
+            View profile
           </Link>
           {canViewAs && (
             <>


### PR DESCRIPTION
## What

Fix the confusing dashboard profile card and profile nav flow. The card's "View profile" button linked to `/u/[handle]` (the *visitor* view of your own profile, which has no edit affordance) while the owner view at `/profile` already carries an "Edit profile" button — so users landed on a dead-end page and the card's two buttons duplicated an action that belongs on the profile page. Adopts a LinkedIn-style model: the card is one clickable link to your profile, and editing starts from the profile page.

## Changes

- **`app/(dashboard)/dashboard/profile-mini-card.tsx`** — the whole card is now a single `<Link href="/profile">` (avatar/name/headline/lab) with a subtle hover tint. Removed the "View profile" / "Edit profile" buttons; "Following · N" is now a separate footer link (kept out of the card link so anchors aren't nested). Dropped the now-unused `handle` prop and refreshed the doc comment.
- **`app/(dashboard)/dashboard/page.tsx`** — removed the `handle={participant.handle}` prop from the `ProfileMiniCard` call.
- **`app/components/chrome/app-nav.tsx`** — avatar dropdown: renamed "Profile" → "View profile" (→ `/profile`); removed the standalone "Edit profile" item.

Editing now consistently starts from the profile page's existing "Edit profile" button — one obvious, non-duplicated path.

## Verify

Ran the full CI pipeline locally, all green:

- [x] `npm run lint` passes
- [x] `npm run test` passes (313 tests)
- [x] `npm run build` passes (all affected routes compile)
- [x] `npx tsc --noEmit` passes
- [x] `npm run check:migrations` passes

## Database

- [x] No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDPrshyuG1N4RR59qbQLsX)_