### PR TITLE
Show Join-the-Slack row to new signups only; exclude it from checklis…

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -71,7 +71,7 @@ export default async function DashboardPage() {
   const serviceClient = createServiceClient();
 
   const [{ data: participant }, { data: cycles }] = await Promise.all([
-    serviceClient.from("participants").select("id, preferred_name, first_name, last_name, profile_image_url, bio, headline, metro_id, handle, page_follows_seeded").eq("auth_user_id", user.id).maybeSingle(),
+    serviceClient.from("participants").select("id, preferred_name, first_name, last_name, profile_image_url, bio, headline, metro_id, handle, page_follows_seeded, created_at").eq("auth_user_id", user.id).maybeSingle(),
     serviceClient.from("cycles").select("id, name, slug, sector_id, start_date, end_date, status, mode, lab_id").order("start_date", { ascending: false }),
   ]);
 
@@ -514,6 +514,13 @@ export default async function DashboardPage() {
     }
   }
 
+  // The Slack row shipped in PR #287 (deployed 2026-07-21). Members created
+  // before then were onboarded without it - only new signups see the row.
+  const SLACK_ROW_SINCE = Date.parse("2026-07-21T00:00:00Z");
+  const slackRowVisible =
+    !!participant.created_at &&
+    Date.parse(participant.created_at) >= SLACK_ROW_SINCE;
+
   const checklistItems: ChecklistItem[] = [
     // Cycle registration leads the list — it's the reason most members are
     // here, and testers looked for it above the housekeeping rows (July 2026
@@ -550,19 +557,27 @@ export default async function DashboardPage() {
       href: "/directory",
       cta: "Find",
     },
-    // Simple always-on reminder to join the org Slack — no completion
-    // tracking yet (see issue #189 for the full membership-verification
-    // integration), so this row never flips to done.
-    {
-      key: "slack",
-      label: "Join the Slack",
-      done: false,
-      href:
-        process.env.NEXT_PUBLIC_SLACK_INVITE_URL ??
-        "https://join.slack.com/t/theupskillinglabs/shared_invite/zt-44hwu2dcz-VgHsBzuxUwJASbyxlqlmSQ",
-      cta: "Join",
-      external: true,
-    },
+    // "Join the Slack" is onboarding-only. It has no completion tracking yet
+    // (issue #189), so a permanently-undone row would pin the checklist open
+    // for members who finished setup long ago (regression of the July 2026
+    // "To Do list reopens" feedback). Members created before the row shipped
+    // never see it; for new signups it's advisory (excluded from the all-done
+    // collapse math in SetupChecklist) so it can't block auto-collapse.
+    ...(slackRowVisible
+      ? [
+          {
+            key: "slack",
+            label: "Join the Slack",
+            done: false,
+            advisory: true,
+            href:
+              process.env.NEXT_PUBLIC_SLACK_INVITE_URL ??
+              "https://join.slack.com/t/theupskillinglabs/shared_invite/zt-44hwu2dcz-VgHsBzuxUwJASbyxlqlmSQ",
+            cta: "Join",
+            external: true,
+          },
+        ]
+      : []),
     // Pod + Learning Log steps belong to the running cohort — an upcoming
     // cohort has no pods yet — so these stay tied to the active cycle. The
     // pod row also waits for its registration window: showing "Choose a pod"

--- a/app/(dashboard)/dashboard/setup-checklist.tsx
+++ b/app/(dashboard)/dashboard/setup-checklist.tsx
@@ -23,12 +23,19 @@ export interface ChecklistItem {
   href?: string;
   cta?: string;
   external?: boolean;
+  /** Row with no completion tracking (e.g. Slack, issue #189). Shown and
+      counted like any row, but excluded from the all-done collapse math so
+      it can never pin the checklist open. */
+  advisory?: boolean;
 }
 
 const KEY = "olos.setupChecklistCollapsed.v1";
 
 export default function SetupChecklist({ items }: { items: ChecklistItem[] }) {
-  const allDone = items.every((i) => i.done);
+  // Advisory rows can never flip to done, so the collapse math skips them:
+  // the list still auto-collapses once every trackable row is done. Counts
+  // stay honest - the strip reads "5 / 6 done" while an advisory row is out.
+  const allDone = items.every((i) => i.done || i.advisory);
   const doneCount = items.filter((i) => i.done).length;
 
   // null = no stored preference yet → fall back to auto-collapse when done.
@@ -75,7 +82,7 @@ export default function SetupChecklist({ items }: { items: ChecklistItem[] }) {
     return (
       <div className="mb-6 flex items-center justify-between rounded-card border border-ink/10 bg-white px-5 py-3 shadow-card">
         <span className="text-sm font-semibold text-teal-deep">
-          {allDone ? "Setup · All done ✓" : `Setup · ${doneCount} / ${items.length} done`}
+          {doneCount === items.length ? "Setup · All done ✓" : `Setup · ${doneCount} / ${items.length} done`}
         </span>
         <button
           type="button"


### PR DESCRIPTION
…t collapse

The Slack row (#287) is hardcoded done:false pending #189, which made allDone permanently false and re-expanded the Get set up checklist for every existing member (regression of the July 2026 'To Do list reopens' feedback). Now:

- Members created before the row shipped (2026-07-21) never see it.
- For new signups the row is advisory: shown and counted, but excluded from the all-done math so the checklist still auto-collapses; the collapsed strip reads '5 / 6 done' while it's outstanding.

<!--
  Branch off `dev` and target `dev` (not `main`). CI (lint + test + build) must
  pass before merge. Keep PRs to one logical change.
-->

## What

<!-- One or two sentences: what does this change and why? -->

## Changes

<!-- Bullet the notable changes. Link the issue if there is one (e.g. Closes #123). -->

-

## Verify

<!-- How you checked it works — commands run, pages exercised, tests added. -->

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Manual testing

<!--
  Step-by-step instructions for the key user-facing flows this PR touches, so
  a reviewer (or whoever promotes to prod) can exercise them without reading
  the diff: where to click, what to enter, and what should happen — including
  the error/edge paths (e.g. "expect a friendly 409, not a 500"). Note which
  environment each step assumes (local / dev preview / prod after deploy).
  If the PR has no user-facing surface (docs, refactor), say "None" and why.
-->

1.

## Database

- [ ] No schema change, **or** a migration was added under `supabase/migrations/`
      (new number, `SCHEMA.md` updated). Prod migrations are applied by a maintainer.
