### PR TITLE
Fix silently-dropped project_min in cycle config save (vibe-scan C1)

### DIFF
--- a/lib/validations/cycles.ts
+++ b/lib/validations/cycles.ts
@@ -24,6 +24,11 @@ export const updateCycleConfigSchema = z.object({
   project_submitter_votes: z.number().int().min(0).optional(),
   project_vote_threshold: z.number().int().min(0).optional(),
   max_projects: z.number().int().min(1).optional(),
+  // project_min was omitted here, so the config form's "Project min
+  // members" edit was silently stripped and the save 200'd without
+  // writing (vibe-scan C1). project_min is load-bearing: shortlist caps,
+  // project registration minimum, and finalize.
+  project_min: z.number().int().min(1).optional(),
   project_max: z.number().int().min(1).optional(),
   // Milestone evaluation weeks (0–12; migration 00047). Admin-configurable.
   milestone_mid_week: z.number().int().min(0).max(12).optional(),


### PR DESCRIPTION
updateCycleConfigSchema had no project_min key, so the non-strict zod object stripped the field the admin config form sends ("Project min members"). The save 200'd without writing, leaving shortlist caps, the project registration minimum, and finalize on the stale value.

Add project_min to the schema (min 1, matching the SMALLINT NOT NULL DEFAULT 3 column). See docs/audit/VIBE_SCAN_2026-07.md C1.

<!--
  Branch off `dev` and target `dev` (not `main`). CI (lint + test + build) must
  pass before merge. Keep PRs to one logical change.
-->

## What

<!-- One or two sentences: what does this change and why? -->

## Changes

<!-- Bullet the notable changes. Link the issue if there is one (e.g. Closes #123). -->

-

## Verify

<!-- How you checked it works — commands run, pages exercised, tests added. -->

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Manual testing

<!--
  Step-by-step instructions for the key user-facing flows this PR touches, so
  a reviewer (or whoever promotes to prod) can exercise them without reading
  the diff: where to click, what to enter, and what should happen — including
  the error/edge paths (e.g. "expect a friendly 409, not a 500"). Note which
  environment each step assumes (local / dev preview / prod after deploy).
  If the PR has no user-facing surface (docs, refactor), say "None" and why.
-->

1.

## Database

- [ ] No schema change, **or** a migration was added under `supabase/migrations/`
      (new number, `SCHEMA.md` updated). Prod migrations are applied by a maintainer.
