### PR TITLE
PR template: require manual-testing instructions for key flows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,19 @@
 - [ ] `npm run test` passes
 - [ ] `npm run build` passes
 
+## Manual testing
+
+<!--
+  Step-by-step instructions for the key user-facing flows this PR touches, so
+  a reviewer (or whoever promotes to prod) can exercise them without reading
+  the diff: where to click, what to enter, and what should happen — including
+  the error/edge paths (e.g. "expect a friendly 409, not a 500"). Note which
+  environment each step assumes (local / dev preview / prod after deploy).
+  If the PR has no user-facing surface (docs, refactor), say "None" and why.
+-->
+
+1.
+
 ## Database
 
 - [ ] No schema change, **or** a migration was added under `supabase/migrations/`


### PR DESCRIPTION
## What

Adds a **Manual testing** section to the PR template so every PR ships with step-by-step instructions for the key user-facing flows it touches — reviewers and whoever promotes to prod shouldn't have to reconstruct the test pass from the diff (as happened after the fact on #278).

## Changes

- `.github/pull_request_template.md`: new `## Manual testing` section between Verify and Database, with guidance in the comment: click-level steps, expected outcomes including error/edge paths, which environment each step assumes (local / dev preview / prod after deploy), and an explicit "None" escape hatch for PRs with no user-facing surface.

## Verify

- [x] `npm run lint` passes (0 errors, 8 pre-existing warnings)
- [x] `npm run test` passes (335/335)
- [ ] `npm run build` — not re-run; markdown-template-only change with no effect on the build (CI runs it regardless)

## Manual testing

None — template-only change with no user-facing surface. (The template itself takes effect on the next PR opened after this merges; its rendered form is visible in this PR's Files tab.)

## Database

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AV8o3zwcxitABaPrN8nSFK