### PR TITLE
Dashboard: checklist pinned on top; survey down to two surfaces

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1001,7 +1001,7 @@ export default async function DashboardPage() {
       id: "share-survey",
       title: "Share the insights survey with a friend",
       detail:
-        "More voices from the field keep the cohort pointed at real problems.",
+        "More voices from the field keep the cycle pointed at real problems.",
       href: `/survey/${fieldSurvey.share_slug}`,
       cta: "Open survey",
       secondaryHref: `/survey/${fieldSurvey.share_slug}/results`,

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -505,17 +505,9 @@ export default async function DashboardPage() {
           },
         ]
       : []),
-    ...(fieldSurvey
-      ? [
-          {
-            key: "survey",
-            label: "Share your field observations",
-            done: surveyContributed,
-            href: `/survey/${fieldSurvey.share_slug}`,
-            cta: "Open",
-          },
-        ]
-      : []),
+    // The survey deliberately has NO checklist row — it already has the
+    // "Start here" card (contribute) and the Up-next share todo; three
+    // surfaces for one action read as clutter (owner call, 2026-07-14).
     {
       key: "profile",
       // Label names the exact fields that flip profileDone (bio || headline),

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1004,6 +1004,8 @@ export default async function DashboardPage() {
         "More voices from the field keep the cohort pointed at real problems.",
       href: `/survey/${fieldSurvey.share_slug}`,
       cta: "Open survey",
+      secondaryHref: `/survey/${fieldSurvey.share_slug}/results`,
+      secondaryCta: "Explore the answers so far",
     });
   }
 

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -570,7 +570,31 @@ export default async function DashboardPage() {
   // The prominent first-CTA card — the visual lead for the cohort's opening
   // activity. Renders above the setup checklist in every state where the cohort
   // has an open survey; pairs "contribute" with "share" (Stage 1 = Distribute).
-  const fieldSurveyCard = (survey: FieldSurvey) => (
+  // Once the member has contributed, the big pitch has done its job — collapse
+  // to a strip (same shape as the checklist's collapsed state) with the two
+  // follow-on actions. Sharing keeps its own Up-next card.
+  const fieldSurveyCard = (survey: FieldSurvey) =>
+    surveyContributed ? (
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-card border border-ink/10 bg-white px-5 py-3 shadow-card">
+        <span className="text-sm font-semibold text-teal-deep">
+          Field survey · Contributed ✓
+        </span>
+        <span className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+          <Link
+            href={`/survey/${survey.share_slug}`}
+            className="font-semibold text-teal-deep hover:underline"
+          >
+            Add another →
+          </Link>
+          <Link
+            href={`/survey/${survey.share_slug}/results`}
+            className="text-meta transition-colors hover:text-teal-deep hover:underline"
+          >
+            See what the cycle is finding →
+          </Link>
+        </span>
+      </div>
+    ) : (
     <section className="mb-6 rounded-card border border-teal/30 bg-white p-6 shadow-card">
       <div className="lbl lbl-teal mb-2">Start here · Field survey</div>
       <h2 className="t-h3 text-ink">{survey.title}</h2>
@@ -584,9 +608,7 @@ export default async function DashboardPage() {
           href={`/survey/${survey.share_slug}`}
           className="inline-flex items-center gap-1.5 rounded-card bg-teal-deep px-4 py-2 text-sm font-semibold tracking-tight text-white transition-colors duration-150 hover:bg-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
         >
-          {surveyContributed
-            ? "Add another observation"
-            : "Contribute an observation"}
+          Contribute an observation
           <ArrowRight className="h-4 w-4" aria-hidden />
         </Link>
         <ShareSurveyButton slug={survey.share_slug} title={survey.title} />

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -884,8 +884,10 @@ export default async function DashboardPage() {
             {/* Org-only staff lead with their actual work; the cohort join CTA
                 is for the participant pipeline they're not in. */}
             {orgActive && workstreamsSection}
-            {fieldSurvey && fieldSurveyCard(fieldSurvey)}
+            {/* Checklist stays pinned above the survey CTA — it's the member's
+                own setup state; the survey is the cohort's opening activity. */}
             <SetupChecklist items={checklistItems} />
+            {fieldSurvey && fieldSurveyCard(fieldSurvey)}
             {!orgActive &&
               (upcomingCycle
                 ? preRegisteredUpcoming
@@ -929,10 +931,10 @@ export default async function DashboardPage() {
         <div className="dash-12">
           <div className="dash-center">
             {orgActive && workstreamsSection}
-            {fieldSurvey && fieldSurveyCard(fieldSurvey)}
             {checklistItems.length > 0 && (
               <SetupChecklist items={checklistItems} />
             )}
+            {fieldSurvey && fieldSurveyCard(fieldSurvey)}
             {!orgActive &&
               (upcomingCycle ? (
                 preRegisteredUpcoming ? (
@@ -1102,11 +1104,12 @@ export default async function DashboardPage() {
       <div className="dash-12">
         {/* CENTER — what to do now, then the community feed */}
         <div className="dash-center">
-          {/* The field survey is the cohort's opening activity — the first CTA. */}
-          {fieldSurvey && fieldSurveyCard(fieldSurvey)}
-
-          {/* Setup leads for a new member; collapses to a strip once done. */}
+          {/* Setup leads — the checklist stays pinned to the top of the column
+              while it has open items; collapses to a strip once done. */}
           {checklistItems.length > 0 && <SetupChecklist items={checklistItems} />}
+
+          {/* The field survey is the cohort's opening activity — right below setup. */}
+          {fieldSurvey && fieldSurveyCard(fieldSurvey)}
 
           {/* The Learning Log lives in the feed composer at the bottom of this
               column. When the weekly gate is active the layout bounces the

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -577,7 +577,7 @@ export default async function DashboardPage() {
       <p className="mt-2 max-w-2xl text-sm text-meta">
         Every Build Cycle starts in the field. Add what you&apos;re seeing, then
         share the survey with people close to the problem — your observations
-        shape the problems this cohort takes on.
+        shape the problems this cycle takes on.
       </p>
       <div className="mt-4 flex flex-wrap items-center gap-3">
         <Link
@@ -595,7 +595,7 @@ export default async function DashboardPage() {
         href={`/survey/${survey.share_slug}/results`}
         className="mt-3 inline-block text-sm font-semibold text-teal-deep hover:underline"
       >
-        See what the cohort is finding &rarr;
+        See what the cycle is finding &rarr;
       </Link>
     </section>
   );

--- a/app/(dashboard)/dashboard/up-next.tsx
+++ b/app/(dashboard)/dashboard/up-next.tsx
@@ -15,6 +15,10 @@ export interface TodoCard {
   detail: string;
   href: string;
   cta: string;
+  /** Optional lighter second link rendered beside the CTA (e.g. "learn
+      more" / "explore" destinations that support the primary action). */
+  secondaryHref?: string;
+  secondaryCta?: string;
 }
 
 const KEY = "olos.dismissedTodos.v1";
@@ -78,12 +82,22 @@ export default function UpNext({ todos }: { todos: TodoCard[] }) {
             </button>
             <h3 className="t-h4 pr-8 text-ink">{t.title}</h3>
             <p className="mt-1 text-sm text-meta">{t.detail}</p>
-            <Link
-              href={t.href}
-              className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold tracking-tight text-teal-deep hover:underline"
-            >
-              {t.cta} →
-            </Link>
+            <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1">
+              <Link
+                href={t.href}
+                className="inline-flex items-center gap-1.5 text-sm font-semibold tracking-tight text-teal-deep hover:underline"
+              >
+                {t.cta} →
+              </Link>
+              {t.secondaryHref && t.secondaryCta && (
+                <Link
+                  href={t.secondaryHref}
+                  className="inline-flex items-center gap-1.5 text-sm text-meta hover:text-teal-deep hover:underline"
+                >
+                  {t.secondaryCta} →
+                </Link>
+              )}
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
Dashboard survey-surface pass (owner feedback, 2026-07-14/15):

1. **Setup checklist pinned on top** — renders above the "Start here · Field survey" card in all three dashboard states (was below it).
2. **Survey down to two surfaces** — the "Share your field observations" checklist row is removed; the survey keeps the "Start here" card (contribute) and the Up-next share todo.
3. **Up-next secondary link** — `TodoCard` supports an optional lighter second link; the share-survey todo adds "Explore the answers so far →" pointing at the results page (always shown, no response-count threshold).
4. **Copy: cycle, not cohort** — Up-next detail + both big-card strings.
5. **Collapsed post-contribution state** — once a member has contributed (their `participant_id` is bound server-side on signed-in submissions), the big card collapses to a checklist-style strip: "Field survey · Contributed ✓" with "Add another →" and "See what the cycle is finding →". The full pitch card only shows pre-contribution.

## Verification
- `npx tsc --noEmit` — clean
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)