### PR TITLE
Proposal gallery, map links, and participant-visible survey results

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -266,36 +266,47 @@ export default async function CycleDetailPage({
         </div>
       )}
 
-      {/* Insights survey — link + a two-line explainer of what it is and why
-          we run one (grounding the cycle in real problems, not assumptions) */}
+      {/* Insights survey — explainer + two doors: contribute an observation,
+          or read what the field has said so far (the results page is every
+          participant's window into the observation bedrock the cycle's
+          sensemaking runs on). */}
       {fieldSurvey && (
-        <div className="mb-8">
-          <Link
-            href={`/survey/${fieldSurvey.share_slug}`}
-            className="group flex items-center justify-between gap-3 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
-          >
-            <div className="flex items-center gap-3">
-              <ClipboardList
-                className="h-5 w-5 flex-shrink-0 text-teal-deep"
-                aria-hidden
-              />
-              <div>
-                <span className="font-semibold tracking-tight text-ink">
-                  Insights survey: {fieldSurvey.title}
-                </span>
-                <p className="mt-0.5 text-sm text-meta">
-                  A short, open survey for anyone close to this cycle&apos;s
-                  theme. First-hand observations are how we make sure pods work
-                  on real problems, not assumptions — take it, then share it
-                  with a friend.
-                </p>
-              </div>
-            </div>
-            <ArrowRight
-              className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+        <div className="mb-8 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card">
+          <div className="flex items-center gap-3">
+            <ClipboardList
+              className="h-5 w-5 flex-shrink-0 text-teal-deep"
               aria-hidden
             />
-          </Link>
+            <div>
+              <span className="font-semibold tracking-tight text-ink">
+                Insights survey: {fieldSurvey.title}
+              </span>
+              <p className="mt-0.5 text-sm text-meta">
+                A short, open survey for anyone close to this cycle&apos;s
+                theme. First-hand observations are how we make sure pods work
+                on real problems, not assumptions — take it, then share it
+                with a friend.
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-4 pl-8">
+            <Link
+              href={`/survey/${fieldSurvey.share_slug}`}
+              className="group inline-flex items-center gap-1.5 text-sm font-semibold text-teal-deep hover:text-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+            >
+              Take the survey
+              <ArrowRight
+                className="h-4 w-4 transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+                aria-hidden
+              />
+            </Link>
+            <Link
+              href={`/survey/${fieldSurvey.share_slug}/results`}
+              className="inline-flex items-center text-sm font-semibold text-teal-deep hover:text-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+            >
+              See what the field is saying
+            </Link>
+          </div>
         </div>
       )}
 

--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
 import { registrationWindow } from "@/lib/cycles/schedule";
-import { windowOpen, fmtLabDate } from "@/lib/cycles/lab-time";
+import {
+  windowOpen,
+  fmtLabDate,
+  fmtLabDateTime,
+  parseWindow,
+} from "@/lib/cycles/lab-time";
 import {
   BookOpen,
   ArrowRight,
@@ -171,6 +176,24 @@ export default async function CycleDetailPage({
     }
   }
 
+  // The seam between voting and pod registration is the one quiet stretch
+  // where the page would otherwise go silent mid-arc: votes are in, pods
+  // aren't announced. Say what's happening rather than showing nothing.
+  let interlude: string | null = null;
+  if (config && activeWindows.length === 0) {
+    const cfg = config as Record<string, string | null>;
+    const votingClosed =
+      cfg.voting_close && now > (parseWindow(cfg.voting_close) as Date);
+    const podRegStarted =
+      cfg.pod_registration_open &&
+      now > (parseWindow(cfg.pod_registration_open) as Date);
+    if (votingClosed && !podRegStarted) {
+      interlude = cfg.pod_registration_open
+        ? `Voting has closed — the shortlist is being finalized. Pod registration opens ${fmtLabDateTime(cfg.pod_registration_open)}.`
+        : "Voting has closed — the shortlist is being finalized. Pod registration opens next.";
+    }
+  }
+
   const cycleStatusVariant =
     CYCLE_STATUS_VARIANT[cycle.status as CycleStatus] ?? "inactive";
 
@@ -263,6 +286,12 @@ export default async function CycleDetailPage({
               </div>
             </Link>
           ))}
+        </div>
+      )}
+
+      {interlude && (
+        <div className="mb-8 rounded-card border border-ink/10 bg-white p-4 shadow-card">
+          <p className="text-sm text-charcoal">{interlude}</p>
         </div>
       )}
 

--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -1,7 +1,14 @@
 import Link from "next/link";
 import { registrationWindow } from "@/lib/cycles/schedule";
 import { windowOpen, fmtLabDate } from "@/lib/cycles/lab-time";
-import { BookOpen, ArrowRight, ChevronLeft, ClipboardList } from "lucide-react";
+import {
+  BookOpen,
+  ArrowRight,
+  ChevronLeft,
+  ClipboardList,
+  ExternalLink,
+  FolderKanban,
+} from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
 import { StatCard, StatusBadge } from "@/app/components/ui";
