### PR TITLE
Enforce 5-digit ZIP format client-side in the sign-up funnel

### DIFF
--- a/app/(auth)/register/funnel.tsx
+++ b/app/(auth)/register/funnel.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import {
   HEAR_ABOUT_SOURCES,
   PARTICIPANT_AGREEMENT_VERSION,
+  ZIP_REGEX,
   type RoleIntent,
   type LabChoice,
 } from "@/lib/validations/funnel-registration";
@@ -97,7 +98,15 @@ function signupSteps(email: string): FlowStep[] {
       fields: [
         { id: "first", label: "First name", ph: "Alex", required: true, half: true },
         { id: "last", label: "Last name", ph: "Rivera", required: true, half: true },
-        { id: "zip", label: "Zip code", ph: "20001", required: true, inputmode: "numeric" },
+        {
+          id: "zip",
+          label: "Zip code",
+          ph: "20001",
+          required: true,
+          inputmode: "numeric",
+          pattern: ZIP_REGEX,
+          error: "Enter a 5-digit zip code",
+        },
       ],
     },
     {

--- a/app/components/flow/flow-screen.tsx
+++ b/app/components/flow/flow-screen.tsx
@@ -40,6 +40,12 @@ export interface FieldDef {
   required: boolean;
   half?: boolean;
   inputmode?: "numeric";
+  /** Optional format check. A non-empty value must match, or the step can't
+   *  advance and `error` renders inline under the field. Empty values are
+   *  governed by `required`, not this. */
+  pattern?: RegExp;
+  /** Inline message shown when a non-empty value fails `pattern`. */
+  error?: string;
 }
 
 export type FlowStep =
@@ -221,9 +227,12 @@ export function FlowScreen({
           ? true
           : String(answers[step.id] ?? "").trim().length > 0;
       case "fields":
-        return step.fields.every(
-          (f) => !f.required || String(answers[f.id] ?? "").trim().length > 0
-        );
+        return step.fields.every((f) => {
+          const v = String(answers[f.id] ?? "").trim();
+          if (f.required && v.length === 0) return false;
+          if (v.length > 0 && f.pattern && !f.pattern.test(v)) return false;
+          return true;
+        });
       case "choice":
         return typeof answers[step.id] === "string";
       case "multiselect": {
@@ -454,26 +463,41 @@ function FieldsInput({
 
   return (
     <div className="field-grid" ref={wrapRef}>
-      {step.fields.map((f, i) => (
-        <div key={f.id} className={`field${f.half ? " half" : ""}`}>
-          <label htmlFor={`ff-${f.id}`}>{f.label}</label>
-          <input
-            id={`ff-${f.id}`}
-            ref={i === 0 ? firstRef : undefined}
-            type="text"
-            inputMode={f.inputmode}
-            placeholder={f.ph}
-            value={String(answers[f.id] ?? "")}
-            onChange={(e) => setAnswer(f.id, e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && valid) {
-                e.preventDefault();
-                advance();
-              }
-            }}
-          />
-        </div>
-      ))}
+      {step.fields.map((f, i) => {
+        const v = String(answers[f.id] ?? "");
+        const showError =
+          v.trim().length > 0 && !!f.pattern && !f.pattern.test(v.trim());
+        return (
+          <div key={f.id} className={`field${f.half ? " half" : ""}`}>
+            <label htmlFor={`ff-${f.id}`}>{f.label}</label>
+            <input
+              id={`ff-${f.id}`}
+              ref={i === 0 ? firstRef : undefined}
+              type="text"
+              inputMode={f.inputmode}
+              placeholder={f.ph}
+              value={v}
+              aria-invalid={showError || undefined}
+              onChange={(e) => setAnswer(f.id, e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && valid) {
+                  e.preventDefault();
+                  advance();
+                }
+              }}
+            />
+            {showError && (
+              <p
+                className="t-small"
+                style={{ color: "var(--red)", marginTop: 4 }}
+                role="alert"
+              >
+                {f.error ?? "Invalid value"}
+              </p>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/lib/validations/funnel-registration.ts
+++ b/lib/validations/funnel-registration.ts
@@ -45,13 +45,18 @@ export const labChoiceSchema = z.discriminatedUnion("kind", [
 
 export type LabChoice = z.infer<typeof labChoiceSchema>;
 
+// ZIP format shared by the funnel schema (server) and the funnel field
+// validator (client) so the two can never drift. Accepts 5-digit or ZIP+4;
+// the lab suggester only reads the first 3 digits (app/api/labs/suggest).
+export const ZIP_REGEX = /^\d{5}(-\d{4})?$/;
+
 export const funnelRegistrationSchema = z.object({
   auth_user_id: z.string().min(1, "auth_user_id is required"),
   google_id: z.string().min(1, "google_id is required").max(200),
   email: z.string().email("Invalid email").max(320),
   first_name: z.string().min(1, "First name is required").max(100),
   last_name: z.string().min(1, "Last name is required").max(100),
-  zip: z.string().regex(/^\d{5}(-\d{4})?$/, "Enter a 5-digit zip code"),
+  zip: z.string().regex(ZIP_REGEX, "Enter a 5-digit zip code"),
   work_situation: z.enum(WORK_SITUATIONS),
   source: z.enum(HEAR_ABOUT_SOURCES),
   referred_by: z.string().max(255).optional(),


### PR DESCRIPTION
## What

The sign-up funnel only checked required fields for non-emptiness, so a
malformed-but-non-empty ZIP passed every step and was rejected only by the
server at final submit — surfacing "Enter a 5-digit zip code" on the lab step,
far from the field at fault. This validates the ZIP format at the field itself.

## Changes

- Add optional `pattern` / `error` to `FieldDef` and enforce `pattern` in the
  fields-step validity gate (`app/components/flow/flow-screen.tsx`), with an
  inline error message rendered under the field.
- Wire the funnel's ZIP field to the format check
  (`app/(auth)/register/funnel.tsx`).
- Export one shared `ZIP_REGEX` from `lib/validations/funnel-registration.ts`
  and use it in both the server schema and the client field, so the two can't
  drift.
- Closes #288.

## Verify

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Manual testing

Local / dev preview:

1. Start registration and reach the "Tell us who you are" step.
2. Enter a valid first/last name and a malformed ZIP such as `2001`, `200011`,
   or `2000a`. Expect an inline "Enter a 5-digit zip code" message under the
   field and the Continue button stays disabled — you cannot advance.
3. Clear the field. Expect no error shown (empty is governed by "required",
   which just keeps Continue disabled without a format error).
4. Enter a valid `20001` (or ZIP+4 `20001-1234`). Expect the error to clear and
   Continue to enable.
5. Finish the funnel and confirm submission succeeds — you no longer hit the
   "Enter a 5-digit zip code" error on the "Where will you build?" step.

## Database

- [x] No schema change.
