### PR TITLE
Add cycle contacts CSV export for admin panel

### DIFF
--- a/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
@@ -482,9 +482,21 @@ export default async function AdminCycleDetailPage({
   const people = (
     <div className="space-y-10">
       <section>
-        <h2 className="mb-4 t-h3 text-ink">
-          {isOrg ? "Core contributors" : "Participants"} ({participants.length})
-        </h2>
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <h2 className="t-h3 text-ink">
+            {isOrg ? "Core contributors" : "Participants"} (
+            {participants.length})
+          </h2>
+          {participants.length > 0 && (
+            <a
+              href={`/api/cycles/${cycleId}/contacts/export`}
+              download
+              className="inline-flex items-center gap-1.5 rounded-card bg-teal-deep px-4 py-2 text-sm font-semibold tracking-tight text-white transition-colors duration-150 hover:bg-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+            >
+              Download contacts CSV
+            </a>
+          )}
+        </div>
         <ParticipantsTable
           participants={participants}
           cycleId={cycleId}

--- a/app/api/cycles/[cycle_id]/contacts/export/route.ts
+++ b/app/api/cycles/[cycle_id]/contacts/export/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import { parseIntParam } from "@/lib/api/params";
+import { dbError } from "@/lib/api/errors";
+import { toCsv } from "@/lib/export/csv";
+import {
+  getCycleContacts,
+  buildCycleContactsTable,
+} from "@/lib/cycle/contacts";
+
+// Contact download for everyone enrolled in a cycle → CSV (admin panel, cycle
+// People tab). Admin-only via withAdminAuth; the loader reads service-role
+// because cycle_enrollments is RLS-locked and the file carries participant PII.
+export const GET = withAdminAuth(async (_request, _auth, params) => {
+  const cycleId = parseIntParam(params.cycle_id, "cycle_id");
+  if (cycleId instanceof NextResponse) return cycleId;
+
+  const { cycle, rows, error } = await getCycleContacts(cycleId);
+  if (error) return dbError(error, "cycle-contacts-export");
+  if (!cycle) {
+    return NextResponse.json({ error: "Cycle not found" }, { status: 404 });
+  }
+
+  const { columns, records } = buildCycleContactsTable(rows);
+  const csv = toCsv(records, columns);
+
+  const date = new Date().toISOString().slice(0, 10);
+  const filename = `${cycle.slug}-contacts-${date}.csv`;
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+});

--- a/lib/cycle/contacts.test.ts
+++ b/lib/cycle/contacts.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { buildCycleContactsTable, type CycleContactRow } from "./contacts";
+import { toCsv } from "@/lib/export/csv";
+
+function row(overrides: Partial<CycleContactRow> = {}): CycleContactRow {
+  return {
+    enrollment_status: "active",
+    first_name: "Ada",
+    last_name: "Lovelace",
+    preferred_name: null,
+    email: "ada@example.com",
+    phone_number: null,
+    linkedin: null,
+    slack_username: null,
+    github_username: null,
+    metro_slug: null,
+    state: null,
+    contact_consent: false,
+    photo_video_consent: false,
+    ...overrides,
+  };
+}
+
+describe("buildCycleContactsTable", () => {
+  it("emits every contact column in a stable order", () => {
+    const { columns } = buildCycleContactsTable([]);
+    expect(columns.map((c) => c.key)).toEqual([
+      "first_name",
+      "last_name",
+      "preferred_name",
+      "email",
+      "phone_number",
+      "linkedin",
+      "slack_username",
+      "github_username",
+      "metro_slug",
+      "state",
+      "enrollment_status",
+      "contact_consent",
+      "photo_video_consent",
+    ]);
+    expect(columns.map((c) => c.header)).toContain("Contact consent");
+    expect(columns.map((c) => c.header)).toContain("Photo/video consent");
+  });
+
+  it("sorts records by last name, then first name", () => {
+    const { records } = buildCycleContactsTable([
+      row({ first_name: "Grace", last_name: "Hopper" }),
+      row({ first_name: "Ada", last_name: "Lovelace" }),
+      row({ first_name: "Alan", last_name: "Hopper" }),
+    ]);
+    expect(
+      (records as unknown as CycleContactRow[]).map(
+        (r) => `${r.first_name} ${r.last_name}`
+      )
+    ).toEqual(["Alan Hopper", "Grace Hopper", "Ada Lovelace"]);
+  });
+
+  it("serializes consent booleans as yes/no and null fields as empty cells", () => {
+    const { columns, records } = buildCycleContactsTable([
+      row({
+        first_name: "Ada",
+        last_name: "Lovelace",
+        phone_number: null,
+        linkedin: null,
+        contact_consent: true,
+        photo_video_consent: false,
+      }),
+    ]);
+    const csv = toCsv(records, columns);
+    const [header, dataRow] = csv.split("\r\n");
+    const headers = header.split(",");
+    const cells = dataRow.split(",");
+    const cell = (key: string) =>
+      cells[columns.findIndex((c) => c.key === key)];
+    expect(headers).toContain("Contact consent");
+    expect(cell("contact_consent")).toBe("yes");
+    expect(cell("photo_video_consent")).toBe("no");
+    expect(cell("phone_number")).toBe("");
+    expect(cell("linkedin")).toBe("");
+    expect(cell("email")).toBe("ada@example.com");
+  });
+});

--- a/lib/cycle/contacts.ts
+++ b/lib/cycle/contacts.ts
@@ -1,0 +1,128 @@
+import { createServiceClient } from "@/lib/supabase/server";
+import type { CsvColumn } from "@/lib/export/csv";
+
+// Contact export for everyone enrolled in a cycle → CSV (admin panel, People
+// tab). Mirrors the field-survey export split: a service-role loader here plus a
+// pure pivot for the route to serialize. Reads are service-role because
+// cycle_enrollments is RLS-locked and the file carries participant PII, so the
+// route that calls this must be admin-gated.
+
+// Contact columns pulled from the embedded participants row.
+const PARTICIPANT_CONTACT_COLUMNS =
+  "first_name, last_name, preferred_name, email, phone_number, linkedin, slack_username, github_username, metro_slug, state, contact_consent, photo_video_consent";
+
+export interface CycleContactRow {
+  enrollment_status: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  preferred_name: string | null;
+  email: string | null;
+  phone_number: string | null;
+  linkedin: string | null;
+  slack_username: string | null;
+  github_username: string | null;
+  metro_slug: string | null;
+  state: string | null;
+  contact_consent: boolean | null;
+  photo_video_consent: boolean | null;
+}
+
+export interface CycleContactsResult {
+  /** The cycle's identity for the download filename; null when no such cycle. */
+  cycle: { slug: string; name: string } | null;
+  rows: CycleContactRow[];
+  /** A DB error to hand to `dbError`; null on success (including "not found"). */
+  error: unknown;
+}
+
+/**
+ * Load the contact roster for a cycle: every enrolled participant (no
+ * test/staff filter — matches the admin People tab exactly), flattened to one
+ * row per person. Returns `cycle: null` when the id doesn't exist so the caller
+ * can 404.
+ */
+export async function getCycleContacts(
+  cycleId: number
+): Promise<CycleContactsResult> {
+  const supabase = createServiceClient();
+
+  const { data: cycle, error: cycleError } = await supabase
+    .from("cycles")
+    .select("slug, name")
+    .eq("id", cycleId)
+    .maybeSingle();
+  if (cycleError) return { cycle: null, rows: [], error: cycleError };
+  if (!cycle) return { cycle: null, rows: [], error: null };
+
+  const { data: enrollments, error } = await supabase
+    .from("cycle_enrollments")
+    .select(`status, participants ( ${PARTICIPANT_CONTACT_COLUMNS} )`)
+    .eq("cycle_id", cycleId);
+  if (error) {
+    return { cycle: { slug: cycle.slug, name: cycle.name }, rows: [], error };
+  }
+
+  const rows: CycleContactRow[] = (enrollments ?? []).map((e) => {
+    // The participants embed is a to-one join; the untyped client returns it as
+    // an object (older typings sometimes model it as an array — mirror the cast
+    // used in app/api/cycles/[cycle_id]/participants/route.ts).
+    const p = (e.participants as unknown) as Record<string, unknown> | null;
+    const str = (v: unknown): string | null =>
+      v == null ? null : String(v);
+    const bool = (v: unknown): boolean | null =>
+      v == null ? null : Boolean(v);
+    return {
+      enrollment_status: str(e.status),
+      first_name: str(p?.first_name),
+      last_name: str(p?.last_name),
+      preferred_name: str(p?.preferred_name),
+      email: str(p?.email),
+      phone_number: str(p?.phone_number),
+      linkedin: str(p?.linkedin),
+      slack_username: str(p?.slack_username),
+      github_username: str(p?.github_username),
+      metro_slug: str(p?.metro_slug),
+      state: str(p?.state),
+      contact_consent: bool(p?.contact_consent),
+      photo_video_consent: bool(p?.photo_video_consent),
+    };
+  });
+
+  return { cycle: { slug: cycle.slug, name: cycle.name }, rows, error: null };
+}
+
+/**
+ * Pivot contact rows into flat CSV columns + records. Rows are already keyed to
+ * match the columns, so this only fixes column order/headers and sorts by name
+ * for a stable file. Boolean consent flags render as yes/no via `formatCsvValue`.
+ */
+export function buildCycleContactsTable(rows: CycleContactRow[]): {
+  columns: CsvColumn[];
+  records: Record<string, unknown>[];
+} {
+  const columns: CsvColumn[] = [
+    { key: "first_name", header: "First name" },
+    { key: "last_name", header: "Last name" },
+    { key: "preferred_name", header: "Preferred name" },
+    { key: "email", header: "Email" },
+    { key: "phone_number", header: "Phone" },
+    { key: "linkedin", header: "LinkedIn" },
+    { key: "slack_username", header: "Slack" },
+    { key: "github_username", header: "GitHub" },
+    { key: "metro_slug", header: "Metro" },
+    { key: "state", header: "State" },
+    { key: "enrollment_status", header: "Enrollment status" },
+    { key: "contact_consent", header: "Contact consent" },
+    { key: "photo_video_consent", header: "Photo/video consent" },
+  ];
+
+  const sorted = [...rows].sort((a, b) => {
+    const byLast = (a.last_name ?? "").localeCompare(b.last_name ?? "");
+    if (byLast !== 0) return byLast;
+    return (a.first_name ?? "").localeCompare(b.first_name ?? "");
+  });
+
+  // CycleContactRow is structurally a Record<string, unknown> for toCsv; the
+  // cast bridges the interface (no implicit index signature) to that shape.
+  return { columns, records: sorted as unknown as Record<string, unknown>[] };
+}


### PR DESCRIPTION
## What

Adds a CSV export feature for the admin cycle People tab, allowing admins to download a roster of all enrolled participants with their contact information and consent flags.

## Changes

- **`lib/cycle/contacts.ts`** — New module with `getCycleContacts()` (service-role loader for cycle enrollments + participant contact fields) and `buildCycleContactsTable()` (pivot to CSV columns, sorted by name)
- **`lib/cycle/contacts.test.ts`** — Unit tests covering column order, name-based sorting, and boolean/null serialization (yes/no for consent, empty cells for nulls)
- **`app/api/cycles/[cycle_id]/contacts/export/route.ts`** — New admin-gated GET endpoint that streams CSV with filename `{cycle-slug}-contacts-{date}.csv`
- **`app/(dashboard)/admin/cycles/[cycle_id]/page.tsx`** — Added "Download contacts CSV" button in the People section (visible when participants exist)

## Verify

- [x] `npm run lint` passes
- [x] `npm run test` passes (new tests in `contacts.test.ts`)
- [x] `npm run build` passes

## Manual testing

1. Log in as an admin and navigate to an admin cycle detail page (e.g., `/admin/cycles/1`)
2. Scroll to the People section — verify the "Download contacts CSV" button appears below the section heading (only if participants exist)
3. Click the button and confirm the CSV downloads with filename `{cycle-slug}-contacts-{YYYY-MM-DD}.csv`
4. Open the CSV and verify:
   - Column headers match the spec (First name, Last name, Email, Phone, LinkedIn, Slack, GitHub, Metro, State, Enrollment status, Contact consent, Photo/video consent)
   - Rows are sorted by last name, then first name
   - Boolean consent fields render as "yes" or "no"
   - Null fields render as empty cells
   - All enrolled participants are included (no test/staff filter)
5. Test edge case: navigate to a cycle with no participants — button should not appear

## Database

- [x] No schema change

https://claude.ai/code/session_01PhMHmQRMKtDmKsqR8b8YJZ