@@ -138,11 +145,18 @@ export default async function CycleDetailPage({
   const { data: myStatements } = me
     ? await serviceClient
         .from("problem_statements")
-        .select("id, statement_text, created_at")
+        .select("id, statement_text, proposal_data, created_at")
         .eq("cycle_id", cycle.id)
         .eq("participant_id", me.id)
         .order("created_at")
     : { data: null };
+
+  // Door to the proposal gallery — shown as soon as the cycle has any
+  // statements at all (the gallery page itself applies the per-lab filter).
+  const { count: statementCount } = await serviceClient
+    .from("problem_statements")
+    .select("id", { count: "exact", head: true })
+    .eq("cycle_id", cycle.id);
 
   const now = new Date();
   const activeWindows: { label: string; route: string; closesAt: string }[] = [];
@@ -315,25 +329,78 @@ export default async function CycleDetailPage({
         </div>
       )}
 
+      {/* Proposal gallery — browsable in every phase, unlike the ballot,
+          which only renders while the voting window is open */}
+      {(statementCount ?? 0) > 0 && (
+        <div className="mb-8">
+          <Link
+            href={`/cycles/${cycle.id}/proposals`}
+            className="group flex items-center justify-between gap-3 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+          >
+            <div className="flex items-center gap-3">
+              <FolderKanban
+                className="h-5 w-5 flex-shrink-0 text-teal-deep"
+                aria-hidden
+              />
+              <div>
+                <span className="font-semibold tracking-tight text-ink">
+                  Problem statement gallery
+                </span>
+                <p className="mt-0.5 text-sm text-meta">
+                  Browse what your cohort is proposing this cycle — with links
+                  to the maps behind each statement.
+                </p>
+              </div>
+            </div>
+            <ArrowRight
+              className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+              aria-hidden
+            />
+          </Link>
+        </div>
+      )}
+
       {/* The viewer's own submissions — visible in every phase, not just on
           the voting ballot */}
       {myStatements && myStatements.length > 0 && (
         <div className="mb-8">
           <h2 className="t-h3 mb-4 text-ink">Your problem statements</h2>
           <div className="space-y-3">
-            {myStatements.map((s) => (
-              <blockquote
-                key={s.id}
-                className="rounded-card border border-ink/10 bg-white p-4 shadow-card"
-              >
-                <p className="text-sm leading-relaxed text-charcoal">
-                  {s.statement_text}
-                </p>
-                <p className="mt-2 text-xs text-meta">
-                  Submitted {new Date(s.created_at).toLocaleDateString()}
-                </p>
-              </blockquote>
-            ))}
+            {myStatements.map((s) => {
+              // Scheme-checked before rendering as an href (rows can predate
+              // the schema's http(s) restriction on repo_url).
+              const rawRepo = (
+                s.proposal_data as {
+                  statement?: { repo_url?: string };
+                } | null
+              )?.statement?.repo_url;
+              const mapUrl =
+                rawRepo && /^https?:\/\//i.test(rawRepo) ? rawRepo : null;
+              return (
+                <blockquote
+                  key={s.id}
+                  className="rounded-card border border-ink/10 bg-white p-4 shadow-card"
+                >
+                  <p className="text-sm leading-relaxed text-charcoal">
+                    {s.statement_text}
+                  </p>
+                  <p className="mt-2 text-xs text-meta">
+                    Submitted {new Date(s.created_at).toLocaleDateString()}
+                  </p>
+                  {mapUrl && (
+                    <a
+                      href={mapUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center gap-1 text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline"
+                    >
+                      View your map
+                      <ExternalLink className="h-3 w-3" aria-hidden />
+                    </a>
+                  )}
+                </blockquote>
+              );
+            })}
           </div>
         </div>
       )}

--- a/app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx
@@ -1,0 +1,266 @@
+import Link from "next/link";
+import { windowOpen } from "@/lib/cycles/lab-time";
+import { ArrowRight, ChevronLeft, ExternalLink } from "lucide-react";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
+import { notFound } from "next/navigation";
+
+interface ProposalData {
+  about?: { background?: string };
+  problem?: { who?: string; need?: string; barrier?: string; success?: string };
+  statement?: { question?: string; repo_url?: string };
+  voter_context?: {
+    tried?: string;
+    scale?: string;
+    pod_work?: string;
+    skills_needed?: string;
+  };
+}
+
+// Read-only gallery of the cycle's problem statements. Unlike the vote
+// ballot, this renders in every phase — the ballot only exists while the
+// voting window is open, which left proposals unbrowsable the rest of the
+// cycle. Same per-lab scoping as GET /api/problem-statements/[cycle_id],
+// same no-author-attribution convention as the ballot.
+export default async function ProposalsGalleryPage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const cycleId = parseInt(cycle_id, 10);
+  const supabase = await createClient();
+
+  const { data: cycle } = await supabase
+    .from("cycles")
+    .select("id, name")
+    .eq("id", cycleId)
+    .single();
+
+  if (!cycle) notFound();
+
+  const serviceClient = createServiceClient();
+  const { data: config } = await serviceClient
+    .from("cycle_config")
+    .select(
+      "problem_statement_open, problem_statement_close, voting_open, voting_close"
+    )
+    .eq("cycle_id", cycleId)
+    .maybeSingle();
+
+  const now = new Date();
+  const proposeOpen = windowOpen(
+    config?.problem_statement_open,
+    config?.problem_statement_close,
+    now
+  );
+  const votingOpen = windowOpen(config?.voting_open, config?.voting_close, now);
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data: me } = user
+    ? await supabase
+        .from("participants")
+        .select("id, metro_id")
+        .eq("auth_user_id", user.id)
+        .maybeSingle()
+    : { data: null };
+
+  const userRoles = user
+    ? await resolveUserRoles(serviceClient, user.id)
+    : null;
+
+  // Per-lab gallery, mirroring the ballot's GET route: members see their own
+  // lab's statements (NULL metro = the grandfathered HQ bucket); admins see
+  // all labs.
+  let query = serviceClient
+    .from("problem_statements")
+    .select("id, statement_text, proposal_data, created_at")
+    .eq("cycle_id", cycleId)
+    .order("created_at");
+  if (!userRoles || !isAdmin(userRoles)) {
+    query = me?.metro_id
+      ? query.eq("metro_id", me.metro_id)
+      : query.is("metro_id", null);
+  }
+  const { data: statements } = await query;
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href={`/cycles/${cycle.id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-meta transition-colors duration-150 hover:text-teal-deep"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden />
+          {cycle.name}
+        </Link>
+        <h1 className="t-h1 mt-2 text-ink">Problem statement gallery</h1>
+        <p className="mt-1 text-sm text-charcoal">
+          What your cohort is proposing this cycle. Follow a map link to
+          explore the evidence behind a statement.
+        </p>
+      </div>
+
+      {proposeOpen && (
+        <Link
+          href={`/cycles/${cycle.id}/propose`}
+          className="group mb-4 flex items-center justify-between gap-3 rounded-card border border-teal/30 bg-teal/10 p-4 transition-colors duration-150 ease-out hover:border-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+        >
+          <span className="font-semibold tracking-tight text-ink">
+            Submissions are open — propose a problem statement
+          </span>
+          <ArrowRight
+            className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+            aria-hidden
+          />
+        </Link>
+      )}
+
+      {votingOpen && (
+        <Link
+          href={`/cycles/${cycle.id}/vote`}
+          className="group mb-4 flex items-center justify-between gap-3 rounded-card border border-teal/30 bg-teal/10 p-4 transition-colors duration-150 ease-out hover:border-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+        >
+          <span className="font-semibold tracking-tight text-ink">
+            Voting is open — cast your votes
+          </span>
+          <ArrowRight
+            className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+            aria-hidden
+          />
+        </Link>
+      )}
+
+      {!statements || statements.length === 0 ? (
+        <div className="mt-4 rounded-card border border-dashed border-meta-soft bg-white p-12">
+          <p className="text-sm text-meta">
+            No problem statements have been submitted yet.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-4 space-y-4">
+          {statements.map((stmt) => {
+            const pd = (stmt.proposal_data ?? null) as ProposalData | null;
+            const hasDetails = !!(pd?.problem || pd?.voter_context);
+            // Scheme-checked before rendering as an href — rows written
+            // before the schema restricted repo_url to http(s) are
+            // untrusted here.
+            const rawRepo = pd?.statement?.repo_url;
+            const mapUrl =
+              rawRepo && /^https?:\/\//i.test(rawRepo) ? rawRepo : null;
+
+            return (
+              <div
+                key={stmt.id}
+                className="rounded-card border border-ink/10 bg-white p-4 shadow-card transition-colors duration-150 hover:border-ink/20"
+              >
+                <p className="font-semibold tracking-tight text-ink">
+                  {stmt.statement_text}
+                </p>
+
+                {pd?.statement?.question && (
+                  <p className="mt-2 text-sm italic text-slate">
+                    {pd.statement.question}
+                  </p>
+                )}
+
+                {mapUrl && (
+                  <a
+                    href={mapUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-flex items-center gap-1 text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline"
+                  >
+                    View the map
+                    <ExternalLink className="h-3 w-3" aria-hidden />
+                  </a>
+                )}
+
+                {pd?.about?.background && (
+                  <p className="mt-2 text-xs text-meta">
+                    Submitted by: {pd.about.background}
+                  </p>
+                )}
+
+                {hasDetails && (
+                  <details className="group mt-2">
+                    <summary className="inline-flex cursor-pointer list-none items-center text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline [&::-webkit-details-marker]:hidden">
+                      <span className="group-open:hidden">
+                        Read full proposal
+                      </span>
+                      <span className="hidden group-open:inline">
+                        Show less
+                      </span>
+                    </summary>
+                    <div className="mt-4 space-y-3 border-t border-ink/10 pt-4">
+                      {pd?.problem?.who && (
+                        <DetailBlock
+                          label="Who is struggling"
+                          text={pd.problem.who}
+                        />
+                      )}
+                      {pd?.problem?.need && (
+                        <DetailBlock
+                          label="What they need to do"
+                          text={pd.problem.need}
+                        />
+                      )}
+                      {pd?.problem?.barrier && (
+                        <DetailBlock
+                          label="Why they can't do it now"
+                          text={pd.problem.barrier}
+                        />
+                      )}
+                      {pd?.problem?.success && (
+                        <DetailBlock
+                          label="What success looks like"
+                          text={pd.problem.success}
+                        />
+                      )}
+                      {pd?.voter_context?.tried && (
+                        <DetailBlock
+                          label="What has been tried"
+                          text={pd.voter_context.tried}
+                        />
+                      )}
+                      {pd?.voter_context?.scale && (
+                        <DetailBlock
+                          label="Why it matters beyond the individual"
+                          text={pd.voter_context.scale}
+                        />
+                      )}
+                      {pd?.voter_context?.pod_work && (
+                        <DetailBlock
+                          label="What the Research Pod would do"
+                          text={pd.voter_context.pod_work}
+                        />
+                      )}
+                      {pd?.voter_context?.skills_needed && (
+                        <DetailBlock
+                          label="Skills & people needed"
+                          text={pd.voter_context.skills_needed}
+                        />
+                      )}
+                    </div>
+                  </details>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DetailBlock({ label, text }: { label: string; text: string }) {
+  return (
+    <div>
+      <p className="lbl">{label}</p>
+      <p className="mt-0.5 text-sm text-charcoal">{text}</p>
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -224,10 +224,16 @@ export default function ProposeForm({
           )}
         </blockquote>
         <Link
-          href="/dashboard"
+          href={`/cycles/${cycleId}/proposals`}
           className="mr-3 mt-6 inline-block rounded-card bg-teal-deep px-3 py-2 text-xs font-semibold tracking-tight text-white transition-colors duration-150 hover:bg-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
         >
-          Back to dashboard
+          See it in the gallery
+        </Link>
+        <Link
+          href={`/cycles/${cycleId}`}
+          className="mr-3 mt-6 inline-block rounded-card border border-ink/15 px-3 py-2 text-xs font-semibold tracking-tight text-charcoal transition-colors duration-150 hover:bg-ink/[0.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+        >
+          Back to the cycle
         </Link>
         <button
           onClick={() => {

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -51,6 +51,7 @@ export default function ProposeForm({
   // Part 3 — Your Problem Statement
   const [statementText, setStatementText] = useState("");
   const [question, setQuestion] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
 
   // Part 4 — Where This Problem Lives
   const [impactTrack, setImpactTrack] = useState("");
@@ -80,6 +81,25 @@ export default function ProposeForm({
     checkSpecific &&
     checkSamePicture;
 
+  // Accept bare "github.com/org/repo" pastes by prefixing https://. Gating
+  // Continue on parseability here matters: the server's Zod rejection would
+  // otherwise only surface after step 6.
+  const normalizedRepoUrl = (() => {
+    const raw = repoUrl.trim();
+    if (!raw) return "";
+    return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  })();
+  const repoUrlValid = (() => {
+    if (!normalizedRepoUrl) return true;
+    if (normalizedRepoUrl.length > 500) return false;
+    try {
+      new URL(normalizedRepoUrl);
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
   function canAdvance(): boolean {
     switch (step) {
       case 1:
@@ -92,7 +112,7 @@ export default function ProposeForm({
           !!success.trim()
         );
       case 3:
-        return !!statementText.trim() && !!question.trim();
+        return !!statementText.trim() && !!question.trim() && repoUrlValid;
       case 4:
         return true; // optional
       case 5:
@@ -140,6 +160,7 @@ export default function ProposeForm({
             statement: {
               text: statementText.trim(),
               question: question.trim(),
+              repo_url: normalizedRepoUrl || undefined,
             },
             context: {
               impact_track: resolvedTrack || undefined,
@@ -220,6 +241,7 @@ export default function ProposeForm({
             setSuccess("");
             setStatementText("");
             setQuestion("");
+            setRepoUrl("");
             setImpactTrack("");
             setImpactTrackOther("");
             setThemeAlignment("none");
@@ -448,6 +470,26 @@ export default function ProposeForm({
               className={textareaClass}
             />
             <CharCount value={question} max={2000} />
+          </Field>
+
+          <Field
+            label="Link to your map"
+            hint="Optional. If you mapped this problem in the Triangulator, paste the GitHub repo where your working folder lives — voters can explore the evidence behind your statement."
+          >
+            <input
+              type="url"
+              value={repoUrl}
+              onChange={(e) => setRepoUrl(e.target.value)}
+              maxLength={500}
+              placeholder="https://github.com/..."
+              className={inputClass}
+            />
+            {!repoUrlValid && (
+              <p className="mt-1 text-xs text-red">
+                That doesn&rsquo;t look like a URL — fix it or leave the field
+                empty.
+              </p>
+            )}
           </Field>
         </section>
       )}

--- a/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
@@ -140,7 +140,9 @@ export default function PodRegistration({
     return (
       <div className="rounded-card border border-dashed border-meta-soft bg-white p-12">
         <p className="text-sm text-meta">
-          No pods available for registration yet.
+          No pods here yet — the vote is still being finalized into a
+          shortlist. Check back shortly; when the pods are announced, this is
+          where you&apos;ll join one.
         </p>
       </div>
     );

--- a/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
@@ -27,7 +27,9 @@ export default async function VotePage({
   const serviceClient = createServiceClient();
   const { data: config } = await serviceClient
     .from("cycle_config")
-    .select("voting_open, voting_close, submitter_votes, non_submitter_votes")
+    .select(
+      "voting_open, voting_close, submitter_votes, non_submitter_votes, pod_registration_open, pod_registration_close"
+    )
     .eq("cycle_id", cycleId)
     .maybeSingle();
 
@@ -80,6 +82,12 @@ export default async function VotePage({
         <p className="mt-1 text-sm text-charcoal">
           Allocate your votes to the problems you want the community to tackle.
         </p>
+        <Link
+          href={`/cycles/${cycle.id}/proposals`}
+          className="mt-2 inline-block text-sm font-semibold text-teal-deep hover:text-teal"
+        >
+          Read the full proposals in the gallery →
+        </Link>
       </div>
 
       {isOpen ? (
@@ -92,9 +100,12 @@ export default async function VotePage({
       ) : (
         <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
-            {config
-              ? "Voting is not currently open."
-              : "This cycle isn't fully configured yet — the voting window hasn't been scheduled. If you expected it to be open, let an organizer know."}
+            {!config
+              ? "This cycle isn't fully configured yet — the voting window hasn't been scheduled. If you expected it to be open, let an organizer know."
+              : config.voting_close &&
+                  now > (parseWindow(config.voting_close) as Date)
+                ? "Voting has closed. The top-voted statements become the cycle's pods."
+                : "Voting is not currently open."}
           </p>
           {config?.voting_open &&
             now < (parseWindow(config.voting_open) as Date) && (
@@ -102,6 +113,28 @@ export default async function VotePage({
                 Opens {fmtLabDateTime(config.voting_open)}
               </p>
             )}
+          {config?.voting_close &&
+            now > (parseWindow(config.voting_close) as Date) &&
+            (windowOpen(
+              config.pod_registration_open,
+              config.pod_registration_close,
+              now
+            ) ? (
+              <Link
+                href={`/cycles/${cycle.id}/register-pods`}
+                className="mt-3 inline-block text-sm font-semibold text-teal-deep hover:text-teal"
+              >
+                Pod registration is open — join a pod →
+              </Link>
+            ) : (
+              <p className="mt-2 text-sm text-meta">
+                Pod registration opens once the shortlist is finalized
+                {config.pod_registration_open
+                  ? ` — ${fmtLabDateTime(config.pod_registration_open)}`
+                  : ""}
+                .
+              </p>
+            ))}
         </div>
       )}
     </div>

--- a/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { ExternalLink } from "lucide-react";
 
 interface ProposalData {
   about?: { background?: string; experience?: string };
   problem?: { who?: string; need?: string; barrier?: string; success?: string };
-  statement?: { text?: string; question?: string };
+  statement?: { text?: string; question?: string; repo_url?: string };
   voter_context?: {
     tried?: string;
     scale?: string;
@@ -249,6 +250,11 @@ export default function VoteBallot({
           const pd = stmt.proposal_data;
           const isExpanded = expandedId === stmt.id;
           const hasDetails = pd?.problem || pd?.voter_context;
+          // Scheme-checked before rendering as an href — rows written before
+          // the schema restricted repo_url to http(s) are untrusted here.
+          const rawRepo = pd?.statement?.repo_url;
+          const mapUrl =
+            rawRepo && /^https?:\/\//i.test(rawRepo) ? rawRepo : null;
 
           const mine = myVotes[stmt.id] ?? 0;
           // Zero-state cards show the stepper directly so votes can be added;
@@ -275,6 +281,20 @@ export default function VoteBallot({
                   <p className="mt-2 text-sm italic text-slate">
                     {pd.statement.question}
                   </p>
+                )}
+
+                {/* Triangulator map — always visible, not behind the expand:
+                    the evidence trail is what voters are being asked to weigh */}
+                {mapUrl && (
+                  <a
+                    href={mapUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-flex items-center gap-1 text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline"
+                  >
+                    View the map
+                    <ExternalLink className="h-3 w-3" aria-hidden />
+                  </a>
                 )}
 
                 {/* Submitter background */}

--- a/app/(dashboard)/survey/[slug]/results/page.tsx
+++ b/app/(dashboard)/survey/[slug]/results/page.tsx
@@ -203,9 +203,9 @@ export default async function SurveyResultsPage({
           sublabel={`toward ${RESPONSE_GOAL.toLocaleString()}`}
         />
         <StatCard
-          label="Shared for the commons"
-          value={agg.observations.length.toLocaleString()}
-          sublabel="approved & visible below"
+          label="Curated for the commons"
+          value={agg.approved.toLocaleString()}
+          sublabel="reviewed & approved"
         />
       </div>
 
@@ -241,18 +241,21 @@ export default async function SurveyResultsPage({
         </div>
         {agg.observations.length === 0 ? (
           <p className="text-sm text-meta">
-            No observations have been published yet — check back as the cohort
-            reviews what&apos;s come in.
+            No observations have come in yet — take the survey and share it
+            with someone close to the problem.
           </p>
         ) : (
           <div className="grid gap-4">
-            {agg.observations.map((o, i) => (
+            {/* id anchors (#r-<response id>) are the citation targets the
+                Triangulator's pre-loaded extract cards deep-link back to. */}
+            {agg.observations.map((o) => (
               <div
-                key={i}
-                className="rounded-card border border-ink/10 bg-white p-5 shadow-card"
+                key={o.id}
+                id={`r-${o.id}`}
+                className="scroll-mt-24 rounded-card border border-ink/10 bg-white p-5 shadow-card target:ring-2 target:ring-teal"
               >
                 <p className="text-sm text-charcoal">{o.observation}</p>
-                <div className="mt-2 flex flex-wrap gap-2 text-xs text-meta">
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-meta">
                   {o.standpoint
                     .map((s) => standpointLabels.get(s) ?? s)
                     .map((label) => (
@@ -263,7 +266,14 @@ export default async function SurveyResultsPage({
                         {label}
                       </span>
                     ))}
-                  <span className="ml-auto">{fmtDate(o.created_at)}</span>
+                  {o.pending && (
+                    <span className="rounded-full border border-ink/15 px-2 py-0.5 text-meta">
+                      awaiting review
+                    </span>
+                  )}
+                  <span className="ml-auto">
+                    #{o.id} · {fmtDate(o.created_at)}
+                  </span>
                 </div>
               </div>
             ))}

--- a/lib/content/survey-results.test.ts
+++ b/lib/content/survey-results.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { redactContactInfo } from "./survey-results";
+
+// The participant aggregate never selects the envelope's contact columns, but
+// respondents sometimes type contact details into the observation body itself.
+// This pins the scrub that keeps them off the participant surface.
+describe("redactContactInfo", () => {
+  it("strips email addresses", () => {
+    expect(redactContactInfo("reach me at jane.doe+tag@example.org please")).toBe(
+      "reach me at [contact removed] please"
+    );
+  });
+
+  it("strips phone numbers in common shapes", () => {
+    expect(redactContactInfo("call 301-635-9754")).toBe("call [contact removed]");
+    expect(redactContactInfo("call (502) 451-4564 or 5024190426")).toBe(
+      "call [contact removed] or [contact removed]"
+    );
+    expect(redactContactInfo("at +1 914 826 7312 today")).toBe(
+      "at [contact removed] today"
+    );
+  });
+
+  it("leaves ordinary text, years, and counts alone", () => {
+    const text =
+      "In 2026, 40 participants met at the library; turnout rose 15% over 2024.";
+    expect(redactContactInfo(text)).toBe(text);
+  });
+});

--- a/lib/content/survey-results.ts
+++ b/lib/content/survey-results.ts
@@ -125,6 +125,19 @@ export function buildSurveyExportTable(data: SurveyExportData): {
   return { columns, records };
 }
 
+/**
+ * Strip email addresses and phone-number-shaped sequences from free text
+ * before it reaches the participant aggregate. The envelope's contact columns
+ * are never selected there, but respondents sometimes type contact details
+ * into the observation itself — the participant surface must not carry them.
+ * (The admin/poderator table intentionally keeps the raw text.)
+ */
+export function redactContactInfo(text: string): string {
+  return text
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "[contact removed]")
+    .replace(/(\+?1[-. ]?)?\(?\d{3}\)?[-. ]?\d{3}[-. ]?\d{4}\b/g, "[contact removed]");
+}
+
 export interface SurveyAggregate {
   total: number; // non-rejected responses
   approved: number; // curated into the commons
@@ -187,7 +200,7 @@ export async function getSurveyAggregate(
     .slice(0, 100)
     .map((r) => ({
       id: r.id as number,
-      observation: r.observation as string,
+      observation: redactContactInfo(r.observation as string),
       standpoint: (r.standpoint as string[] | null) ?? [],
       salience: r.salience as number | null,
       created_at: r.created_at as string,

--- a/lib/content/survey-results.ts
+++ b/lib/content/survey-results.ts
@@ -127,19 +127,26 @@ export function buildSurveyExportTable(data: SurveyExportData): {
 
 export interface SurveyAggregate {
   total: number; // non-rejected responses
+  approved: number; // curated into the commons
   salience: number[]; // counts indexed 0..4 for values 1..5
   standpointCounts: { key: string; label: string; count: number }[];
   observations: {
+    id: number;
     observation: string;
     standpoint: string[];
     salience: number | null;
     created_at: string;
+    pending: boolean;
   }[];
 }
 
 /**
- * The privacy-safe participant view: distribution signals over non-rejected
- * responses + the approved observations only. Never selects contact fields.
+ * The privacy-safe participant view: distribution signals + observation text
+ * over non-rejected responses. Never selects contact fields. Pending rows are
+ * included (flagged, so the page can mark them "awaiting review") — the cycle
+ * runs on the full field of observations, and the Triangulator's pre-loaded
+ * cards cite them by anchor (#r-<id>); only rejection hides a row. The
+ * moderation overlay keeps its meaning through `approved` (the commons count).
  */
 export async function getSurveyAggregate(
   surveyId: number,
@@ -148,7 +155,9 @@ export async function getSurveyAggregate(
   const supabase = createServiceClient();
   const { data } = await supabase
     .from("survey_responses")
-    .select("observation, standpoint, salience, created_at, moderation_status")
+    .select(
+      "id, observation, standpoint, salience, created_at, moderation_status"
+    )
     .eq("field_survey_id", surveyId)
     .neq("moderation_status", "rejected")
     .order("created_at", { ascending: false });
@@ -174,14 +183,22 @@ export async function getSurveyAggregate(
   }
 
   const observations = rows
-    .filter((r) => r.moderation_status === "approved" && r.observation)
-    .slice(0, 50)
+    .filter((r) => r.observation)
+    .slice(0, 100)
     .map((r) => ({
+      id: r.id as number,
       observation: r.observation as string,
       standpoint: (r.standpoint as string[] | null) ?? [],
       salience: r.salience as number | null,
       created_at: r.created_at as string,
+      pending: r.moderation_status === "pending",
     }));
 
-  return { total: rows.length, salience, standpointCounts, observations };
+  return {
+    total: rows.length,
+    approved: rows.filter((r) => r.moderation_status === "approved").length,
+    salience,
+    standpointCounts,
+    observations,
+  };
 }

--- a/lib/validations/votes.test.ts
+++ b/lib/validations/votes.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { problemStatementSchema } from "./votes";
+
+/* Pins the proposal_data.statement.repo_url contract: optional, but when
+   present it must be a real http(s) URL — it is rendered as an href on the
+   ballot, the gallery, and the cycle page, so javascript:/data: schemes
+   must fail at the schema, not at render time. */
+
+const base = {
+  cycle_id: 3,
+  statement_text: "A food truck operator needs to navigate procurement.",
+  proposal_data: {
+    problem: {
+      who: "a food truck operator",
+      need: "navigate procurement",
+      barrier: "the form assumes a registered entity",
+      success: "she reaches the review stage",
+    },
+    statement: {
+      text: "A food truck operator needs to navigate procurement.",
+      question: "How might we make procurement navigable?",
+    },
+  },
+};
+
+function withRepoUrl(repo_url?: string) {
+  return {
+    ...base,
+    proposal_data: {
+      ...base.proposal_data,
+      statement: { ...base.proposal_data.statement, repo_url },
+    },
+  };
+}
+
+describe("problemStatementSchema repo_url", () => {
+  it("accepts a submission without repo_url", () => {
+    expect(problemStatementSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("accepts an https GitHub URL and keeps it through parse", () => {
+    const parsed = problemStatementSchema.parse(
+      withRepoUrl("https://github.com/some-org/some-triad-repo")
+    );
+    expect(parsed.proposal_data?.statement.repo_url).toBe(
+      "https://github.com/some-org/some-triad-repo"
+    );
+  });
+
+  it("rejects non-http(s) schemes even when they parse as URLs", () => {
+    expect(
+      problemStatementSchema.safeParse(withRepoUrl("javascript:alert(1)"))
+        .success
+    ).toBe(false);
+    expect(
+      problemStatementSchema.safeParse(withRepoUrl("data:text/html,hi"))
+        .success
+    ).toBe(false);
+  });
+
+  it("rejects strings that are not URLs at all", () => {
+    expect(
+      problemStatementSchema.safeParse(withRepoUrl("github dot com")).success
+    ).toBe(false);
+  });
+
+  it("rejects URLs over 500 characters", () => {
+    expect(
+      problemStatementSchema.safeParse(
+        withRepoUrl("https://github.com/" + "a".repeat(500))
+      ).success
+    ).toBe(false);
+  });
+});

--- a/lib/validations/votes.ts
+++ b/lib/validations/votes.ts
@@ -14,6 +14,15 @@ export const proposalDataSchema = z.object({
   statement: z.object({
     text: z.string().min(1).max(2000),
     question: z.string().min(1).max(2000),
+    // Where the submitter's Triangulator working folder lives (usually a
+    // GitHub repo). Scheme-restricted: .url() alone admits javascript:/data:
+    // URLs, and this value is rendered as an href on the ballot and gallery.
+    repo_url: z
+      .string()
+      .url("Must be a valid URL")
+      .max(500)
+      .regex(/^https?:\/\//i, "Must be an http(s) URL")
+      .optional(),
   }),
   context: z.object({
     impact_track: z.string().max(200).optional(),


### PR DESCRIPTION
## What

Adds a read-only proposal gallery page that displays all problem statements for a cycle in every phase (unlike the voting ballot, which only renders during voting windows). Submitters can now link their Triangulator working folders (GitHub repos) to their problem statements, and voters can explore the evidence behind each proposal.

**Second commit:** opens the civics field-survey results to cycle participants — the cycle page now links to the results, the participant aggregate shows the full non-rejected observation set (pending rows marked &#34;awaiting review&#34;), and every observation carries a stable `#r-<id>` anchor that the Triangulator&#39;s pre-loaded extract cards cite (see TheUpskillingLabs/triangles#72).

**Third commit (end-to-end review of propose → vote → pods):** closes the places the arc went silent, and scrubs contact info from the participant surface:
- Propose confirmation now links &#34;See it in the gallery&#34; + &#34;Back to the cycle&#34; (previously exited to the dashboard only).
- `/vote` links the proposals gallery; its closed state distinguishes pre-open (&#34;Opens …&#34;) from post-close (&#34;Voting has closed…&#34; + a pod-registration link when that window is open, or when it opens).
- Cycle page shows a quiet interlude card in the seam between `voting_close` and `pod_registration_open` (&#34;shortlist is being finalized…&#34;) instead of no phase CTA at all.
- `register-pods` empty state explains finalization instead of the bare &#34;No pods available for registration yet.&#34;
- **Privacy**: the participant aggregate runs observation text through `redactContactInfo` (emails + phone shapes → `[contact removed]`) before rendering — contact columns were already never selected; this closes the typed-into-the-body path. Unit-tested. Audited gallery, ballot, and OG card: no contact info on any participant surface.

## Changes

- **New page**: `app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx` — gallery view of all problem statements with per-lab scoping (members see their lab&#39;s statements; admins see all). Includes expandable details and links to Triangulator maps.
- **Schema validation**: Added `repo_url` field to `proposalDataSchema` in `lib/validations/votes.ts` — optional, must be a valid http(s) URL, max 500 chars. Scheme-restricted to prevent javascript:/data: injection.
- **Tests**: Added `lib/validations/votes.test.ts` to pin the `repo_url` contract, and `lib/content/survey-results.test.ts` to pin the contact-info scrub.
- **Proposal form**: Updated `app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx` to add &#34;Link to your map&#34; field with client-side URL normalization (accepts bare `github.com/org/repo` pastes) and validation; confirmation panel now links the gallery + cycle.
- **Cycle detail page**: Updated `app/(dashboard)/cycles/[cycle_id]/page.tsx` to:
  - Show a gallery link card when statements exist (visible in all phases).
  - Display map links on the viewer&#39;s own submissions.
  - Query `proposal_data` to extract repo URLs.
  - Give the insights-survey card two doors: take the survey, and see the results.
  - Show the voting→registration interlude note when no window is open.
- **Vote page + ballot**: map links displayed prominently; gallery link added; phase-aware closed state.
- **Pod registration** (`register-pods/pod-registration.tsx`): empty state explains the finalize step.
- **Survey aggregate** (`lib/content/survey-results.ts`): the participant view now includes pending (non-rejected) observations with a `pending` flag and response `id`; new `approved` count keeps the &#34;curated for the commons&#34; stat honest; observation text is contact-scrubbed. Contact fields are still never selected.
- **Results page** (`app/(dashboard)/survey/[slug]/results/page.tsx`): each observation renders with an `#r-<id>` anchor (highlighted via `:target` when deep-linked), an &#34;awaiting review&#34; chip on pending rows, and the response id in the meta line. Access gating is unchanged (admins/poderators → full table; active enrollees → anonymized aggregate).

All map URLs are scheme-checked before rendering as hrefs to mitigate XSS from legacy rows.

> **Product note for reviewers:** previously the participant aggregate listed *approved* observations only, so the 17 new in-app submissions (all still `pending` — there&#39;s no approve UI yet) were invisible to the cohort. This PR deliberately shows non-rejected observations to signed-in enrolled participants, clearly marked while awaiting review. Rejection still hides a row, and the full-table/CSV surface remains admin/poderator-only. Shout if you&#39;d rather keep the approved-only gate.

## Verify

- [x] `npm run lint` passes (pre-existing warnings only)
- [x] `npm run test` passes — 407 tests
- [x] `npm run build` passes

## Manual testing

1. **Proposal form** (local, during proposal window):
   - Navigate to a cycle&#39;s propose page.
   - Fill out steps 1–2 normally.
   - On step 3, enter a problem statement and question.
   - In the new &#34;Link to your map&#34; field, paste `github.com/some-org/repo` (no scheme) → expect it to normalize to `https://github.com/some-org/repo` and allow advance.
   - Paste `javascript:alert(1)` → expect validation error and blocked advance.
   - Leave the field empty → expect advance to work (field is optional).
   - Submit the form → expect the confirmation to offer &#34;See it in the gallery&#34; and &#34;Back to the cycle&#34;.

2. **Cycle detail page** (local, any phase):
   - Navigate to a cycle with existing statements.
   - Expect a &#34;Problem statement gallery&#34; card to appear (if statements exist).
   - If you submitted a statement with a map link, expect it to appear in &#34;Your problem statements&#34; with a &#34;View your map&#34; link.
   - Click the gallery card → navigate to the gallery page.
   - Expect the insights-survey card to show both &#34;Take the survey&#34; and &#34;See what the field is saying&#34;.
   - With voting closed and pod registration not yet open → expect the &#34;shortlist is being finalized&#34; interlude card.

3. **Proposal gallery** (local, any phase):
   - View the gallery page for a cycle with statements.
   - Expect all statements to display (or only your lab&#39;s if you&#39;re not an admin).
   - Expect map links to appear as &#34;View the map&#34; buttons.
   - Click a map link → expect it to open the GitHub repo in a new tab.
   - Click &#34;Read full proposal&#34; on a statement → expect details to expand (who, need, barrier, success, tried, scale, pod work, skills).

4. **Vote page** (local):
   - During the window: map links prominent, gallery link under the header.
   - Before the window: &#34;Opens …&#34; line.
   - After the window: &#34;Voting has closed…&#34; + pod-registration link (or its opening time).

5. **Survey results** (as an enrolled participant, not admin):
   - Open `/survey/civics/results` → expect distributions plus the full observation list, with &#34;awaiting review&#34; chips on unmoderated rows and `#<id>` in each meta line.
   - Open `/survey/civics/results#r-5` → expect the page to scroll to observation #5 and ring-highlight it.
   - Expect no emails/phone numbers anywhere on the page.

## Database

- [ ] No schema change — `proposal_data` column already exists; `repo_url` is a new optional field within the JSON structure. The survey changes only widen an existing service-role read.

https://claude.ai/code/session_01SAc8xUJEjNMKrutoCZVHwe