### PR TITLE
Surface the insights survey: share todo + cycle-overview explainer

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 import { windowOpen, fmtLabDate } from "@/lib/cycles/lab-time";
-import { BookOpen, ArrowRight, ChevronLeft } from "lucide-react";
+import { BookOpen, ArrowRight, ChevronLeft, ClipboardList } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
 import { StatCard, StatusBadge } from "@/app/components/ui";
 import { cycleInfoContent } from "@/lib/cycles/info";
+import { getFieldSurveyForCycle } from "@/lib/content/surveys";
 
 type CycleStatus = "active" | "closed" | "draft";
 type PodStatus = "active" | "forming" | "closed" | "inactive";
@@ -48,11 +49,18 @@ export default async function CycleDetailPage({
 
   const { data: cycle } = await supabase
     .from("cycles")
-    .select("id, name, slug, start_date, end_date, status")
+    .select("id, name, slug, start_date, end_date, status, sector_id")
     .eq("id", parseInt(cycle_id))
     .single();
 
   if (!cycle) notFound();
+
+  // The cycle's open field survey (cycle-tied, else sector commons) — same
+  // resolution the dashboard uses for the member's first CTA.
+  const fieldSurvey = await getFieldSurveyForCycle(
+    cycle.id,
+    cycle.sector_id ?? null
+  );
 
   const { data: pods } = await supabase
     .from("pods")
@@ -164,6 +172,39 @@ export default async function CycleDetailPage({
               </div>
             </Link>
           ))}
+        </div>
+      )}
+
+      {/* Insights survey — link + a two-line explainer of what it is and why
+          we run one (grounding the cycle in real problems, not assumptions) */}
+      {fieldSurvey && (
+        <div className="mb-8">
+          <Link
+            href={`/survey/${fieldSurvey.share_slug}`}
+            className="group flex items-center justify-between gap-3 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+          >
+            <div className="flex items-center gap-3">
+              <ClipboardList
+                className="h-5 w-5 flex-shrink-0 text-teal-deep"
+                aria-hidden
+              />
+              <div>
+                <span className="font-semibold tracking-tight text-ink">
+                  Insights survey: {fieldSurvey.title}
+                </span>
+                <p className="mt-0.5 text-sm text-meta">
+                  A short, open survey for anyone close to this cycle&apos;s
+                  theme. First-hand observations are how we make sure pods work
+                  on real problems, not assumptions — take it, then share it
+                  with a friend.
+                </p>
+              </div>
+            </div>
+            <ArrowRight
+              className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+              aria-hidden
+            />
+          </Link>
         </div>
       )}
 

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -998,6 +998,20 @@ export default async function DashboardPage() {
         ];
       })
     : [];
+  // Distributing the field survey rides the same list (SENSEMAKING_FLOW §2,
+  // Stage 1 "Distribute") — unlike the window todos it isn't deadline-bound,
+  // just open while the cohort's survey is. getFieldSurveyForCycle only
+  // returns open surveys, so presence is the whole gate.
+  if (fieldSurvey) {
+    upNextTodos.push({
+      id: "share-survey",
+      title: "Share the insights survey with a friend",
+      detail:
+        "More voices from the field keep the cohort pointed at real problems.",
+      href: `/survey/${fieldSurvey.share_slug}`,
+      cta: "Open survey",
+    });
+  }
 
   // The per-week "What's next" nudge (weekly_messages — program-global, the
   // cycle only supplies which week it is) — surfaced only once the member has


### PR DESCRIPTION
Two small touchpoints to help distribute the cycle's field survey (e.g. https://theupskillinglabs.org/survey/civics):

1. **Dashboard "On your plate" list** — a new dismissible card, **"Share the insights survey with a friend"**, linking to the cycle's open survey (`/survey/<share_slug>`). Appears whenever the member's cohort has an open field survey, alongside the window-driven todos.
2. **Cycle overview page** (`/cycles/[cycle_id]`) — a survey card (matching the Learning Log card style) linking to the survey, with a mini explainer: what it is (a short, open survey for anyone close to the cycle's theme) and why we run it (first-hand observations keep pods focused on real problems, not assumptions).

Both reuse `getFieldSurveyForCycle` (cycle-tied survey, sector-commons fallback, open only), so no hardcoded slugs — the civics survey shows for the civics cycle automatically.

## Verification
- `npm run build` — clean
- `npm test` — 331/331 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)