### PR TITLE
Add Slack invite link to registration email and dashboard

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -26,7 +26,7 @@ NEXT_PUBLIC_APP_URL=https://theupskillinglabs.org
 # invite link to never expire (Settings & administration > Invite people >
 # Invite Links > expiration "Never") so this rarely needs rotating. Update
 # here (and in Vercel) if it ever does, no code change needed.
-NEXT_PUBLIC_SLACK_INVITE_URL=https://join.slack.com/t/theupskillinglabs/shared_invite/zt-4470ewhsk-~OKlGBXlPuGW6L9oQ8iAOw
+NEXT_PUBLIC_SLACK_INVITE_URL=https://join.slack.com/t/theupskillinglabs/shared_invite/zt-44hwu2dcz-VgHsBzuxUwJASbyxlqlmSQ
 
 # Entity Explorer (read-only admin entity browser). Single flag, default OFF:
 # the route 404s and the nav link is hidden unless this is exactly "true".

--- a/.env.local.example
+++ b/.env.local.example
@@ -21,6 +21,13 @@ NEXT_PUBLIC_APP_URL=https://theupskillinglabs.org
 # GITHUB_TOKEN=
 # GOOGLE_SERVICE_ACCOUNT=
 
+# Slack workspace invite link shown on the dashboard onboarding checklist and
+# the welcome email. Slack invite links can expire — set the workspace's
+# invite link to never expire (Settings & administration > Invite people >
+# Invite Links > expiration "Never") so this rarely needs rotating. Update
+# here (and in Vercel) if it ever does, no code change needed.
+NEXT_PUBLIC_SLACK_INVITE_URL=https://join.slack.com/t/theupskillinglabs/shared_invite/zt-4470ewhsk-~OKlGBXlPuGW6L9oQ8iAOw
+
 # Entity Explorer (read-only admin entity browser). Single flag, default OFF:
 # the route 404s and the nav link is hidden unless this is exactly "true".
 # ENTITY_EXPLORER_ENABLED=true

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -524,6 +524,19 @@ export default async function DashboardPage() {
       href: "/directory",
       cta: "Find",
     },
+    // Simple always-on reminder to join the org Slack — no completion
+    // tracking yet (see issue #189 for the full membership-verification
+    // integration), so this row never flips to done.
+    {
+      key: "slack",
+      label: "Join the Slack",
+      done: false,
+      href:
+        process.env.NEXT_PUBLIC_SLACK_INVITE_URL ??
+        "https://join.slack.com/t/theupskillinglabs/shared_invite/zt-4470ewhsk-~OKlGBXlPuGW6L9oQ8iAOw",
+      cta: "Join",
+      external: true,
+    },
     // Pod + Learning Log steps belong to the running cohort — an upcoming
     // cohort has no pods yet — so these stay tied to the active cycle. The
     // pod row also waits for its registration window: showing "Choose a pod"

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -533,7 +533,7 @@ export default async function DashboardPage() {
       done: false,
       href:
         process.env.NEXT_PUBLIC_SLACK_INVITE_URL ??
-        "https://join.slack.com/t/theupskillinglabs/shared_invite/zt-4470ewhsk-~OKlGBXlPuGW6L9oQ8iAOw",
+        "https://join.slack.com/t/theupskillinglabs/shared_invite/zt-44hwu2dcz-VgHsBzuxUwJASbyxlqlmSQ",
       cta: "Join",
       external: true,
     },

--- a/app/(dashboard)/dashboard/setup-checklist.tsx
+++ b/app/(dashboard)/dashboard/setup-checklist.tsx
@@ -22,6 +22,7 @@ export interface ChecklistItem {
   done: boolean;
   href?: string;
   cta?: string;
+  external?: boolean;
 }
 
 const KEY = "olos.setupChecklistCollapsed.v1";
