### PR TITLE
Profile save fixes + pod activity feed (deterministic instrument)

### DIFF
--- a/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
@@ -70,6 +70,31 @@ export default async function ModeratorPodPage({
   // hydrates from /api/moderator/ui-state in the client (see RosterTable).
   const initialTab = uiState.last_pod_tab ?? "members";
 
+  // A pod practices ONE weekly instrument in practice - Learning Logs
+  // (current) or pulse checks (legacy) - so the activity tab auto-selects
+  // whichever has data instead of always offering both (owner decision,
+  // 2026-07-22). Head-only count queries; members are the roster ids.
+  const memberIds = detail.members.map((m) => m.participant_id);
+  const [logCountRes, pulseCountRes] = await Promise.all([
+    memberIds.length
+      ? serviceClient
+          .from("learning_logs")
+          .select("id", { head: true, count: "exact" })
+          .in("participant_id", memberIds)
+          .eq("cycle_id", detail.cycle_id)
+      : Promise.resolve({ count: 0 }),
+    memberIds.length
+      ? serviceClient
+          .from("pulse_checks")
+          .select("id", { head: true, count: "exact" })
+          .in("participant_id", memberIds)
+          .eq("cycle_id", detail.cycle_id)
+          .not("completed_at", "is", null)
+      : Promise.resolve({ count: 0 }),
+  ]);
+  const hasLogs = (logCountRes.count ?? 0) > 0;
+  const hasPulses = (pulseCountRes.count ?? 0) > 0;
+
   // §7.9.2 pod-level insights — pre-compute both ranges so the client
   // toggle doesn't need a round-trip. Plus the AI-summary prompt for
   // §7.10.3. Org runs have no pulse checks, so skip the fetches entirely —
@@ -149,6 +174,8 @@ export default async function ModeratorPodPage({
           podName={detail.name ?? `${podNoun(detail.cycle_mode)} ${detail.id}`}
           initialTab={initialTab}
           mode={detail.cycle_mode}
+          hasLogs={hasLogs}
+          hasPulses={hasPulses}
         />
       </section>
     </div>

--- a/app/(dashboard)/moderator/pods/[pod_id]/pod-content-tabs.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/pod-content-tabs.tsx
@@ -38,12 +38,16 @@ export function PodContentTabs({
   podName,
   initialTab,
   mode,
+  hasLogs = false,
+  hasPulses = false,
 }: {
   members: RosterRow[];
   podId: number;
   podName: string;
   initialTab: PodTab;
   mode?: string | null;
+  hasLogs?: boolean;
+  hasPulses?: boolean;
 }) {
   const isOrg = mode === "org";
   const tabs = isOrg ? TABS.filter((t) => t.value !== "recent_pulses") : TABS;
@@ -81,7 +85,13 @@ export function PodContentTabs({
       {tab === "members" && (
         <RosterTable members={members} podId={podId} podName={podName} />
       )}
-      {tab === "recent_pulses" && !isOrg && <RecentActivityFeed podId={podId} />}
+      {tab === "recent_pulses" && !isOrg && (
+        <RecentActivityFeed
+          podId={podId}
+          hasLogs={hasLogs}
+          hasPulses={hasPulses}
+        />
+      )}
     </section>
   );
 }

--- a/app/(dashboard)/moderator/pods/[pod_id]/pod-content-tabs.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/pod-content-tabs.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import type { RosterRow } from "@/lib/moderator/pod-detail";
 import type { PodTab } from "@/lib/moderator/ui-state";
 import { RosterTable } from "./roster-table";
-import { RecentPulsesFeed } from "./recent-pulses-feed";
+import { RecentActivityFeed } from "./recent-activity-feed";
 import { persistUiState } from "../../switcher";
 
 /**
@@ -12,7 +12,7 @@ import { persistUiState } from "../../switcher";
  *
  * Two tabs:
  *   - Members         → the existing RosterTable + pulse-review side panel
- *   - Recent pulses   → cross-member chronological feed (chunk B)
+ *   - Recent activity → Learning Logs feed (default) + pulse checks toggle
  *
  * Initial tab comes from the server (read from moderator_ui_state.last_pod_tab).
  * Every tab change persists via PUT /api/moderator/ui-state so the next
@@ -24,9 +24,12 @@ import { persistUiState } from "../../switcher";
  * cross-cycle read) falls back to the members tab.
  */
 
+// The activity tab keeps its historical `recent_pulses` value so persisted
+// moderator_ui_state.last_pod_tab rows stay valid; the label and body moved
+// on to cover Learning Logs (default) + pulse checks behind a toggle.
 const TABS: { value: PodTab; label: string }[] = [
   { value: "members", label: "Members" },
-  { value: "recent_pulses", label: "Recent pulses" },
+  { value: "recent_pulses", label: "Recent activity" },
 ];
 
 export function PodContentTabs({
@@ -78,7 +81,7 @@ export function PodContentTabs({
       {tab === "members" && (
         <RosterTable members={members} podId={podId} podName={podName} />
       )}
-      {tab === "recent_pulses" && !isOrg && <RecentPulsesFeed podId={podId} />}
+      {tab === "recent_pulses" && !isOrg && <RecentActivityFeed podId={podId} />}
     </section>
   );
 }

--- a/app/(dashboard)/moderator/pods/[pod_id]/recent-activity-feed.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/recent-activity-feed.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import * as React from "react";
+import { RecentPulsesFeed } from "./recent-pulses-feed";
+import { RecentLogsFeed } from "./recent-logs-feed";
+
+/**
+ * The "Recent activity" tab body: a two-way switch between the pod's
+ * Learning Logs (the current weekly instrument, default) and pulse
+ * checks (the legacy instrument). Mixing both in one stream read as
+ * confusing (owner feedback, 2026-07-22), so each gets its own view.
+ */
+
+export function RecentActivityFeed({ podId }: { podId: number }) {
+  const [view, setView] = React.useState<"logs" | "pulses">("logs");
+
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label="Activity type"
+        className="mb-4 inline-flex rounded-card border border-ink/10 bg-white p-0.5 shadow-card"
+      >
+        {(
+          [
+            ["logs", "Learning Logs"],
+            ["pulses", "Pulse checks"],
+          ] as const
+        ).map(([value, label]) => (
+          <button
+            key={value}
+            role="tab"
+            aria-selected={view === value}
+            onClick={() => setView(value)}
+            className={`rounded-[10px] px-3 py-1.5 text-sm transition-colors ${
+              view === value
+                ? "bg-teal/10 font-semibold text-teal-deep"
+                : "text-meta hover:text-ink"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      {view === "logs" ? (
+        <RecentLogsFeed podId={podId} />
+      ) : (
+        <RecentPulsesFeed podId={podId} />
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/moderator/pods/[pod_id]/recent-activity-feed.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/recent-activity-feed.tsx
@@ -5,65 +5,24 @@ import { RecentPulsesFeed } from "./recent-pulses-feed";
 import { RecentLogsFeed } from "./recent-logs-feed";
 
 /**
- * The "Recent activity" tab body. A pod practices one weekly instrument
- * in practice - Learning Logs (current) or pulse checks (legacy) - so the
- * view auto-selects whichever has data (owner decision, 2026-07-22):
- *
- *   - logs only (or neither)  -> Learning Logs feed, no switch
- *   - pulses only             -> pulse feed, no switch
- *   - both                    -> Learning Logs default + a switch
+ * The "Recent activity" tab body. Deterministic, no switch (owner
+ * decision, 2026-07-22): a pod with pulse checks is a legacy pod (the
+ * weekly log gate replaced the pulse system, so new cycles never
+ * generate pulses) and shows the pulse feed; every other pod shows
+ * Learning Logs. Test logs saved into a legacy cycle don't flip it.
  */
 
 export function RecentActivityFeed({
   podId,
-  hasLogs = false,
   hasPulses = false,
 }: {
   podId: number;
   hasLogs?: boolean;
   hasPulses?: boolean;
 }) {
-  const both = hasLogs && hasPulses;
-  const pulsesOnly = hasPulses && !hasLogs;
-  const [view, setView] = React.useState<"logs" | "pulses">(
-    pulsesOnly ? "pulses" : "logs"
-  );
-
-  return (
-    <div>
-      {both && (
-        <div
-          role="tablist"
-          aria-label="Activity type"
-          className="mb-4 inline-flex rounded-card border border-ink/10 bg-white p-0.5 shadow-card"
-        >
-          {(
-            [
-              ["logs", "Learning Logs"],
-              ["pulses", "Pulse checks"],
-            ] as const
-          ).map(([value, label]) => (
-            <button
-              key={value}
-              role="tab"
-              aria-selected={view === value}
-              onClick={() => setView(value)}
-              className={`rounded-[10px] px-3 py-1.5 text-sm transition-colors ${
-                view === value
-                  ? "bg-teal/10 font-semibold text-teal-deep"
-                  : "text-meta hover:text-ink"
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      )}
-      {view === "logs" ? (
-        <RecentLogsFeed podId={podId} />
-      ) : (
-        <RecentPulsesFeed podId={podId} />
-      )}
-    </div>
+  return hasPulses ? (
+    <RecentPulsesFeed podId={podId} />
+  ) : (
+    <RecentLogsFeed podId={podId} />
   );
 }

--- a/app/(dashboard)/moderator/pods/[pod_id]/recent-activity-feed.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/recent-activity-feed.tsx
@@ -5,43 +5,60 @@ import { RecentPulsesFeed } from "./recent-pulses-feed";
 import { RecentLogsFeed } from "./recent-logs-feed";
 
 /**
- * The "Recent activity" tab body: a two-way switch between the pod's
- * Learning Logs (the current weekly instrument, default) and pulse
- * checks (the legacy instrument). Mixing both in one stream read as
- * confusing (owner feedback, 2026-07-22), so each gets its own view.
+ * The "Recent activity" tab body. A pod practices one weekly instrument
+ * in practice - Learning Logs (current) or pulse checks (legacy) - so the
+ * view auto-selects whichever has data (owner decision, 2026-07-22):
+ *
+ *   - logs only (or neither)  -> Learning Logs feed, no switch
+ *   - pulses only             -> pulse feed, no switch
+ *   - both                    -> Learning Logs default + a switch
  */
 
-export function RecentActivityFeed({ podId }: { podId: number }) {
-  const [view, setView] = React.useState<"logs" | "pulses">("logs");
+export function RecentActivityFeed({
+  podId,
+  hasLogs = false,
+  hasPulses = false,
+}: {
+  podId: number;
+  hasLogs?: boolean;
+  hasPulses?: boolean;
+}) {
+  const both = hasLogs && hasPulses;
+  const pulsesOnly = hasPulses && !hasLogs;
+  const [view, setView] = React.useState<"logs" | "pulses">(
+    pulsesOnly ? "pulses" : "logs"
+  );
 
   return (
     <div>
-      <div
-        role="tablist"
-        aria-label="Activity type"
-        className="mb-4 inline-flex rounded-card border border-ink/10 bg-white p-0.5 shadow-card"
-      >
-        {(
-          [
-            ["logs", "Learning Logs"],
-            ["pulses", "Pulse checks"],
-          ] as const
-        ).map(([value, label]) => (
-          <button
-            key={value}
-            role="tab"
-            aria-selected={view === value}
-            onClick={() => setView(value)}
-            className={`rounded-[10px] px-3 py-1.5 text-sm transition-colors ${
-              view === value
-                ? "bg-teal/10 font-semibold text-teal-deep"
-                : "text-meta hover:text-ink"
-            }`}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
+      {both && (
+        <div
+          role="tablist"
+          aria-label="Activity type"
+          className="mb-4 inline-flex rounded-card border border-ink/10 bg-white p-0.5 shadow-card"
+        >
+          {(
+            [
+              ["logs", "Learning Logs"],
+              ["pulses", "Pulse checks"],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              role="tab"
+              aria-selected={view === value}
+              onClick={() => setView(value)}
+              className={`rounded-[10px] px-3 py-1.5 text-sm transition-colors ${
+                view === value
+                  ? "bg-teal/10 font-semibold text-teal-deep"
+                  : "text-meta hover:text-ink"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
       {view === "logs" ? (
         <RecentLogsFeed podId={podId} />
       ) : (

--- a/app/(dashboard)/moderator/pods/[pod_id]/recent-logs-feed.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/recent-logs-feed.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import * as React from "react";
+import type {
+  RecentLog,
+  RecentLogsPayload,
+} from "@/lib/moderator/recent-logs";
+
+/**
+ * Learning Logs feed — the default view of the per-pod "Recent activity"
+ * tab. Mirrors RecentPulsesFeed's load/paginate pattern; rendering is
+ * inline because log cards are text-first (no survey payload).
+ */
+
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; payload: RecentLogsPayload; appending: boolean }
+  | { kind: "loading-more"; payload: RecentLogsPayload }
+  | { kind: "error"; message: string };
+
+export function RecentLogsFeed({ podId }: { podId: number }) {
+  const [state, setState] = React.useState<LoadState>({ kind: "idle" });
+
+  React.useEffect(() => {
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState({ kind: "loading" });
+    fetch(`/api/moderator/pods/${podId}/recent-logs`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        return (await res.json()) as RecentLogsPayload;
+      })
+      .then((payload) => {
+        if (!cancelled)
+          setState({ kind: "loaded", payload, appending: false });
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setState({ kind: "error", message: err.message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [podId]);
+
+  const loadMore = async () => {
+    if (state.kind !== "loaded" || !state.payload.nextCursor) return;
+    const cursor = state.payload.nextCursor;
+    const prev = state.payload;
+    setState({ kind: "loading-more", payload: prev });
+    try {
+      const res = await fetch(
+        `/api/moderator/pods/${podId}/recent-logs?before=${encodeURIComponent(cursor)}`
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      const next = (await res.json()) as RecentLogsPayload;
+      setState({
+        kind: "loaded",
+        payload: { ...next, logs: [...prev.logs, ...next.logs] },
+        appending: true,
+      });
+    } catch (err) {
+      setState({ kind: "error", message: (err as Error).message });
+    }
+  };
+
+  if (state.kind === "idle" || state.kind === "loading") {
+    return <p className="py-6 text-sm text-meta">Loading logs…</p>;
+  }
+  if (state.kind === "error") {
+    return (
+      <p className="py-6 text-sm text-red">
+        Could not load Learning Logs: {state.message}
+      </p>
+    );
+  }
+
+  const { payload } = state;
+  if (payload.logs.length === 0) {
+    return (
+      <p className="py-6 text-sm text-meta">
+        No Learning Logs from this pod yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {payload.logs.map((log, i) => (
+        <LogCard key={`${log.participant_id}-${log.created_at}-${i}`} log={log} />
+      ))}
+      {payload.nextCursor && (
+        <button
+          type="button"
+          onClick={loadMore}
+          disabled={state.kind === "loading-more"}
+          className="w-full rounded-card border border-ink/10 bg-white px-3 py-2 text-sm text-charcoal shadow-card transition-colors hover:bg-ink/[0.04] disabled:opacity-60"
+        >
+          {state.kind === "loading-more" ? "Loading…" : "Load older"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function LogCard({ log }: { log: RecentLog }) {
+  const fields: { label: string; value: string | null }[] =
+    log.schema_version === "v2"
+      ? [
+          { label: "This week", value: log.contribution },
+          { label: "Learned", value: log.learned },
+        ]
+      : [
+          { label: "Accomplished", value: log.accomplished },
+          { label: "Exploring", value: log.exploring },
+          { label: "Next focus", value: log.next_focus },
+        ];
+  const filled = fields.filter((f) => f.value?.trim());
+
+  return (
+    <div
+      className={`rounded-card border p-4 ${
+        log.is_blocked
+          ? "border-red/20 bg-red/[0.03]"
+          : "border-ink/10 bg-white shadow-card"
+      }`}
+    >
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <span className="flex items-center gap-2">
+          <span className="flex h-7 w-7 items-center justify-center rounded-full bg-teal/10 text-xs font-semibold text-teal-deep">
+            {log.initials}
+          </span>
+          <span className="text-sm font-medium text-ink">
+            {log.display_name}
+          </span>
+          {log.is_blocked && (
+            <span className="rounded-full bg-red/10 px-2 py-0.5 text-xs font-semibold text-red">
+              Blocked
+            </span>
+          )}
+        </span>
+        <span className="text-xs text-meta tabular-nums">
+          {formatDateTime(log.created_at)}
+        </span>
+      </div>
+      {log.is_blocked && log.blocker_context?.trim() && (
+        <p className="mb-3 text-sm text-charcoal">
+          <span className="font-semibold text-red">Needs help: </span>
+          {log.blocker_context}
+        </p>
+      )}
+      {filled.length > 0 ? (
+        <dl className="space-y-2">
+          {filled.map((f) => (
+            <div key={f.label}>
+              <dt className="text-xs uppercase tracking-wide text-meta">
+                {f.label}
+              </dt>
+              <dd className="text-sm text-charcoal">{f.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p className="text-sm text-meta">No written answers this week.</p>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/profile/edit/profile-edit-form.tsx
+++ b/app/(dashboard)/profile/edit/profile-edit-form.tsx
@@ -375,7 +375,7 @@ export default function ProfileEditForm({
           <p className="rounded-card border border-teal/30 bg-teal/10 px-3 py-2 text-sm text-teal-deep">
             Saved.{" "}
             <Link href="/profile" className="underline">
-              Back to profile
+              View profile
             </Link>
           </p>
         )}
@@ -592,7 +592,7 @@ export default function ProfileEditForm({
           <p className="rounded-card border border-teal/30 bg-teal/10 px-3 py-2 text-sm text-teal-deep">
             Saved.{" "}
             <Link href="/profile" className="underline">
-              Back to profile
+              View profile
             </Link>
           </p>
         )}

--- a/app/(dashboard)/profile/edit/profile-edit-form.tsx
+++ b/app/(dashboard)/profile/edit/profile-edit-form.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useForm, FormProvider } from "react-hook-form";
+import type { FieldErrors } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { FormField, Input, Textarea, Select } from "@/app/components/ui/form";
@@ -31,6 +32,10 @@ const formSchema = z.object({
   handle: z
     .string()
     .max(50)
+    // Normalize case instead of rejecting it: members type their handle the
+    // way they write their name ("Tati") and a casing-only rejection reads as
+    // a silent save failure. Lowercase first, then validate the rest.
+    .transform((v) => v.trim().toLowerCase())
     .refine((s) => !s || HANDLE_RE.test(s), {
       message: "Use lowercase letters, numbers, and dashes",
     })
@@ -279,6 +284,24 @@ export default function ProfileEditForm({
     }
   }
 
+  // A submit blocked by client validation used to be silent: the error text
+  // renders inline at the field, which can be far off-screen, so members
+  // assumed the save went through (reported: preferred name + handle "not
+  // persisting" when a casing error on handle was blocking the whole form).
+  // Surface a banner and bring the first errored field into view.
+  function onInvalid(errors: FieldErrors<FormData>) {
+    setSaved(false);
+    setServerError(
+      "Not saved yet. Fix the highlighted field below and save again."
+    );
+    const first = Object.keys(errors)[0];
+    if (first) {
+      const el = document.querySelector<HTMLElement>(`[name="${first}"]`);
+      el?.scrollIntoView({ behavior: "smooth", block: "center" });
+      el?.focus?.({ preventScroll: true });
+    }
+  }
+
   async function onSubmit(values: FormData) {
     setServerError("");
 
@@ -344,7 +367,7 @@ export default function ProfileEditForm({
 
   return (
     <FormProvider {...form}>
-      <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-5">
+      <form onSubmit={handleSubmit(onSubmit, onInvalid)} className="mt-6 space-y-5">
         {/* Saving scrolls to the top — the confirmation has to be waiting
             where the scroll lands, not only down by the submit bar
             (July 2026 feedback). */}

--- a/app/api/moderator/pods/[pod_id]/recent-logs/route.ts
+++ b/app/api/moderator/pods/[pod_id]/recent-logs/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse, NextRequest } from "next/server";
+import { withAuth, type AuthenticatedRequest } from "@/lib/auth/middleware";
+import { requireModeratorForPod } from "@/lib/auth/moderator";
+import { parseIntParam } from "@/lib/api/params";
+import {
+  getRecentLogs,
+  RECENT_LOGS_PAGE_SIZE,
+} from "@/lib/moderator/recent-logs";
+
+/**
+ * GET /api/moderator/pods/[pod_id]/recent-logs
+ *
+ * Backs the Learning Logs view of the per-pod "Recent activity" tab.
+ *
+ * Query params:
+ *   - before  (optional ISO timestamp) — return logs created strictly
+ *             before this value, used for paging older.
+ *   - limit   (optional int) — page size; clamped to [1, 50].
+ *
+ * Auth: same as the other /api/moderator/pods/[pod_id]/* routes — admin
+ * or active moderator for the pod.
+ */
+export const GET = withAuth(
+  async (
+    request: NextRequest,
+    auth: AuthenticatedRequest,
+    params: Record<string, string>
+  ) => {
+    const podId = parseIntParam(params.pod_id, "pod_id");
+    if (podId instanceof NextResponse) return podId;
+
+    const guard = requireModeratorForPod(auth.user, podId);
+    if (guard) return guard;
+
+    const url = new URL(request.url);
+    const before = url.searchParams.get("before");
+    const limitParam = url.searchParams.get("limit");
+    const limit = limitParam
+      ? Number.parseInt(limitParam, 10)
+      : RECENT_LOGS_PAGE_SIZE;
+
+    const result = await getRecentLogs(auth.supabase, podId, {
+      before: before && before.length > 0 ? before : null,
+      limit: Number.isFinite(limit) ? limit : RECENT_LOGS_PAGE_SIZE,
+    });
+    if ("error" in result) {
+      return NextResponse.json({ error: "Pod not found" }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  }
+);

--- a/lib/moderator/recent-logs.ts
+++ b/lib/moderator/recent-logs.ts
@@ -1,0 +1,130 @@
+/**
+ * Recent Learning Logs across a pod — feed view.
+ *
+ * Backs the Learning Logs side of the per-pod "Recent activity" tab
+ * (default view; pulse checks sit behind the toggle). Mirrors
+ * recent-pulses.ts: newest first, cursor pagination on created_at,
+ * cycle-scoped so a dual-enrolled member's other-cycle logs never bleed
+ * into this pod's feed (same attribution rule as log-health.ts).
+ *
+ * Auth is enforced at the route layer (requireModeratorForPod); this
+ * helper does NOT check authorization.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const RECENT_LOGS_PAGE_SIZE = 20;
+export const RECENT_LOGS_MAX_PAGE_SIZE = 50;
+
+export type RecentLog = {
+  participant_id: number;
+  display_name: string;
+  initials: string;
+  created_at: string;
+  schema_version: string | null;
+  is_blocked: boolean;
+  blocker_context: string | null;
+  /* v1 prompts */
+  accomplished: string | null;
+  exploring: string | null;
+  next_focus: string | null;
+  /* v2 prompts */
+  contribution: string | null;
+  learned: string | null;
+  feeling_word: string | null;
+};
+
+export type RecentLogsPayload = {
+  podId: number;
+  cycleId: number;
+  logs: RecentLog[];
+  /** created_at of the oldest log in this page; pass back as `before`
+      to load older. Null when there are no more pages. */
+  nextCursor: string | null;
+};
+
+export async function getRecentLogs(
+  supabase: SupabaseClient,
+  podId: number,
+  options: { before?: string | null; limit?: number } = {}
+): Promise<RecentLogsPayload | { error: "pod-not-found" }> {
+  const limit = Math.min(
+    Math.max(1, options.limit ?? RECENT_LOGS_PAGE_SIZE),
+    RECENT_LOGS_MAX_PAGE_SIZE
+  );
+
+  const { data: pod } = await supabase
+    .from("pods")
+    .select("id, cycle_id")
+    .eq("id", podId)
+    .maybeSingle();
+  if (!pod) return { error: "pod-not-found" };
+  const cycleId = pod.cycle_id as number;
+
+  // Current or historical members — logs from members who later left stay
+  // visible, so the feed is a complete record (same choice as pulses).
+  const { data: memberRows } = await supabase
+    .from("pod_memberships")
+    .select(`
+      participant_id,
+      participants ( id, first_name, last_name, preferred_name )
+    `)
+    .eq("pod_id", podId);
+
+  const memberIds = (memberRows ?? []).map((m) => m.participant_id as number);
+  if (memberIds.length === 0) {
+    return { podId, cycleId, logs: [], nextCursor: null };
+  }
+
+  const nameByParticipant = new Map<
+    number,
+    { display_name: string; initials: string }
+  >();
+  for (const m of memberRows ?? []) {
+    const p = (m.participants as unknown) as {
+      first_name: string;
+      last_name: string;
+      preferred_name: string | null;
+    } | null;
+    const first = p?.preferred_name?.trim() || p?.first_name?.trim() || "?";
+    const lastInitial = p?.last_name ? p.last_name[0].toUpperCase() : "";
+    const display = lastInitial ? `${first} ${lastInitial}.` : first;
+    const initials = `${first[0] ?? "?"}${lastInitial}`.toUpperCase();
+    nameByParticipant.set(m.participant_id as number, {
+      display_name: display,
+      initials,
+    });
+  }
+
+  let query = supabase
+    .from("learning_logs")
+    .select(
+      "participant_id, created_at, schema_version, is_blocked, blocker_context, accomplished, exploring, next_focus, contribution, learned, feeling_word"
+    )
+    .in("participant_id", memberIds)
+    .eq("cycle_id", cycleId)
+    .order("created_at", { ascending: false })
+    .limit(limit + 1);
+
+  if (options.before) {
+    query = query.lt("created_at", options.before);
+  }
+
+  const { data: logRows } = await query;
+  const rows = (logRows ?? []) as Array<
+    Omit<RecentLog, "display_name" | "initials">
+  >;
+
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor = hasMore ? page[page.length - 1].created_at : null;
+
+  const logs: RecentLog[] = page.map((r) => {
+    const ident = nameByParticipant.get(r.participant_id) ?? {
+      display_name: "?",
+      initials: "?",
+    };
+    return { ...r, ...ident };
+  });
+
+  return { podId, cycleId, logs, nextCursor };
+}

--- a/lib/validations/participants-update.ts
+++ b/lib/validations/participants-update.ts
@@ -55,6 +55,7 @@ export const participantsUpdateSchema = z
     handle: z
       .string()
       .trim()
+      .toLowerCase()
       .min(1)
       .max(50)
       .regex(HANDLE_RE, "Use lowercase letters, numbers, and dashes"),


### PR DESCRIPTION
Handle casing normalized client+server; blocked saves show a banner and scroll to the errored field; saved-banner link reads 'View profile'. Pod feed tab renamed 'Recent activity': legacy pods (with pulses) show the pulse feed, all others show a Learning Logs feed. No migrations.