### PR TITLE
Let admins link existing surveys to a cycle

### DIFF
--- a/app/(dashboard)/admin/surveys/[slug]/page.tsx
+++ b/app/(dashboard)/admin/surveys/[slug]/page.tsx
@@ -15,7 +15,7 @@ export default async function SurveyBuilderPage({
 }: {
   params: Promise<{ slug: string }>;
 }) {
-  await requireAdmin();
+  const { serviceClient } = await requireAdmin();
   const { slug } = await params;
 
   const survey = await getFieldSurveyBySlug(slug);
@@ -24,6 +24,28 @@ export default async function SurveyBuilderPage({
   const questions = await getFieldSurveyQuestions(survey.id, {
     includeInactive: true,
   });
+
+  // Cycle affiliation options for the settings panel — one survey per cycle
+  // (00089), so cycles claimed by OTHER surveys render disabled.
+  const [{ data: cycleRows }, { data: takenRows }] = await Promise.all([
+    serviceClient
+      .from("cycles")
+      .select("id, name, status")
+      .order("start_date", { ascending: false }),
+    serviceClient
+      .from("field_surveys")
+      .select("cycle_id")
+      .not("cycle_id", "is", null)
+      .neq("id", survey.id),
+  ]);
+  const taken = new Set(
+    ((takenRows as { cycle_id: number }[] | null) ?? []).map(
+      (r) => r.cycle_id
+    )
+  );
+  const cycles = (
+    (cycleRows as { id: number; name: string; status: string }[] | null) ?? []
+  ).map((c) => ({ ...c, hasSurvey: taken.has(c.id) }));
 
   return (
     <div>
@@ -55,7 +77,7 @@ export default async function SurveyBuilderPage({
         </div>
       </div>
 
-      <SurveyBuilder survey={survey} initialQuestions={questions} />
+      <SurveyBuilder survey={survey} initialQuestions={questions} cycles={cycles} />
     </div>
   );
 }

--- a/app/(dashboard)/admin/surveys/[slug]/survey-builder.tsx
+++ b/app/(dashboard)/admin/surveys/[slug]/survey-builder.tsx
@@ -43,12 +43,21 @@ const AUTHORABLE_TYPES: SurveyQuestionType[] = [
 const hasOptions = (t: SurveyQuestionType) =>
   t === "single_select" || t === "multi_select" || t === "yes_no";
 
+export interface CycleOption {
+  id: number;
+  name: string;
+  status: string;
+  hasSurvey: boolean;
+}
+
 export default function SurveyBuilder({
   survey,
   initialQuestions,
+  cycles,
 }: {
   survey: FieldSurvey;
   initialQuestions: SurveyQuestion[];
+  cycles: CycleOption[];
 }) {
   const router = useRouter();
   const questions = initialQuestions;
@@ -95,7 +104,7 @@ export default function SurveyBuilder({
 
   return (
     <div className="grid gap-8 lg:grid-cols-[1fr_1.4fr]">
-      <SettingsPanel survey={survey} onSaved={() => router.refresh()} />
+      <SettingsPanel survey={survey} cycles={cycles} onSaved={() => router.refresh()} />
 
       <div>
         <div className="mb-4 flex items-center justify-between">
@@ -228,9 +237,11 @@ export default function SurveyBuilder({
 
 function SettingsPanel({
   survey,
+  cycles,
   onSaved,
 }: {
   survey: FieldSurvey;
+  cycles: CycleOption[];
   onSaved: () => void;
 }) {
   const router = useRouter();
@@ -240,6 +251,9 @@ function SettingsPanel({
   const [slug, setSlug] = useState(survey.share_slug);
   const [status, setStatus] = useState(survey.status);
   const [anon, setAnon] = useState(survey.allow_anonymous);
+  const [cycleId, setCycleId] = useState(
+    survey.cycle_id !== null ? String(survey.cycle_id) : ""
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
@@ -259,6 +273,10 @@ function SettingsPanel({
         share_slug: slug.trim(),
         status,
         allow_anonymous: anon,
+        // Legacy surveys may predate the cycle link (00089) — an unset select
+        // stays unset (omit, don't null out), but once linked a survey keeps
+        // some cycle.
+        ...(cycleId !== "" ? { cycle_id: Number(cycleId) } : {}),
       }),
     }).catch(() => null);
     setSaving(false);
@@ -317,6 +335,23 @@ function SettingsPanel({
             onChange={(e) => setSlug(e.target.value)}
             className={`${inputCls} font-mono text-sm`}
           />
+        </label>
+        <label className={labelCls}>
+          Cycle (one survey per cycle)
+          <select
+            value={cycleId}
+            onChange={(e) => setCycleId(e.target.value)}
+            className={inputCls}
+          >
+            {survey.cycle_id === null && (
+              <option value="">Not linked to a cycle yet</option>
+            )}
+            {cycles.map((c) => (
+              <option key={c.id} value={c.id} disabled={c.hasSurvey}>
+                {c.name} ({c.status}){c.hasSurvey ? " — has a survey" : ""}
+              </option>
+            ))}
+          </select>
         </label>
         <div className="flex gap-3">
           <label className={`${labelCls} flex-1`}>

--- a/app/api/surveys/[slug]/route.ts
+++ b/app/api/surveys/[slug]/route.ts
@@ -28,7 +28,22 @@ export const PATCH = withAdminAuth(async (request, _auth, params) => {
     .eq("id", survey.id)
     .select("share_slug")
     .single();
-  if (error) return dbError(error, "survey-settings-update");
+  if (error) {
+    // One survey per cycle (uq_field_surveys_cycle, 00089) and the slug's
+    // UNIQUE both surface as 23505 — actionable 409, not a sanitized 500.
+    if (error.code === "23505") {
+      const taken = error.message.includes("uq_field_surveys_cycle");
+      return NextResponse.json(
+        {
+          error: taken
+            ? "That cycle already has a survey — each cycle can have only one."
+            : "That share slug is already in use.",
+        },
+        { status: 409 }
+      );
+    }
+    return dbError(error, "survey-settings-update");
+  }
 
   return NextResponse.json({ ok: true, share_slug: data.share_slug });
 });


### PR DESCRIPTION
Follow-up to #271: creation requires a cycle, but the two shipped surveys (civics, education) predate the link and had no UI to gain one.

- **Survey builder → Settings** gains the same "Cycle (one survey per cycle)" select as the create form — cycles claimed by *other* surveys are disabled; a legacy unlinked survey shows "Not linked to a cycle yet" until a cycle is chosen (saving without choosing leaves it unset; it never nulls out an existing link).
- **`PATCH /api/surveys/[slug]`** now returns the same actionable 409 as create when the chosen cycle is already taken (or the slug is), instead of a sanitized 500. The API already accepted `cycle_id` via `surveySettingsSchema` — this was UI + error-shaping only, no migration needed.

With this, the civics survey can be linked to its cycle from the admin UI (that's also how the prod backfill can be done by hand instead of SQL, if preferred).

## Verification
- `npm run build` — clean
- `npm test` — 331/331

🤖 Generated with [Claude Code](https://claude.com/claude-code)