@@ -134,7 +135,16 @@ export default function SetupChecklist({ items }: { items: ChecklistItem[] }) {
               // <Link> does a pushState soft-nav that scrolls but never fires
               // `hashchange`, so the feed composer's hash listener wouldn't flip
               // to the Learning Log tab. A native anchor fires it and still scrolls.
-              item.href.startsWith("#") ? (
+              item.external ? (
+                <a
+                  href={item.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex min-h-11 flex-shrink-0 items-center rounded-card bg-teal/10 px-3 py-1 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+                >
+                  {item.cta ?? "Start"} →
+                </a>
+              ) : item.href.startsWith("#") ? (
                 <a
                   href={item.href}
                   className="flex min-h-11 flex-shrink-0 items-center rounded-card bg-teal/10 px-3 py-1 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"

--- a/lib/email/registration-confirmation-template.ts
+++ b/lib/email/registration-confirmation-template.ts
@@ -4,6 +4,10 @@ type RegistrationEmailProps = {
   cycleJoinUrl?: string | null;
 };
 
+const SLACK_INVITE_URL =
+  process.env.NEXT_PUBLIC_SLACK_INVITE_URL ??
+  "https://join.slack.com/t/theupskillinglabs/shared_invite/zt-4470ewhsk-~OKlGBXlPuGW6L9oQ8iAOw";
+
 export function registrationConfirmationHtml({
   firstName,
   cycleName,
@@ -36,6 +40,9 @@ export function registrationConfirmationHtml({
         <a href="${cycleJoinUrl}" style="color:#00b8c8;word-break:break-all;">${cycleJoinUrl}</a>
       </p>
       <p style="margin:0 0 20px;font-size:14px;line-height:1.6;color:rgba(200,210,230,0.75);">
+        Join us on Slack: <a href="${SLACK_INVITE_URL}" style="color:#00b8c8;">${SLACK_INVITE_URL}</a>
+      </p>
+      <p style="margin:0 0 20px;font-size:14px;line-height:1.6;color:rgba(200,210,230,0.75);">
         If you have any questions, please write to <a href="mailto:olos-help@theupskillinglabs.org" style="color:#00b8c8;">olos-help@theupskillinglabs.org</a> and we will be glad to help.
       </p>
       <p style="margin:0 0 24px;font-size:14px;line-height:1.6;color:rgba(200,210,230,0.75);">
@@ -50,6 +57,9 @@ export function registrationConfirmationHtml({
       </p>
       <p style="margin:0 0 28px;font-size:15px;line-height:1.6;color:rgba(200,210,230,0.75);">
         There is no Build Cycle currently open for new participants. We will email you when the next cycle opens, and you will be able to join from there.
+      </p>
+      <p style="margin:0 0 20px;font-size:14px;line-height:1.6;color:rgba(200,210,230,0.75);">
+        Join us on Slack: <a href="${SLACK_INVITE_URL}" style="color:#00b8c8;">${SLACK_INVITE_URL}</a>
       </p>
       <p style="margin:0 0 20px;font-size:14px;line-height:1.6;color:rgba(200,210,230,0.75);">
         If you have any questions, please write to <a href="mailto:olos-help@theupskillinglabs.org" style="color:#00b8c8;">olos-help@theupskillinglabs.org</a> and we will be glad to help.
@@ -115,6 +125,8 @@ If you would like to join the current cycle, ${cycleName}, please complete the f
 
 Complete the form: ${cycleJoinUrl}
 
+Join us on Slack: ${SLACK_INVITE_URL}
+
 If you have any questions, please write to olos-help@theupskillinglabs.org and we will be glad to help.
 
 Best regards,
@@ -129,6 +141,8 @@ If you didn't register, you can safely ignore this email.`;
 We received your registration to The Upskilling Labs.
 
 There is no Build Cycle currently open for new participants. We will email you when the next cycle opens, and you will be able to join from there.
+
+Join us on Slack: ${SLACK_INVITE_URL}
 
 If you have any questions, please write to olos-help@theupskillinglabs.org and we will be glad to help.
 

--- a/lib/email/registration-confirmation-template.ts
+++ b/lib/email/registration-confirmation-template.ts
@@ -6,7 +6,7 @@ type RegistrationEmailProps = {
 
 const SLACK_INVITE_URL =
   process.env.NEXT_PUBLIC_SLACK_INVITE_URL ??
-  "https://join.slack.com/t/theupskillinglabs/shared_invite/zt-4470ewhsk-~OKlGBXlPuGW6L9oQ8iAOw";
+  "https://join.slack.com/t/theupskillinglabs/shared_invite/zt-44hwu2dcz-VgHsBzuxUwJASbyxlqlmSQ";
 
 export function registrationConfirmationHtml({
   firstName,


### PR DESCRIPTION
## What

Adds a Slack workspace invite link to the registration confirmation email and the dashboard setup checklist, with the URL configurable via environment variable to support link rotation without code changes.

## Changes

- Add `NEXT_PUBLIC_SLACK_INVITE_URL` environment variable (with sensible default) to `lib/email/registration-confirmation-template.ts` and use it in both HTML and plain-text email templates
- Add "Join the Slack" item to the dashboard setup checklist in `app/(dashboard)/dashboard/page.tsx` that always appears and never marks as done (pending full membership verification in #189)
- Extend `ChecklistItem` interface in `app/(dashboard)/dashboard/setup-checklist.tsx` with `external?: boolean` flag to support opening links in a new tab with `target="_blank"`
- Update `.env.local.example` with documentation about the Slack invite URL and rotation guidance

## Verify

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Manual testing

1. **Registration email (local):** Complete a registration flow and verify the confirmation email includes a "Join us on Slack" paragraph with a clickable link in both the active cycle and no-cycle-open scenarios
2. **Dashboard checklist (local):** Log in to the dashboard and verify a "Join the Slack" item appears in the setup checklist with a "Join →" button that opens the Slack invite in a new tab
3. **Environment override (local):** Set `NEXT_PUBLIC_SLACK_INVITE_URL` to a test value and verify it appears in both email and dashboard

## Database

- [ ] No schema change

https://claude.ai/code/session_01EWdCa9AxgMujQ1NSmdNrbh