### PR TITLE
Promote dev to main: sprint-day survey results, arc fixes, and the lean problem-situation form

### DIFF
--- a/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/cycle-config-form.tsx
@@ -52,7 +52,7 @@ function fromLocal(val: string): string | null {
 
 const PHASES = [
   {
-    label: "Problem Statement",
+    label: "Problem Situation",
     open: "problem_statement_open",
     close: "problem_statement_close",
   },

--- a/app/(dashboard)/admin/cycles/[cycle_id]/finalize-voting-button.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/finalize-voting-button.tsx
@@ -77,7 +77,7 @@ export default function FinalizeVotingButton({
         >
           {result.pods.length === 0 ? (
             <p className="text-sm text-charcoal">
-              No eligible problem statements met the vote threshold.
+              No eligible problem situations met the vote threshold.
             </p>
           ) : (
             <>

--- a/app/(dashboard)/admin/cycles/[cycle_id]/testing-controls.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/testing-controls.tsx
@@ -13,7 +13,7 @@ const PHASE_SEQUENCE = [
 ] as const;
 
 const PHASE_LABELS: Record<string, string> = {
-  problem_statement: "Problem Statements",
+  problem_statement: "Problem Situations",
   voting: "Voting",
   pod_registration: "Pod Registration",
   solution_proposal: "Solution Proposals",

--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -266,36 +266,47 @@ export default async function CycleDetailPage({
         </div>
       )}
 
-      {/* Insights survey — link + a two-line explainer of what it is and why
-          we run one (grounding the cycle in real problems, not assumptions) */}
+      {/* Insights survey — explainer + two doors: contribute an observation,
+          or read what the field has said so far (the results page is every
+          participant's window into the observation bedrock the cycle's
+          sensemaking runs on). */}
       {fieldSurvey && (
-        <div className="mb-8">
-          <Link
-            href={`/survey/${fieldSurvey.share_slug}`}
-            className="group flex items-center justify-between gap-3 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
-          >
-            <div className="flex items-center gap-3">
-              <ClipboardList
-                className="h-5 w-5 flex-shrink-0 text-teal-deep"
-                aria-hidden
-              />
-              <div>
-                <span className="font-semibold tracking-tight text-ink">
-                  Insights survey: {fieldSurvey.title}
-                </span>
-                <p className="mt-0.5 text-sm text-meta">
-                  A short, open survey for anyone close to this cycle&apos;s
-                  theme. First-hand observations are how we make sure pods work
-                  on real problems, not assumptions — take it, then share it
-                  with a friend.
-                </p>
-              </div>
-            </div>
-            <ArrowRight
-              className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+        <div className="mb-8 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card">
+          <div className="flex items-center gap-3">
+            <ClipboardList
+              className="h-5 w-5 flex-shrink-0 text-teal-deep"
               aria-hidden
             />
-          </Link>
+            <div>
+              <span className="font-semibold tracking-tight text-ink">
+                Insights survey: {fieldSurvey.title}
+              </span>
+              <p className="mt-0.5 text-sm text-meta">
+                A short, open survey for anyone close to this cycle&apos;s
+                theme. First-hand observations are how we make sure pods work
+                on real problems, not assumptions — take it, then share it
+                with a friend.
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-4 pl-8">
+            <Link
+              href={`/survey/${fieldSurvey.share_slug}`}
+              className="group inline-flex items-center gap-1.5 text-sm font-semibold text-teal-deep hover:text-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+            >
+              Take the survey
+              <ArrowRight
+                className="h-4 w-4 transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+                aria-hidden
+              />
+            </Link>
+            <Link
+              href={`/survey/${fieldSurvey.share_slug}/results`}
+              className="inline-flex items-center text-sm font-semibold text-teal-deep hover:text-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal"
+            >
+              See what the field is saying
+            </Link>
+          </div>
         </div>
       )}
 

--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
 import { registrationWindow } from "@/lib/cycles/schedule";
-import { windowOpen, fmtLabDate } from "@/lib/cycles/lab-time";
+import {
+  windowOpen,
+  fmtLabDate,
+  fmtLabDateTime,
+  parseWindow,
+} from "@/lib/cycles/lab-time";
 import {
   BookOpen,
   ArrowRight,
@@ -171,6 +176,24 @@ export default async function CycleDetailPage({
     }
   }
 
+  // The seam between voting and pod registration is the one quiet stretch
+  // where the page would otherwise go silent mid-arc: votes are in, pods
+  // aren't announced. Say what's happening rather than showing nothing.
+  let interlude: string | null = null;
+  if (config && activeWindows.length === 0) {
+    const cfg = config as Record<string, string | null>;
+    const votingClosed =
+      cfg.voting_close && now > (parseWindow(cfg.voting_close) as Date);
+    const podRegStarted =
+      cfg.pod_registration_open &&
+      now > (parseWindow(cfg.pod_registration_open) as Date);
+    if (votingClosed && !podRegStarted) {
+      interlude = cfg.pod_registration_open
+        ? `Voting has closed — the shortlist is being finalized. Pod registration opens ${fmtLabDateTime(cfg.pod_registration_open)}.`
+        : "Voting has closed — the shortlist is being finalized. Pod registration opens next.";
+    }
+  }
+
   const cycleStatusVariant =
     CYCLE_STATUS_VARIANT[cycle.status as CycleStatus] ?? "inactive";
 
@@ -263,6 +286,12 @@ export default async function CycleDetailPage({
               </div>
             </Link>
           ))}
+        </div>
+      )}
+
+      {interlude && (
+        <div className="mb-8 rounded-card border border-ink/10 bg-white p-4 shadow-card">
+          <p className="text-sm text-charcoal">{interlude}</p>
         </div>
       )}
 

--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -1,7 +1,14 @@
 import Link from "next/link";
 import { registrationWindow } from "@/lib/cycles/schedule";
 import { windowOpen, fmtLabDate } from "@/lib/cycles/lab-time";
-import { BookOpen, ArrowRight, ChevronLeft, ClipboardList } from "lucide-react";
+import {
+  BookOpen,
+  ArrowRight,
+  ChevronLeft,
+  ClipboardList,
+  ExternalLink,
+  FolderKanban,
+} from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
 import { StatCard, StatusBadge } from "@/app/components/ui";
@@ -138,11 +145,18 @@ export default async function CycleDetailPage({
   const { data: myStatements } = me
     ? await serviceClient
         .from("problem_statements")
-        .select("id, statement_text, created_at")
+        .select("id, statement_text, proposal_data, created_at")
         .eq("cycle_id", cycle.id)
         .eq("participant_id", me.id)
         .order("created_at")
     : { data: null };
+
+  // Door to the proposal gallery — shown as soon as the cycle has any
+  // statements at all (the gallery page itself applies the per-lab filter).
+  const { count: statementCount } = await serviceClient
+    .from("problem_statements")
+    .select("id", { count: "exact", head: true })
+    .eq("cycle_id", cycle.id);
 
   const now = new Date();
   const activeWindows: { label: string; route: string; closesAt: string }[] = [];
@@ -315,25 +329,78 @@ export default async function CycleDetailPage({
         </div>
       )}
 
+      {/* Proposal gallery — browsable in every phase, unlike the ballot,
+          which only renders while the voting window is open */}
+      {(statementCount ?? 0) > 0 && (
+        <div className="mb-8">
+          <Link
+            href={`/cycles/${cycle.id}/proposals`}
+            className="group flex items-center justify-between gap-3 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+          >
+            <div className="flex items-center gap-3">
+              <FolderKanban
+                className="h-5 w-5 flex-shrink-0 text-teal-deep"
+                aria-hidden
+              />
+              <div>
+                <span className="font-semibold tracking-tight text-ink">
+                  Problem statement gallery
+                </span>
+                <p className="mt-0.5 text-sm text-meta">
+                  Browse what your cohort is proposing this cycle — with links
+                  to the maps behind each statement.
+                </p>
+              </div>
+            </div>
+            <ArrowRight
+              className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+              aria-hidden
+            />
+          </Link>
+        </div>
+      )}
+
       {/* The viewer's own submissions — visible in every phase, not just on
           the voting ballot */}
       {myStatements && myStatements.length > 0 && (
         <div className="mb-8">
           <h2 className="t-h3 mb-4 text-ink">Your problem statements</h2>
           <div className="space-y-3">
-            {myStatements.map((s) => (
-              <blockquote
-                key={s.id}
-                className="rounded-card border border-ink/10 bg-white p-4 shadow-card"
-              >
-                <p className="text-sm leading-relaxed text-charcoal">
-                  {s.statement_text}
-                </p>
-                <p className="mt-2 text-xs text-meta">
-                  Submitted {new Date(s.created_at).toLocaleDateString()}
-                </p>
-              </blockquote>
-            ))}
+            {myStatements.map((s) => {
+              // Scheme-checked before rendering as an href (rows can predate
+              // the schema's http(s) restriction on repo_url).
+              const rawRepo = (
+                s.proposal_data as {
+                  statement?: { repo_url?: string };
+                } | null
+              )?.statement?.repo_url;
+              const mapUrl =
+                rawRepo && /^https?:\/\//i.test(rawRepo) ? rawRepo : null;
+              return (
+                <blockquote
+                  key={s.id}
+                  className="rounded-card border border-ink/10 bg-white p-4 shadow-card"
+                >
+                  <p className="text-sm leading-relaxed text-charcoal">
+                    {s.statement_text}
+                  </p>
+                  <p className="mt-2 text-xs text-meta">
+                    Submitted {new Date(s.created_at).toLocaleDateString()}
+                  </p>
+                  {mapUrl && (
+                    <a
+                      href={mapUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center gap-1 text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline"
+                    >
+                      View your map
+                      <ExternalLink className="h-3 w-3" aria-hidden />
+                    </a>
+                  )}
+                </blockquote>
+              );
+            })}
           </div>
         </div>
       )}

--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -45,8 +45,8 @@ const WINDOW_ROUTES: {
   field: string;
   route: string;
 }[] = [
-  { label: "Submit Problem Statements", field: "problem_statement", route: "propose" },
-  { label: "Vote on Problem Statements", field: "voting", route: "vote" },
+  { label: "Submit Problem Situations", field: "problem_statement", route: "propose" },
+  { label: "Vote on Problem Situations", field: "voting", route: "vote" },
   { label: "Register for Pods", field: "pod_registration", route: "register-pods" },
   { label: "Submit Solution Proposals", field: "solution_proposal", route: "solutions" },
   { label: "Vote on Solutions", field: "solution_voting", route: "solution-vote" },
@@ -142,7 +142,7 @@ export default async function CycleDetailPage({
     }
   }
 
-  // The viewer's own problem statements (July 2026 feedback, running-list #2):
+  // The viewer's own problem situations (July 2026 feedback, running-list #2):
   // before this, statements were only ever listed on the vote ballot during
   // the voting phase, so a submitter had no way to see their own submission
   // back. Deliberately a direct owner-scoped query, not the shared GET route —
@@ -384,7 +384,7 @@ export default async function CycleDetailPage({
               />
               <div>
                 <span className="font-semibold tracking-tight text-ink">
-                  Problem statement gallery
+                  Problem situation gallery
                 </span>
                 <p className="mt-0.5 text-sm text-meta">
                   Browse what your cohort is proposing this cycle — with links
@@ -404,7 +404,7 @@ export default async function CycleDetailPage({
           the voting ballot */}
       {myStatements && myStatements.length > 0 && (
         <div className="mb-8">
-          <h2 className="t-h3 mb-4 text-ink">Your problem statements</h2>
+          <h2 className="t-h3 mb-4 text-ink">Your problem situations</h2>
           <div className="space-y-3">
             {myStatements.map((s) => {
               // Scheme-checked before rendering as an href (rows can predate

--- a/app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx
@@ -1,0 +1,266 @@
+import Link from "next/link";
+import { windowOpen } from "@/lib/cycles/lab-time";
+import { ArrowRight, ChevronLeft, ExternalLink } from "lucide-react";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
+import { notFound } from "next/navigation";
+
+interface ProposalData {
+  about?: { background?: string };
+  problem?: { who?: string; need?: string; barrier?: string; success?: string };
+  statement?: { question?: string; repo_url?: string };
+  voter_context?: {
+    tried?: string;
+    scale?: string;
+    pod_work?: string;
+    skills_needed?: string;
+  };
+}
+
+// Read-only gallery of the cycle's problem statements. Unlike the vote
+// ballot, this renders in every phase — the ballot only exists while the
+// voting window is open, which left proposals unbrowsable the rest of the
+// cycle. Same per-lab scoping as GET /api/problem-statements/[cycle_id],
+// same no-author-attribution convention as the ballot.
+export default async function ProposalsGalleryPage({
+  params,
+}: {
+  params: Promise<{ cycle_id: string }>;
+}) {
+  const { cycle_id } = await params;
+  const cycleId = parseInt(cycle_id, 10);
+  const supabase = await createClient();
+
+  const { data: cycle } = await supabase
+    .from("cycles")
+    .select("id, name")
+    .eq("id", cycleId)
+    .single();
+
+  if (!cycle) notFound();
+
+  const serviceClient = createServiceClient();
+  const { data: config } = await serviceClient
+    .from("cycle_config")
+    .select(
+      "problem_statement_open, problem_statement_close, voting_open, voting_close"
+    )
+    .eq("cycle_id", cycleId)
+    .maybeSingle();
+
+  const now = new Date();
+  const proposeOpen = windowOpen(
+    config?.problem_statement_open,
+    config?.problem_statement_close,
+    now
+  );
+  const votingOpen = windowOpen(config?.voting_open, config?.voting_close, now);
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data: me } = user
+    ? await supabase
+        .from("participants")
+        .select("id, metro_id")
+        .eq("auth_user_id", user.id)
+        .maybeSingle()
+    : { data: null };
+
+  const userRoles = user
+    ? await resolveUserRoles(serviceClient, user.id)
+    : null;
+
+  // Per-lab gallery, mirroring the ballot's GET route: members see their own
+  // lab's statements (NULL metro = the grandfathered HQ bucket); admins see
+  // all labs.
+  let query = serviceClient
+    .from("problem_statements")
+    .select("id, statement_text, proposal_data, created_at")
+    .eq("cycle_id", cycleId)
+    .order("created_at");
+  if (!userRoles || !isAdmin(userRoles)) {
+    query = me?.metro_id
+      ? query.eq("metro_id", me.metro_id)
+      : query.is("metro_id", null);
+  }
+  const { data: statements } = await query;
+
+  return (
+    <div>
+      <div className="mb-8">
+        <Link
+          href={`/cycles/${cycle.id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-meta transition-colors duration-150 hover:text-teal-deep"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden />
+          {cycle.name}
+        </Link>
+        <h1 className="t-h1 mt-2 text-ink">Problem statement gallery</h1>
+        <p className="mt-1 text-sm text-charcoal">
+          What your cohort is proposing this cycle. Follow a map link to
+          explore the evidence behind a statement.
+        </p>
+      </div>
+
+      {proposeOpen && (
+        <Link
+          href={`/cycles/${cycle.id}/propose`}
+          className="group mb-4 flex items-center justify-between gap-3 rounded-card border border-teal/30 bg-teal/10 p-4 transition-colors duration-150 ease-out hover:border-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+        >
+          <span className="font-semibold tracking-tight text-ink">
+            Submissions are open — propose a problem statement
+          </span>
+          <ArrowRight
+            className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+            aria-hidden
+          />
+        </Link>
+      )}
+
+      {votingOpen && (
+        <Link
+          href={`/cycles/${cycle.id}/vote`}
+          className="group mb-4 flex items-center justify-between gap-3 rounded-card border border-teal/30 bg-teal/10 p-4 transition-colors duration-150 ease-out hover:border-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+        >
+          <span className="font-semibold tracking-tight text-ink">
+            Voting is open — cast your votes
+          </span>
+          <ArrowRight
+            className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
+            aria-hidden
+          />
+        </Link>
+      )}
+
+      {!statements || statements.length === 0 ? (
+        <div className="mt-4 rounded-card border border-dashed border-meta-soft bg-white p-12">
+          <p className="text-sm text-meta">
+            No problem statements have been submitted yet.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-4 space-y-4">
+          {statements.map((stmt) => {
+            const pd = (stmt.proposal_data ?? null) as ProposalData | null;
+            const hasDetails = !!(pd?.problem || pd?.voter_context);
+            // Scheme-checked before rendering as an href — rows written
+            // before the schema restricted repo_url to http(s) are
+            // untrusted here.
+            const rawRepo = pd?.statement?.repo_url;
+            const mapUrl =
+              rawRepo && /^https?:\/\//i.test(rawRepo) ? rawRepo : null;
+
+            return (
+              <div
+                key={stmt.id}
+                className="rounded-card border border-ink/10 bg-white p-4 shadow-card transition-colors duration-150 hover:border-ink/20"
+              >
+                <p className="font-semibold tracking-tight text-ink">
+                  {stmt.statement_text}
+                </p>
+
+                {pd?.statement?.question && (
+                  <p className="mt-2 text-sm italic text-slate">
+                    {pd.statement.question}
+                  </p>
+                )}
+
+                {mapUrl && (
+                  <a
+                    href={mapUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-flex items-center gap-1 text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline"
+                  >
+                    View the map
+                    <ExternalLink className="h-3 w-3" aria-hidden />
+                  </a>
+                )}
+
+                {pd?.about?.background && (
+                  <p className="mt-2 text-xs text-meta">
+                    Submitted by: {pd.about.background}
+                  </p>
+                )}
+
+                {hasDetails && (
+                  <details className="group mt-2">
+                    <summary className="inline-flex cursor-pointer list-none items-center text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline [&::-webkit-details-marker]:hidden">
+                      <span className="group-open:hidden">
+                        Read full proposal
+                      </span>
+                      <span className="hidden group-open:inline">
+                        Show less
+                      </span>
+                    </summary>
+                    <div className="mt-4 space-y-3 border-t border-ink/10 pt-4">
+                      {pd?.problem?.who && (
+                        <DetailBlock
+                          label="Who is struggling"
+                          text={pd.problem.who}
+                        />
+                      )}
+                      {pd?.problem?.need && (
+                        <DetailBlock
+                          label="What they need to do"
+                          text={pd.problem.need}
+                        />
+                      )}
+                      {pd?.problem?.barrier && (
+                        <DetailBlock
+                          label="Why they can't do it now"
+                          text={pd.problem.barrier}
+                        />
+                      )}
+                      {pd?.problem?.success && (
+                        <DetailBlock
+                          label="What success looks like"
+                          text={pd.problem.success}
+                        />
+                      )}
+                      {pd?.voter_context?.tried && (
+                        <DetailBlock
+                          label="What has been tried"
+                          text={pd.voter_context.tried}
+                        />
+                      )}
+                      {pd?.voter_context?.scale && (
+                        <DetailBlock
+                          label="Why it matters beyond the individual"
+                          text={pd.voter_context.scale}
+                        />
+                      )}
+                      {pd?.voter_context?.pod_work && (
+                        <DetailBlock
+                          label="What the Research Pod would do"
+                          text={pd.voter_context.pod_work}
+                        />
+                      )}
+                      {pd?.voter_context?.skills_needed && (
+                        <DetailBlock
+                          label="Skills & people needed"
+                          text={pd.voter_context.skills_needed}
+                        />
+                      )}
+                    </div>
+                  </details>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DetailBlock({ label, text }: { label: string; text: string }) {
+  return (
+    <div>
+      <p className="lbl">{label}</p>
+      <p className="mt-0.5 text-sm text-charcoal">{text}</p>
+    </div>
+  );
+}

--- a/app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx
@@ -7,6 +7,16 @@ import { notFound } from "next/navigation";
 
 interface ProposalData {
   about?: { background?: string };
+  // Triangulator-aligned shape (current submissions)…
+  situation?: {
+    title?: string;
+    description?: string;
+    openness?: string;
+    paradox?: string;
+    beneficiaries?: string;
+    problematization?: string;
+  };
+  // …and the legacy who/need/barrier/success block (pre-alignment rows).
   problem?: { who?: string; need?: string; barrier?: string; success?: string };
   statement?: { question?: string; repo_url?: string };
   voter_context?: {
@@ -17,7 +27,7 @@ interface ProposalData {
   };
 }
 
-// Read-only gallery of the cycle's problem statements. Unlike the vote
+// Read-only gallery of the cycle's problem situations. Unlike the vote
 // ballot, this renders in every phase — the ballot only exists while the
 // voting window is open, which left proposals unbrowsable the rest of the
 // cycle. Same per-lab scoping as GET /api/problem-statements/[cycle_id],
@@ -97,10 +107,10 @@ export default async function ProposalsGalleryPage({
           <ChevronLeft className="h-4 w-4" aria-hidden />
           {cycle.name}
         </Link>
-        <h1 className="t-h1 mt-2 text-ink">Problem statement gallery</h1>
+        <h1 className="t-h1 mt-2 text-ink">Problem situation gallery</h1>
         <p className="mt-1 text-sm text-charcoal">
           What your cohort is proposing this cycle. Follow a map link to
-          explore the evidence behind a statement.
+          explore the evidence behind a situation.
         </p>
       </div>
 
@@ -110,7 +120,7 @@ export default async function ProposalsGalleryPage({
           className="group mb-4 flex items-center justify-between gap-3 rounded-card border border-teal/30 bg-teal/10 p-4 transition-colors duration-150 ease-out hover:border-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
         >
           <span className="font-semibold tracking-tight text-ink">
-            Submissions are open — propose a problem statement
+            Submissions are open — propose a problem situation
           </span>
           <ArrowRight
             className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
@@ -137,14 +147,18 @@ export default async function ProposalsGalleryPage({
       {!statements || statements.length === 0 ? (
         <div className="mt-4 rounded-card border border-dashed border-meta-soft bg-white p-12">
           <p className="text-sm text-meta">
-            No problem statements have been submitted yet.
+            No problem situations have been submitted yet.
           </p>
         </div>
       ) : (
         <div className="mt-4 space-y-4">
           {statements.map((stmt) => {
             const pd = (stmt.proposal_data ?? null) as ProposalData | null;
-            const hasDetails = !!(pd?.problem || pd?.voter_context);
+            const hasDetails = !!(
+              pd?.situation ||
+              pd?.problem ||
+              pd?.voter_context
+            );
             // Scheme-checked before rendering as an href — rows written
             // before the schema restricted repo_url to http(s) are
             // untrusted here.
@@ -157,6 +171,9 @@ export default async function ProposalsGalleryPage({
                 key={stmt.id}
                 className="rounded-card border border-ink/10 bg-white p-4 shadow-card transition-colors duration-150 hover:border-ink/20"
               >
+                {pd?.situation?.title && (
+                  <p className="lbl lbl-teal mb-1">{pd.situation.title}</p>
+                )}
                 <p className="font-semibold tracking-tight text-ink">
                   {stmt.statement_text}
                 </p>
@@ -196,6 +213,36 @@ export default async function ProposalsGalleryPage({
                       </span>
                     </summary>
                     <div className="mt-4 space-y-3 border-t border-ink/10 pt-4">
+                      {pd?.situation?.description && (
+                        <DetailBlock
+                          label="The situation"
+                          text={pd.situation.description}
+                        />
+                      )}
+                      {pd?.situation?.openness && (
+                        <DetailBlock
+                          label="What makes it open"
+                          text={pd.situation.openness}
+                        />
+                      )}
+                      {pd?.situation?.paradox && (
+                        <DetailBlock
+                          label="The paradox"
+                          text={pd.situation.paradox}
+                        />
+                      )}
+                      {pd?.situation?.beneficiaries && (
+                        <DetailBlock
+                          label="Who benefits from its persistence"
+                          text={pd.situation.beneficiaries}
+                        />
+                      )}
+                      {pd?.situation?.problematization && (
+                        <DetailBlock
+                          label="Pressure-test"
+                          text={pd.situation.problematization}
+                        />
+                      )}
                       {pd?.problem?.who && (
                         <DetailBlock
                           label="Who is struggling"

--- a/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
@@ -42,24 +42,6 @@ export default async function ProposePage({
     now
   );
 
-  // Get user's name for pre-filling
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  let participantName = "";
-  if (user) {
-    const { data: participant } = await supabase
-      .from("participants")
-      .select("first_name, last_name, preferred_name")
-      .eq("auth_user_id", user.id)
-      .single();
-    if (participant) {
-      participantName =
-        `${participant.preferred_name || participant.first_name || ""} ${participant.last_name || ""}`.trim();
-    }
-  }
-
   return (
     <div className="max-w-2xl">
       <div className="mb-8">
@@ -74,22 +56,16 @@ export default async function ProposePage({
           Submit your problem situation
         </h1>
         <p className="mt-2 text-sm leading-relaxed text-charcoal">
-          Bring over what your Triangulator map already holds: the situation
-          you named in the workbook, the paradox at its core, and one
-          distilled sentence for the ballot. Cycle participants vote to
-          shortlist the strongest situations; the shortlist becomes the
-          cycle&rsquo;s pods, and pods that reach the minimum number of
-          registrants officially form.
-        </p>
-        <p className="mt-2 text-sm font-medium text-charcoal">
-          Parts 2 and 3 are a paste from your workbook — if a field feels
-          hard to fill, that&rsquo;s the workbook telling you it isn&rsquo;t
-          done yet.
+          Your map is the submission — this form just points at it. Paste
+          your triad&rsquo;s repo link, name the situation, and distill it to
+          one sentence. Cycle participants vote to shortlist the strongest
+          situations; the shortlist becomes the cycle&rsquo;s pods, and pods
+          that reach the minimum number of registrants officially form.
         </p>
       </div>
 
       {isOpen ? (
-        <ProposeForm cycleId={cycleId} participantName={participantName} />
+        <ProposeForm cycleId={cycleId} />
       ) : (
         <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">

--- a/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/page.tsx
@@ -71,17 +71,20 @@ export default async function ProposePage({
           {cycle.name}
         </Link>
         <h1 className="t-h1 mt-2 text-ink">
-          Open cycle problem proposal
+          Submit your problem situation
         </h1>
         <p className="mt-2 text-sm leading-relaxed text-charcoal">
-          The Open Cycle accepts problem proposals year-round. At the start of
-          each cycle, active participants vote to shortlist the strongest
-          proposals. Shortlisted proposals open for registration. If a research
-          pod reaches the minimum number of registrants, it officially forms.
+          Bring over what your Triangulator map already holds: the situation
+          you named in the workbook, the paradox at its core, and one
+          distilled sentence for the ballot. Cycle participants vote to
+          shortlist the strongest situations; the shortlist becomes the
+          cycle&rsquo;s pods, and pods that reach the minimum number of
+          registrants officially form.
         </p>
         <p className="mt-2 text-sm font-medium text-charcoal">
-          Take your time with Part 2 — it&rsquo;s the most important section.
-          Everything else supports it.
+          Parts 2 and 3 are a paste from your workbook — if a field feels
+          hard to fill, that&rsquo;s the workbook telling you it isn&rsquo;t
+          done yet.
         </p>
       </div>
 
@@ -91,7 +94,7 @@ export default async function ProposePage({
         <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
             {config
-              ? "Problem statement submission is not currently open."
+              ? "Problem situation submission is not currently open."
               : "This cycle isn't fully configured yet — the submission window hasn't been scheduled. If you expected it to be open, let an organizer know."}
           </p>
           {config?.problem_statement_open &&

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -224,10 +224,16 @@ export default function ProposeForm({
           )}
         </blockquote>
         <Link
-          href="/dashboard"
+          href={`/cycles/${cycleId}/proposals`}
           className="mr-3 mt-6 inline-block rounded-card bg-teal-deep px-3 py-2 text-xs font-semibold tracking-tight text-white transition-colors duration-150 hover:bg-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
         >
-          Back to dashboard
+          See it in the gallery
+        </Link>
+        <Link
+          href={`/cycles/${cycleId}`}
+          className="mr-3 mt-6 inline-block rounded-card border border-ink/15 px-3 py-2 text-xs font-semibold tracking-tight text-charcoal transition-colors duration-150 hover:bg-ink/[0.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+        >
+          Back to the cycle
         </Link>
         <button
           onClick={() => {

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -3,11 +3,17 @@
 import { useState } from "react";
 import Link from "next/link";
 
+// The wizard mirrors the Triangulator's Deepen workbook on purpose: steps 2–3
+// ask for the exact fields the workbook made the submitter write (situation
+// name/description/openness, then the paradox and its pressure-test), with the
+// tool's own labels and placeholder grammar, so submitting is a paste — not a
+// re-derivation into someone else's vocabulary. Step 1 leads with the map
+// link because the room's flow arrives here straight from the Git handoff.
 const STEP_NAMES = [
-  "About you",
-  "The problem",
-  "Your problem statement",
-  "Where this problem lives",
+  "Your map & you",
+  "The Problem Situation",
+  "The paradox",
+  "Distill it",
   "Context for voters",
   "Before you submit",
 ] as const;
@@ -35,25 +41,33 @@ export default function ProposeForm({
   const [error, setError] = useState("");
   const [submitted, setSubmitted] = useState(false);
 
-  // Part 1 — About You
+  // Part 1 — Your map & you
+  const [repoUrl, setRepoUrl] = useState("");
   const [name, setName] = useState(participantName);
   const [background, setBackground] = useState("");
   const [experience, setExperience] = useState<
     "lived" | "witnessed" | "both" | ""
   >("");
 
-  // Part 2 — The Problem
-  const [who, setWho] = useState("");
-  const [need, setNeed] = useState("");
-  const [barrier, setBarrier] = useState("");
-  const [success, setSuccess] = useState("");
+  // Part 2 — The Problem Situation (Triangulator workbook, Stage 1)
+  const [sitTitle, setSitTitle] = useState("");
+  const [sitDescription, setSitDescription] = useState("");
+  const [sitOpenness, setSitOpenness] = useState("");
 
-  // Part 3 — Your Problem Statement
+  // Part 3 — The paradox (workbook Stage 5)
+  const [paradox, setParadox] = useState("");
+  const [beneficiaries, setBeneficiaries] = useState("");
+  const [problematization, setProblematization] = useState("");
+
+  // Part 4 — The distilled statement + How-Might-We
   const [statementText, setStatementText] = useState("");
   const [question, setQuestion] = useState("");
-  const [repoUrl, setRepoUrl] = useState("");
 
-  // Part 4 — Where This Problem Lives
+  // Part 5 — Context for Voters (+ where this lives)
+  const [tried, setTried] = useState("");
+  const [scale, setScale] = useState("");
+  const [podWork, setPodWork] = useState("");
+  const [skillsNeeded, setSkillsNeeded] = useState("");
   const [impactTrack, setImpactTrack] = useState("");
   const [impactTrackOther, setImpactTrackOther] = useState("");
   const [themeAlignment, setThemeAlignment] = useState<
@@ -61,24 +75,18 @@ export default function ProposeForm({
   >("none");
   const [themeConnection, setThemeConnection] = useState("");
 
-  // Part 5 — Context for Voters
-  const [tried, setTried] = useState("");
-  const [scale, setScale] = useState("");
-  const [podWork, setPodWork] = useState("");
-  const [skillsNeeded, setSkillsNeeded] = useState("");
-
-  // Part 6 — Checklist
-  const [checkRealPerson, setCheckRealPerson] = useState(false);
-  const [checkAction, setCheckAction] = useState(false);
+  // Part 6 — Checklist (the Triangulator's own rules)
+  const [checkGrounded, setCheckGrounded] = useState(false);
+  const [checkActors, setCheckActors] = useState(false);
   const [checkNoSolution, setCheckNoSolution] = useState(false);
-  const [checkSpecific, setCheckSpecific] = useState(false);
+  const [checkParadox, setCheckParadox] = useState(false);
   const [checkSamePicture, setCheckSamePicture] = useState(false);
 
   const allChecked =
-    checkRealPerson &&
-    checkAction &&
+    checkGrounded &&
+    checkActors &&
     checkNoSolution &&
-    checkSpecific &&
+    checkParadox &&
     checkSamePicture;
 
   // Accept bare "github.com/org/repo" pastes by prefixing https://. Gating
@@ -103,18 +111,15 @@ export default function ProposeForm({
   function canAdvance(): boolean {
     switch (step) {
       case 1:
-        return !!name.trim();
+        return !!name.trim() && repoUrlValid;
       case 2:
         return (
-          !!who.trim() &&
-          !!need.trim() &&
-          !!barrier.trim() &&
-          !!success.trim()
+          !!sitTitle.trim() && !!sitDescription.trim() && !!sitOpenness.trim()
         );
       case 3:
-        return !!statementText.trim() && !!question.trim() && repoUrlValid;
+        return !!paradox.trim();
       case 4:
-        return true; // optional
+        return !!statementText.trim() && !!question.trim();
       case 5:
         return true; // optional but valuable
       case 6:
@@ -151,11 +156,13 @@ export default function ProposeForm({
               background: background.trim() || undefined,
               experience: experience || undefined,
             },
-            problem: {
-              who: who.trim(),
-              need: need.trim(),
-              barrier: barrier.trim(),
-              success: success.trim(),
+            situation: {
+              title: sitTitle.trim(),
+              description: sitDescription.trim(),
+              openness: sitOpenness.trim(),
+              paradox: paradox.trim(),
+              beneficiaries: beneficiaries.trim() || undefined,
+              problematization: problematization.trim() || undefined,
             },
             statement: {
               text: statementText.trim(),
@@ -175,10 +182,10 @@ export default function ProposeForm({
               skills_needed: skillsNeeded.trim() || undefined,
             },
             checklist: {
-              real_person: checkRealPerson,
-              action_not_thing: checkAction,
+              grounded_in_evidence: checkGrounded,
+              real_actors: checkActors,
               no_solution: checkNoSolution,
-              specific_outcome: checkSpecific,
+              paradox_self_undoing: checkParadox,
               same_picture: checkSamePicture,
             },
           },
@@ -203,17 +210,22 @@ export default function ProposeForm({
     return (
       <div className="rounded-card border border-teal/30 bg-teal/10 p-8">
         <h2 className="t-h3 text-ink">
-          Proposal submitted
+          Problem situation submitted
         </h2>
         <p className="mt-3 max-w-lg text-sm leading-relaxed text-charcoal">
-          Your proposal enters the Open Cycle queue. At the start of each cycle,
-          active participants vote during Phase 1 to build a shortlist. If your
-          proposal makes the shortlist, it opens for registration. Research pods
-          that reach the minimum number of registrants officially form and begin
-          work. You&rsquo;ll be notified at each stage.
+          Your problem situation is in. During the voting window, cycle
+          participants read the gallery and allocate their votes; the
+          top-voted situations become the cycle&rsquo;s pods, and pod
+          registration opens after the shortlist is finalized. You&rsquo;ll be
+          notified at each stage.
         </p>
         <blockquote className="mt-5 max-w-lg rounded-card border border-teal/30 bg-white p-4">
-          <div className="lbl mb-2">Your problem statement</div>
+          <div className="lbl mb-2">Your problem situation</div>
+          {sitTitle.trim() && (
+            <p className="mb-1 text-sm font-semibold text-ink">
+              {sitTitle.trim()}
+            </p>
+          )}
           <p className="text-sm leading-relaxed text-charcoal">
             {statementText.trim()}
           </p>
@@ -239,15 +251,17 @@ export default function ProposeForm({
           onClick={() => {
             setSubmitted(false);
             setStep(1);
+            setRepoUrl("");
             setBackground("");
             setExperience("");
-            setWho("");
-            setNeed("");
-            setBarrier("");
-            setSuccess("");
+            setSitTitle("");
+            setSitDescription("");
+            setSitOpenness("");
+            setParadox("");
+            setBeneficiaries("");
+            setProblematization("");
             setStatementText("");
             setQuestion("");
-            setRepoUrl("");
             setImpactTrack("");
             setImpactTrackOther("");
             setThemeAlignment("none");
@@ -256,15 +270,15 @@ export default function ProposeForm({
             setScale("");
             setPodWork("");
             setSkillsNeeded("");
-            setCheckRealPerson(false);
-            setCheckAction(false);
+            setCheckGrounded(false);
+            setCheckActors(false);
             setCheckNoSolution(false);
-            setCheckSpecific(false);
+            setCheckParadox(false);
             setCheckSamePicture(false);
           }}
           className="mt-6 rounded-card bg-teal/10 px-3 py-2 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
         >
-          Submit another proposal
+          Submit another problem situation
         </button>
       </div>
     );
@@ -288,14 +302,39 @@ export default function ProposeForm({
         </div>
       </div>
 
-      {/* PART 1 */}
+      {/* PART 1 — the map link leads: the room arrives here from the Git
+          handoff with the repo URL on their clipboard. */}
       {step === 1 && (
         <section className="space-y-6">
           <div>
             <h2 className="t-h3 text-ink">
-              Part 1 — About You
+              Part 1 — Your Map &amp; You
             </h2>
+            <p className="mt-1 text-sm text-meta">
+              Start with the map you just published — everything you submit
+              here should be readable off it.
+            </p>
           </div>
+
+          <Field
+            label="Link to your map"
+            hint="The GitHub repo your triad shares (or a link straight to your folder in it). Voters open this to see the evidence behind your situation."
+          >
+            <input
+              type="url"
+              value={repoUrl}
+              onChange={(e) => setRepoUrl(e.target.value)}
+              maxLength={500}
+              placeholder="https://github.com/..."
+              className={inputClass}
+            />
+            {!repoUrlValid && (
+              <p className="mt-1 text-xs text-red">
+                That doesn&rsquo;t look like a URL — fix it or leave the field
+                empty.
+              </p>
+            )}
+          </Field>
 
           <Field label="Your name" required>
             <input
@@ -306,7 +345,7 @@ export default function ProposeForm({
             />
           </Field>
 
-          <Field label="Your background in one sentence" hint="What you do or have done — helps voters understand where this problem comes from.">
+          <Field label="Your background in one sentence" hint="What you do or have done — helps voters understand where this situation comes from.">
             <input
               type="text"
               value={background}
@@ -316,7 +355,7 @@ export default function ProposeForm({
             />
           </Field>
 
-          <Field label="Have you personally experienced this problem, or are you bringing it on behalf of others you know?">
+          <Field label="Have you personally experienced this situation, or are you bringing it on behalf of others you know?">
             <div className="space-y-2">
               {(
                 [
@@ -345,106 +384,149 @@ export default function ProposeForm({
         </section>
       )}
 
-      {/* PART 2 */}
+      {/* PART 2 — the workbook's Stage 1 fields, same labels and grammar */}
       {step === 2 && (
         <section className="space-y-6">
           <div>
             <h2 className="t-h3 text-ink">
-              Part 2 — The Problem
+              Part 2 — The Problem Situation
             </h2>
             <p className="mt-1 text-sm text-meta">
-              This is the core of your proposal. Answer all four prompts
-              carefully.
+              These are the same three fields you filled in the
+              Triangulator&rsquo;s workbook (Stage 1) — bring them over in
+              your own words.
             </p>
           </div>
 
           <Field
-            label="2a. Who is struggling with this problem?"
-            hint={"Describe the person \u2014 not a category or institution. Include what they\u2019re doing, what they\u2019re up against, or how they\u2019re feeling."}
-            example={"Not: \u201Csmall business owners.\u201D Better: \u201Ca food truck operator in Southeast DC who built her business without a formal financial background and is now trying to figure out whether she qualifies for a city contract.\u201D"}
+            label="Name the problem situation"
+            hint="A short name for this open condition — the title on your situation box."
             required
           >
-            <textarea
-              value={who}
-              onChange={(e) => setWho(e.target.value)}
-              maxLength={2000}
-              rows={4}
-              className={textareaClass}
+            <input
+              type="text"
+              value={sitTitle}
+              onChange={(e) => setSitTitle(e.target.value)}
+              maxLength={200}
+              placeholder="A short name for this open condition"
+              className={inputClass}
             />
-            <CharCount value={who} max={2000} />
           </Field>
 
           <Field
-            label="2b. What do they need to be able to do?"
-            hint={"Express this as an action \u2014 something they\u2019re trying to accomplish, not something they\u2019re trying to acquire."}
-            example={"Not: \u201Cthey need better resources.\u201D Better: \u201Cthey need to navigate the city\u2019s procurement process without having to hire someone to explain it to them.\u201D"}
+            label="Describe it — the open, complex, networked condition"
             required
           >
             <textarea
-              value={need}
-              onChange={(e) => setNeed(e.target.value)}
+              value={sitDescription}
+              onChange={(e) => setSitDescription(e.target.value)}
               maxLength={2000}
               rows={4}
+              placeholder="This is an open condition, not a bounded problem, because ___"
               className={textareaClass}
             />
-            <CharCount value={need} max={2000} />
+            <CharCount value={sitDescription} max={2000} />
           </Field>
 
           <Field
-            label={"2c. Why can\u2019t they do it right now?"}
-            hint={"This is your insight. What\u2019s actually in the way \u2014 not the obvious answer, but the real one?"}
-            example={"Not: \u201Cbecause the process is complicated.\u201D Better: \u201Cbecause the application assumes you already have a DUNS number and a registered business entity, and no one explains that until after you\u2019ve spent three hours filling out the form.\u201D"}
+            label="What makes it open?"
+            hint="Why this is a situation, not a task: the network of actors, the moving parts, the absence of a known path."
             required
           >
             <textarea
-              value={barrier}
-              onChange={(e) => setBarrier(e.target.value)}
+              value={sitOpenness}
+              onChange={(e) => setSitOpenness(e.target.value)}
               maxLength={2000}
               rows={4}
+              placeholder="What makes this open: the network of actors, the moving parts, the absence of a known path…"
               className={textareaClass}
             />
-            <CharCount value={barrier} max={2000} />
-          </Field>
-
-          <Field
-            label="2d. What does success actually look like for this person?"
-            hint={"Describe the specific outcome \u2014 what changes in their life or work when this problem is solved. Avoid vague words like \u201Cbetter\u201D or \u201Cimproved.\u201D"}
-            example={"Not: \u201Cthey feel more empowered.\u201D Better: \u201Cshe submits a complete procurement application on her own and makes it to the review stage for the first time.\u201D"}
-            required
-          >
-            <textarea
-              value={success}
-              onChange={(e) => setSuccess(e.target.value)}
-              maxLength={2000}
-              rows={4}
-              className={textareaClass}
-            />
-            <CharCount value={success} max={2000} />
+            <CharCount value={sitOpenness} max={2000} />
           </Field>
         </section>
       )}
 
-      {/* PART 3 */}
+      {/* PART 3 — the workbook's Stage 5: the paradox is what the pod forms around */}
       {step === 3 && (
         <section className="space-y-6">
           <div>
             <h2 className="t-h3 text-ink">
-              Part 3 — Your Problem Statement
+              Part 3 — The Paradox
             </h2>
             <p className="mt-1 text-sm text-meta">
-              Using your answers above, assemble your statement in one sentence.
+              Stage 5 of the workbook. The paradox is the self-undoing
+              deadlock your pod forms around — X requires not-X, not a mere
+              trade-off.
+            </p>
+          </div>
+
+          <Field
+            label="The paradox"
+            required
+          >
+            <textarea
+              value={paradox}
+              onChange={(e) => setParadox(e.target.value)}
+              maxLength={2000}
+              rows={4}
+              placeholder="The situation demands ___, but the same conditions that create the need also prevent ___ from working."
+              className={textareaClass}
+            />
+            <CharCount value={paradox} max={2000} />
+          </Field>
+
+          <Field
+            label="Who benefits from its persistence?"
+            hint="Name the actor and the mechanism — a paradox that benefits no one usually isn't one."
+          >
+            <textarea
+              value={beneficiaries}
+              onChange={(e) => setBeneficiaries(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              placeholder="Actor: ___. Mechanism: ___."
+              className={textareaClass}
+            />
+          </Field>
+
+          <Field
+            label="Pressure-test"
+            hint="The workbook's problematization pass — carry it over."
+          >
+            <textarea
+              value={problematization}
+              onChange={(e) => setProblematization(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              placeholder="What's assumed, what would break this, what you've chosen not to see. Your words."
+              className={textareaClass}
+            />
+          </Field>
+        </section>
+      )}
+
+      {/* PART 4 — the one-sentence distillation OLOS asks for */}
+      {step === 4 && (
+        <section className="space-y-6">
+          <div>
+            <h2 className="t-h3 text-ink">
+              Part 4 — Distill It
+            </h2>
+            <p className="mt-1 text-sm text-meta">
+              The gallery and the ballot lead with one sentence. Distill the
+              situation so a stranger pictures it — the map holds the depth.
             </p>
           </div>
 
           <div className="rounded-card border border-ink/10 bg-white p-4 text-sm text-slate">
             <p className="font-semibold text-charcoal">Template:</p>
             <p className="mt-1 italic">
-              [Who is struggling] needs to [what they need to do] because [why
-              they can&rsquo;t right now].
+              [Who, specifically] needs to [do what] because [what&rsquo;s
+              actually in the way].
             </p>
           </div>
 
-          <Field label="Your problem statement" required>
+          <Field label="Your problem situation, in one sentence" required>
             <textarea
               value={statementText}
               onChange={(e) => setStatementText(e.target.value)}
@@ -458,11 +540,11 @@ export default function ProposeForm({
 
           <div className="rounded-card border border-ink/10 bg-white p-4 text-sm text-slate">
             <p className="font-semibold text-charcoal">
-              Now reframe it as a question your Research Pod would work to
+              Now reframe it as the question your Research Pod would work to
               answer:
             </p>
             <p className="mt-1 italic">
-              How might we [action] for [who] so that [the outcome from 2d]?
+              How might we [action] for [who] so that [what changes]?
             </p>
           </div>
 
@@ -477,44 +559,77 @@ export default function ProposeForm({
             />
             <CharCount value={question} max={2000} />
           </Field>
-
-          <Field
-            label="Link to your map"
-            hint="Optional. If you mapped this problem in the Triangulator, paste the GitHub repo where your working folder lives — voters can explore the evidence behind your statement."
-          >
-            <input
-              type="url"
-              value={repoUrl}
-              onChange={(e) => setRepoUrl(e.target.value)}
-              maxLength={500}
-              placeholder="https://github.com/..."
-              className={inputClass}
-            />
-            {!repoUrlValid && (
-              <p className="mt-1 text-xs text-red">
-                That doesn&rsquo;t look like a URL — fix it or leave the field
-                empty.
-              </p>
-            )}
-          </Field>
         </section>
       )}
 
-      {/* PART 4 */}
-      {step === 4 && (
+      {/* PART 5 */}
+      {step === 5 && (
         <section className="space-y-6">
           <div>
             <h2 className="t-h3 text-ink">
-              Part 4 — Where This Problem Lives
+              Part 5 — Context for Voters
             </h2>
             <p className="mt-1 text-sm text-meta">
-              These fields help us connect your Pod to the right mentors and
-              advisors. Skip this section if your problem doesn&rsquo;t fit
-              neatly — it won&rsquo;t affect your proposal.
+              This section is read by active Cycle participants during the
+              voting window. Give them enough to make a real decision — about
+              whether the situation matters and whether they want to work on
+              it. Everything here is optional.
             </p>
           </div>
 
-          <Field label="Impact Track" hint="If your problem maps to one of these, select it. If it cuts across more than one, pick the primary.">
+          <Field
+            label="What has already been tried?"
+            hint={"Programs, tools, workarounds — even if they partially work. “Nothing I know of” is a valid answer."}
+          >
+            <textarea
+              value={tried}
+              onChange={(e) => setTried(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className={textareaClass}
+            />
+          </Field>
+
+          <Field
+            label="Why does this matter beyond the individual?"
+            hint={"Who else is affected — a neighborhood, a sector, a workforce? What’s the scale?"}
+          >
+            <textarea
+              value={scale}
+              onChange={(e) => setScale(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className={textareaClass}
+            />
+          </Field>
+
+          <Field
+            label="What would this Research Pod actually do together?"
+            hint="A pilot, a toolkit, a guide, a mapped process, a prototype — give voters a picture of the work, even a rough one."
+          >
+            <textarea
+              value={podWork}
+              onChange={(e) => setPodWork(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className={textareaClass}
+            />
+          </Field>
+
+          <Field
+            label="What kinds of people or skills would make this Research Pod stronger?"
+            hint={"Be specific — “someone who has worked in city government,” “a designer,” “someone who has used this system themselves.”"}
+          >
+            <textarea
+              value={skillsNeeded}
+              onChange={(e) => setSkillsNeeded(e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className={textareaClass}
+            />
+          </Field>
+
+          <Field label="Impact Track" hint="Optional — helps us connect your Pod to the right mentors and advisors. If it cuts across more than one, pick the primary.">
             <div className="space-y-2">
               {IMPACT_TRACKS.map((track) => (
                 <label
@@ -555,7 +670,7 @@ export default function ProposeForm({
             </div>
           </Field>
 
-          <Field label="Cycle Theme Alignment" hint="Each Cycle recruits mentors and advisors around a specific industry theme. If your problem connects to the current theme, note it here.">
+          <Field label="Cycle Theme Alignment" hint="Each Cycle recruits mentors and advisors around a specific industry theme. If your situation connects to the current theme, note it here.">
             <div className="space-y-2">
               <label className="flex cursor-pointer items-center gap-2 text-sm text-charcoal transition-colors duration-150 hover:text-ink">
                 <input
@@ -575,7 +690,7 @@ export default function ProposeForm({
                   onChange={() => setThemeAlignment("direct")}
                   className="accent-teal"
                 />
-                My problem sits directly inside this theme
+                My situation sits directly inside this theme
               </label>
               <label className="flex cursor-pointer items-center gap-2 text-sm text-charcoal transition-colors duration-150 hover:text-ink">
                 <input
@@ -585,7 +700,7 @@ export default function ProposeForm({
                   onChange={() => setThemeAlignment("adjacent")}
                   className="accent-teal"
                 />
-                My problem touches this theme from an adjacent angle
+                My situation touches this theme from an adjacent angle
               </label>
             </div>
             {themeAlignment !== "none" && (
@@ -602,75 +717,7 @@ export default function ProposeForm({
         </section>
       )}
 
-      {/* PART 5 */}
-      {step === 5 && (
-        <section className="space-y-6">
-          <div>
-            <h2 className="t-h3 text-ink">
-              Part 5 — Context for Voters
-            </h2>
-            <p className="mt-1 text-sm text-meta">
-              This section is read by active Cycle participants during the
-              voting window. Give them enough to make a real decision — about
-              whether the problem matters and whether they want to work on it.
-            </p>
-          </div>
-
-          <Field
-            label="What has already been tried?"
-            hint={"Programs, tools, workarounds \u2014 even if they partially work. \u201CNothing I know of\u201D is a valid answer."}
-          >
-            <textarea
-              value={tried}
-              onChange={(e) => setTried(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              className={textareaClass}
-            />
-          </Field>
-
-          <Field
-            label="Why does this problem matter beyond the individual?"
-            hint={"Who else is affected \u2014 a neighborhood, a sector, a workforce? What\u2019s the scale?"}
-          >
-            <textarea
-              value={scale}
-              onChange={(e) => setScale(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              className={textareaClass}
-            />
-          </Field>
-
-          <Field
-            label="What would this Research Pod actually do together?"
-            hint="A pilot, a toolkit, a guide, a mapped process, a prototype — give voters a picture of the work, even a rough one."
-          >
-            <textarea
-              value={podWork}
-              onChange={(e) => setPodWork(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              className={textareaClass}
-            />
-          </Field>
-
-          <Field
-            label="What kinds of people or skills would make this Research Pod stronger?"
-            hint={"Be specific \u2014 \u201Csomeone who has worked in city government,\u201D \u201Ca designer,\u201D \u201Csomeone who has used this system themselves.\u201D"}
-          >
-            <textarea
-              value={skillsNeeded}
-              onChange={(e) => setSkillsNeeded(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              className={textareaClass}
-            />
-          </Field>
-        </section>
-      )}
-
-      {/* PART 6 */}
+      {/* PART 6 — the tool's own rules, as a self-check */}
       {step === 6 && (
         <section className="space-y-6">
           <div>
@@ -678,12 +725,17 @@ export default function ProposeForm({
               Part 6 — Before You Submit
             </h2>
             <p className="mt-1 text-sm text-meta">
-              Read your problem statement one more time. Check each box
-              honestly.
+              Read your distilled situation one more time. These are the same
+              rules the Triangulator held you to — check each box honestly.
             </p>
           </div>
 
           <div className="rounded-card border border-ink/10 bg-white p-4">
+            {sitTitle.trim() && (
+              <p className="mb-1 text-sm font-semibold text-ink">
+                {sitTitle.trim()}
+              </p>
+            )}
             <p className="text-sm italic text-charcoal">
               &ldquo;{statementText}&rdquo;
             </p>
@@ -691,24 +743,24 @@ export default function ProposeForm({
 
           <div className="space-y-3">
             <CheckItem
-              checked={checkRealPerson}
-              onChange={setCheckRealPerson}
-              label="The problem describes a real person, not an institution or a system"
+              checked={checkGrounded}
+              onChange={setCheckGrounded}
+              label="Every claim traces back to extracts on my map — evidence, not vibes"
             />
             <CheckItem
-              checked={checkAction}
-              onChange={setCheckAction}
-              label="The need is something to do, not something to have"
+              checked={checkActors}
+              onChange={setCheckActors}
+              label={"It points at real, specific actors — people I could name or find, not “society”"}
             />
             <CheckItem
               checked={checkNoSolution}
               onChange={setCheckNoSolution}
-              label="The statement contains no solution — just the problem"
+              label="It proposes no solution — the situation stays open for the pod to frame"
             />
             <CheckItem
-              checked={checkSpecific}
-              onChange={setCheckSpecific}
-              label={"The outcome in 2d is specific enough that you\u2019d know when you\u2019d reached it"}
+              checked={checkParadox}
+              onChange={setCheckParadox}
+              label={"The paradox is self-undoing (X requires not-X) — not a mere trade-off or “it's complicated”"}
             />
             <CheckItem
               checked={checkSamePicture}
@@ -719,8 +771,8 @@ export default function ProposeForm({
 
           {!allChecked && (
             <p className="text-sm text-meta">
-              If any box is unchecked, revise before submitting. A sharper
-              proposal earns more votes.
+              If any box is unchecked, revise before submitting — the workbook
+              is one tab away. A sharper situation earns more votes.
             </p>
           )}
         </section>
@@ -763,7 +815,7 @@ export default function ProposeForm({
               disabled={submitting || !allChecked}
               className="btn btn-teal btn-sm"
             >
-              {submitting ? "Submitting..." : "Submit proposal"}
+              {submitting ? "Submitting..." : "Submit problem situation"}
             </button>
           )}
         </div>

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -51,6 +51,7 @@ export default function ProposeForm({
   // Part 3 — Your Problem Statement
   const [statementText, setStatementText] = useState("");
   const [question, setQuestion] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
 
   // Part 4 — Where This Problem Lives
   const [impactTrack, setImpactTrack] = useState("");
@@ -80,6 +81,25 @@ export default function ProposeForm({
     checkSpecific &&
     checkSamePicture;
 
+  // Accept bare "github.com/org/repo" pastes by prefixing https://. Gating
+  // Continue on parseability here matters: the server's Zod rejection would
+  // otherwise only surface after step 6.
+  const normalizedRepoUrl = (() => {
+    const raw = repoUrl.trim();
+    if (!raw) return "";
+    return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  })();
+  const repoUrlValid = (() => {
+    if (!normalizedRepoUrl) return true;
+    if (normalizedRepoUrl.length > 500) return false;
+    try {
+      new URL(normalizedRepoUrl);
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
   function canAdvance(): boolean {
     switch (step) {
       case 1:
@@ -92,7 +112,7 @@ export default function ProposeForm({
           !!success.trim()
         );
       case 3:
-        return !!statementText.trim() && !!question.trim();
+        return !!statementText.trim() && !!question.trim() && repoUrlValid;
       case 4:
         return true; // optional
       case 5:
@@ -140,6 +160,7 @@ export default function ProposeForm({
             statement: {
               text: statementText.trim(),
               question: question.trim(),
+              repo_url: normalizedRepoUrl || undefined,
             },
             context: {
               impact_track: resolvedTrack || undefined,
@@ -220,6 +241,7 @@ export default function ProposeForm({
             setSuccess("");
             setStatementText("");
             setQuestion("");
+            setRepoUrl("");
             setImpactTrack("");
             setImpactTrackOther("");
             setThemeAlignment("none");
@@ -448,6 +470,26 @@ export default function ProposeForm({
               className={textareaClass}
             />
             <CharCount value={question} max={2000} />
+          </Field>
+
+          <Field
+            label="Link to your map"
+            hint="Optional. If you mapped this problem in the Triangulator, paste the GitHub repo where your working folder lives — voters can explore the evidence behind your statement."
+          >
+            <input
+              type="url"
+              value={repoUrl}
+              onChange={(e) => setRepoUrl(e.target.value)}
+              maxLength={500}
+              placeholder="https://github.com/..."
+              className={inputClass}
+            />
+            {!repoUrlValid && (
+              <p className="mt-1 text-xs text-red">
+                That doesn&rsquo;t look like a URL — fix it or leave the field
+                empty.
+              </p>
+            )}
           </Field>
         </section>
       )}

--- a/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/propose/propose-form.tsx
@@ -3,102 +3,33 @@
 import { useState } from "react";
 import Link from "next/link";
 
-// The wizard mirrors the Triangulator's Deepen workbook on purpose: steps 2–3
-// ask for the exact fields the workbook made the submitter write (situation
-// name/description/openness, then the paradox and its pressure-test), with the
-// tool's own labels and placeholder grammar, so submitting is a paste — not a
-// re-derivation into someone else's vocabulary. Step 1 leads with the map
-// link because the room's flow arrives here straight from the Git handoff.
-const STEP_NAMES = [
-  "Your map & you",
-  "The Problem Situation",
-  "The paradox",
-  "Distill it",
-  "Context for voters",
-  "Before you submit",
-] as const;
-
-const IMPACT_TRACKS = [
-  "Workforce & Economic Mobility",
-  "Civic Infrastructure & Public Services",
-  "Small Business & Entrepreneurship",
-  "Education & Skills",
-  "Health & Community Wellbeing",
-  "Technology & Digital Access",
-];
-
-type Step = 1 | 2 | 3 | 4 | 5 | 6;
-
-export default function ProposeForm({
-  cycleId,
-  participantName,
-}: {
-  cycleId: number;
-  participantName: string;
-}) {
-  const [step, setStep] = useState<Step>(1);
+// One short form, no wizard. The submission leans on the map: the GitHub
+// link (the triad repo from the Triangulator's Git handoff) carries the
+// evidence, the openness, and the paradox — so the form only asks for the
+// link plus the basics a ballot card needs: a name, one distilled sentence,
+// and optional context for voters who won't open the repo. The server
+// attributes the submission to the signed-in participant; there is no name
+// field to fill.
+export default function ProposeForm({ cycleId }: { cycleId: number }) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [submitted, setSubmitted] = useState(false);
 
-  // Part 1 — Your map & you
   const [repoUrl, setRepoUrl] = useState("");
-  const [name, setName] = useState(participantName);
-  const [background, setBackground] = useState("");
-  const [experience, setExperience] = useState<
-    "lived" | "witnessed" | "both" | ""
-  >("");
-
-  // Part 2 — The Problem Situation (Triangulator workbook, Stage 1)
   const [sitTitle, setSitTitle] = useState("");
-  const [sitDescription, setSitDescription] = useState("");
-  const [sitOpenness, setSitOpenness] = useState("");
-
-  // Part 3 — The paradox (workbook Stage 5)
-  const [paradox, setParadox] = useState("");
-  const [beneficiaries, setBeneficiaries] = useState("");
-  const [problematization, setProblematization] = useState("");
-
-  // Part 4 — The distilled statement + How-Might-We
   const [statementText, setStatementText] = useState("");
   const [question, setQuestion] = useState("");
+  const [description, setDescription] = useState("");
+  const [confirmed, setConfirmed] = useState(false);
 
-  // Part 5 — Context for Voters (+ where this lives)
-  const [tried, setTried] = useState("");
-  const [scale, setScale] = useState("");
-  const [podWork, setPodWork] = useState("");
-  const [skillsNeeded, setSkillsNeeded] = useState("");
-  const [impactTrack, setImpactTrack] = useState("");
-  const [impactTrackOther, setImpactTrackOther] = useState("");
-  const [themeAlignment, setThemeAlignment] = useState<
-    "none" | "direct" | "adjacent"
-  >("none");
-  const [themeConnection, setThemeConnection] = useState("");
-
-  // Part 6 — Checklist (the Triangulator's own rules)
-  const [checkGrounded, setCheckGrounded] = useState(false);
-  const [checkActors, setCheckActors] = useState(false);
-  const [checkNoSolution, setCheckNoSolution] = useState(false);
-  const [checkParadox, setCheckParadox] = useState(false);
-  const [checkSamePicture, setCheckSamePicture] = useState(false);
-
-  const allChecked =
-    checkGrounded &&
-    checkActors &&
-    checkNoSolution &&
-    checkParadox &&
-    checkSamePicture;
-
-  // Accept bare "github.com/org/repo" pastes by prefixing https://. Gating
-  // Continue on parseability here matters: the server's Zod rejection would
-  // otherwise only surface after step 6.
+  // Accept bare "github.com/org/repo" pastes by prefixing https://.
   const normalizedRepoUrl = (() => {
     const raw = repoUrl.trim();
     if (!raw) return "";
     return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
   })();
   const repoUrlValid = (() => {
-    if (!normalizedRepoUrl) return true;
+    if (!normalizedRepoUrl) return false;
     if (normalizedRepoUrl.length > 500) return false;
     try {
       new URL(normalizedRepoUrl);
@@ -108,41 +39,12 @@ export default function ProposeForm({
     }
   })();
 
-  function canAdvance(): boolean {
-    switch (step) {
-      case 1:
-        return !!name.trim() && repoUrlValid;
-      case 2:
-        return (
-          !!sitTitle.trim() && !!sitDescription.trim() && !!sitOpenness.trim()
-        );
-      case 3:
-        return !!paradox.trim();
-      case 4:
-        return !!statementText.trim() && !!question.trim();
-      case 5:
-        return true; // optional but valuable
-      case 6:
-        return allChecked;
-      default:
-        return false;
-    }
-  }
-
-  // Step changes reset the scroll position — the nav buttons sit at the
-  // bottom of a long step, so without this the next (often shorter) step
-  // renders with the viewport still parked at the footer.
-  function goToStep(next: Step) {
-    setStep(next);
-    window.scrollTo({ top: 0 });
-  }
+  const canSubmit =
+    repoUrlValid && !!sitTitle.trim() && !!statementText.trim() && confirmed;
 
   async function handleSubmit() {
     setError("");
     setSubmitting(true);
-
-    const resolvedTrack =
-      impactTrack === "Other" ? impactTrackOther : impactTrack;
 
     try {
       const res = await fetch("/api/problem-statements", {
@@ -152,41 +54,14 @@ export default function ProposeForm({
           cycle_id: cycleId,
           statement_text: statementText.trim(),
           proposal_data: {
-            about: {
-              background: background.trim() || undefined,
-              experience: experience || undefined,
-            },
             situation: {
               title: sitTitle.trim(),
-              description: sitDescription.trim(),
-              openness: sitOpenness.trim(),
-              paradox: paradox.trim(),
-              beneficiaries: beneficiaries.trim() || undefined,
-              problematization: problematization.trim() || undefined,
+              description: description.trim() || undefined,
             },
             statement: {
               text: statementText.trim(),
-              question: question.trim(),
-              repo_url: normalizedRepoUrl || undefined,
-            },
-            context: {
-              impact_track: resolvedTrack || undefined,
-              theme_alignment:
-                themeAlignment !== "none" ? themeAlignment : undefined,
-              theme_connection: themeConnection.trim() || undefined,
-            },
-            voter_context: {
-              tried: tried.trim() || undefined,
-              scale: scale.trim() || undefined,
-              pod_work: podWork.trim() || undefined,
-              skills_needed: skillsNeeded.trim() || undefined,
-            },
-            checklist: {
-              grounded_in_evidence: checkGrounded,
-              real_actors: checkActors,
-              no_solution: checkNoSolution,
-              paradox_self_undoing: checkParadox,
-              same_picture: checkSamePicture,
+              question: question.trim() || undefined,
+              repo_url: normalizedRepoUrl,
             },
           },
         }),
@@ -214,10 +89,9 @@ export default function ProposeForm({
         </h2>
         <p className="mt-3 max-w-lg text-sm leading-relaxed text-charcoal">
           Your problem situation is in. During the voting window, cycle
-          participants read the gallery and allocate their votes; the
-          top-voted situations become the cycle&rsquo;s pods, and pod
-          registration opens after the shortlist is finalized. You&rsquo;ll be
-          notified at each stage.
+          participants read the gallery, open the maps, and allocate their
+          votes; the top-voted situations become the cycle&rsquo;s pods, and
+          pod registration opens after the shortlist is finalized.
         </p>
         <blockquote className="mt-5 max-w-lg rounded-card border border-teal/30 bg-white p-4">
           <div className="lbl mb-2">Your problem situation</div>
@@ -250,31 +124,12 @@ export default function ProposeForm({
         <button
           onClick={() => {
             setSubmitted(false);
-            setStep(1);
             setRepoUrl("");
-            setBackground("");
-            setExperience("");
             setSitTitle("");
-            setSitDescription("");
-            setSitOpenness("");
-            setParadox("");
-            setBeneficiaries("");
-            setProblematization("");
             setStatementText("");
             setQuestion("");
-            setImpactTrack("");
-            setImpactTrackOther("");
-            setThemeAlignment("none");
-            setThemeConnection("");
-            setTried("");
-            setScale("");
-            setPodWork("");
-            setSkillsNeeded("");
-            setCheckGrounded(false);
-            setCheckActors(false);
-            setCheckNoSolution(false);
-            setCheckParadox(false);
-            setCheckSamePicture(false);
+            setDescription("");
+            setConfirmed(false);
           }}
           className="mt-6 rounded-card bg-teal/10 px-3 py-2 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
         >
@@ -285,500 +140,98 @@ export default function ProposeForm({
   }
 
   return (
-    <div className="space-y-8">
-      {/* Step indicator — design-system wizard pattern */}
-      <div>
-        <div className="mb-2 flex items-center justify-between text-xs text-meta">
-          <span className="tabular-nums">Step {step} of 6</span>
-          <span className="font-medium text-charcoal">
-            {STEP_NAMES[step - 1]}
-          </span>
-        </div>
-        <div className="h-1 overflow-hidden rounded-full bg-ink/10">
-          <div
-            className="h-full rounded-full bg-teal transition-all duration-500 ease-spring"
-            style={{ width: `${(step / 6) * 100}%` }}
-          />
-        </div>
-      </div>
+    <div className="space-y-6">
+      <Field
+        label="Link to your map"
+        hint="The GitHub repo your triad shares (or a link straight to your folder in it). This is the submission's spine — voters open it to see the situation, the paradox, and the evidence behind it."
+        required
+      >
+        <input
+          type="url"
+          value={repoUrl}
+          onChange={(e) => setRepoUrl(e.target.value)}
+          maxLength={500}
+          placeholder="https://github.com/..."
+          className={inputClass}
+        />
+        {repoUrl.trim() !== "" && !repoUrlValid && (
+          <p className="mt-1 text-xs text-red">
+            That doesn&rsquo;t look like a URL — check it and try again.
+          </p>
+        )}
+      </Field>
 
-      {/* PART 1 — the map link leads: the room arrives here from the Git
-          handoff with the repo URL on their clipboard. */}
-      {step === 1 && (
-        <section className="space-y-6">
-          <div>
-            <h2 className="t-h3 text-ink">
-              Part 1 — Your Map &amp; You
-            </h2>
-            <p className="mt-1 text-sm text-meta">
-              Start with the map you just published — everything you submit
-              here should be readable off it.
-            </p>
-          </div>
+      <Field
+        label="Name the problem situation"
+        hint="The title on your situation box in the Triangulator."
+        required
+      >
+        <input
+          type="text"
+          value={sitTitle}
+          onChange={(e) => setSitTitle(e.target.value)}
+          maxLength={200}
+          placeholder="A short name for this open condition"
+          className={inputClass}
+        />
+      </Field>
 
-          <Field
-            label="Link to your map"
-            hint="The GitHub repo your triad shares (or a link straight to your folder in it). Voters open this to see the evidence behind your situation."
-          >
-            <input
-              type="url"
-              value={repoUrl}
-              onChange={(e) => setRepoUrl(e.target.value)}
-              maxLength={500}
-              placeholder="https://github.com/..."
-              className={inputClass}
-            />
-            {!repoUrlValid && (
-              <p className="mt-1 text-xs text-red">
-                That doesn&rsquo;t look like a URL — fix it or leave the field
-                empty.
-              </p>
-            )}
-          </Field>
+      <Field
+        label="Your problem situation, in one sentence"
+        hint="The line the ballot and gallery lead with — distill it so a stranger pictures it."
+        required
+      >
+        <textarea
+          value={statementText}
+          onChange={(e) => setStatementText(e.target.value)}
+          maxLength={2000}
+          rows={3}
+          placeholder="[Who, specifically] needs to [do what] because [what's actually in the way]..."
+          className={textareaClass}
+        />
+        <CharCount value={statementText} max={2000} />
+      </Field>
 
-          <Field label="Your name" required>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className={inputClass}
-            />
-          </Field>
+      <Field
+        label="How might we…?"
+        hint="Optional — the question your Research Pod would work to answer."
+      >
+        <textarea
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          maxLength={2000}
+          rows={2}
+          placeholder="How might we..."
+          className={textareaClass}
+        />
+      </Field>
 
-          <Field label="Your background in one sentence" hint="What you do or have done — helps voters understand where this situation comes from.">
-            <input
-              type="text"
-              value={background}
-              onChange={(e) => setBackground(e.target.value)}
-              maxLength={500}
-              className={inputClass}
-            />
-          </Field>
+      <Field
+        label="Anything voters should know before they open the map?"
+        hint="Optional — a few sentences of context: scale, what's been tried, who you need."
+      >
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          maxLength={2000}
+          rows={3}
+          className={textareaClass}
+        />
+      </Field>
 
-          <Field label="Have you personally experienced this situation, or are you bringing it on behalf of others you know?">
-            <div className="space-y-2">
-              {(
-                [
-                  ["lived", "I've lived it directly"],
-                  ["witnessed", "I've witnessed it in people I've worked with"],
-                  ["both", "Both"],
-                ] as const
-              ).map(([val, label]) => (
-                <label
-                  key={val}
-                  className="flex cursor-pointer items-center gap-2 text-sm text-charcoal transition-colors duration-150 hover:text-ink"
-                >
-                  <input
-                    type="radio"
-                    name="experience"
-                    value={val}
-                    checked={experience === val}
-                    onChange={() => setExperience(val)}
-                    className="h-4 w-4 accent-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
-                  />
-                  {label}
-                </label>
-              ))}
-            </div>
-          </Field>
-        </section>
-      )}
+      <label className="flex cursor-pointer items-start gap-3 rounded-card border border-ink/10 bg-white p-4 text-sm text-charcoal transition-colors duration-150 hover:text-ink">
+        <input
+          type="checkbox"
+          checked={confirmed}
+          onChange={(e) => setConfirmed(e.target.checked)}
+          className="mt-0.5 h-4 w-4 rounded border-ink/20 bg-white accent-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+        />
+        <span>
+          It names an open situation — no solution baked in — and the map
+          holds the evidence.
+        </span>
+      </label>
 
-      {/* PART 2 — the workbook's Stage 1 fields, same labels and grammar */}
-      {step === 2 && (
-        <section className="space-y-6">
-          <div>
-            <h2 className="t-h3 text-ink">
-              Part 2 — The Problem Situation
-            </h2>
-            <p className="mt-1 text-sm text-meta">
-              These are the same three fields you filled in the
-              Triangulator&rsquo;s workbook (Stage 1) — bring them over in
-              your own words.
-            </p>
-          </div>
-
-          <Field
-            label="Name the problem situation"
-            hint="A short name for this open condition — the title on your situation box."
-            required
-          >
-            <input
-              type="text"
-              value={sitTitle}
-              onChange={(e) => setSitTitle(e.target.value)}
-              maxLength={200}
-              placeholder="A short name for this open condition"
-              className={inputClass}
-            />
-          </Field>
-
-          <Field
-            label="Describe it — the open, complex, networked condition"
-            required
-          >
-            <textarea
-              value={sitDescription}
-              onChange={(e) => setSitDescription(e.target.value)}
-              maxLength={2000}
-              rows={4}
-              placeholder="This is an open condition, not a bounded problem, because ___"
-              className={textareaClass}
-            />
-            <CharCount value={sitDescription} max={2000} />
-          </Field>
-
-          <Field
-            label="What makes it open?"
-            hint="Why this is a situation, not a task: the network of actors, the moving parts, the absence of a known path."
-            required
-          >
-            <textarea
-              value={sitOpenness}
-              onChange={(e) => setSitOpenness(e.target.value)}
-              maxLength={2000}
-              rows={4}
-              placeholder="What makes this open: the network of actors, the moving parts, the absence of a known path…"
-              className={textareaClass}
-            />
-            <CharCount value={sitOpenness} max={2000} />
-          </Field>
-        </section>
-      )}
-
-      {/* PART 3 — the workbook's Stage 5: the paradox is what the pod forms around */}
-      {step === 3 && (
-        <section className="space-y-6">
-          <div>
-            <h2 className="t-h3 text-ink">
-              Part 3 — The Paradox
-            </h2>
-            <p className="mt-1 text-sm text-meta">
-              Stage 5 of the workbook. The paradox is the self-undoing
-              deadlock your pod forms around — X requires not-X, not a mere
-              trade-off.
-            </p>
-          </div>
-
-          <Field
-            label="The paradox"
-            required
-          >
-            <textarea
-              value={paradox}
-              onChange={(e) => setParadox(e.target.value)}
-              maxLength={2000}
-              rows={4}
-              placeholder="The situation demands ___, but the same conditions that create the need also prevent ___ from working."
-              className={textareaClass}
-            />
-            <CharCount value={paradox} max={2000} />
-          </Field>
-
-          <Field
-            label="Who benefits from its persistence?"
-            hint="Name the actor and the mechanism — a paradox that benefits no one usually isn't one."
-          >
-            <textarea
-              value={beneficiaries}
-              onChange={(e) => setBeneficiaries(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              placeholder="Actor: ___. Mechanism: ___."
-              className={textareaClass}
-            />
-          </Field>
-
-          <Field
-            label="Pressure-test"
-            hint="The workbook's problematization pass — carry it over."
-          >
-            <textarea
-              value={problematization}
-              onChange={(e) => setProblematization(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              placeholder="What's assumed, what would break this, what you've chosen not to see. Your words."
-              className={textareaClass}
-            />
-          </Field>
-        </section>
-      )}
-
-      {/* PART 4 — the one-sentence distillation OLOS asks for */}
-      {step === 4 && (
-        <section className="space-y-6">
-          <div>
-            <h2 className="t-h3 text-ink">
-              Part 4 — Distill It
-            </h2>
-            <p className="mt-1 text-sm text-meta">
-              The gallery and the ballot lead with one sentence. Distill the
-              situation so a stranger pictures it — the map holds the depth.
-            </p>
-          </div>
-
-          <div className="rounded-card border border-ink/10 bg-white p-4 text-sm text-slate">
-            <p className="font-semibold text-charcoal">Template:</p>
-            <p className="mt-1 italic">
-              [Who, specifically] needs to [do what] because [what&rsquo;s
-              actually in the way].
-            </p>
-          </div>
-
-          <Field label="Your problem situation, in one sentence" required>
-            <textarea
-              value={statementText}
-              onChange={(e) => setStatementText(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              placeholder="[Who] needs to [what] because [why]..."
-              className={textareaClass}
-            />
-            <CharCount value={statementText} max={2000} />
-          </Field>
-
-          <div className="rounded-card border border-ink/10 bg-white p-4 text-sm text-slate">
-            <p className="font-semibold text-charcoal">
-              Now reframe it as the question your Research Pod would work to
-              answer:
-            </p>
-            <p className="mt-1 italic">
-              How might we [action] for [who] so that [what changes]?
-            </p>
-          </div>
-
-          <Field label="Your question" required>
-            <textarea
-              value={question}
-              onChange={(e) => setQuestion(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              placeholder="How might we..."
-              className={textareaClass}
-            />
-            <CharCount value={question} max={2000} />
-          </Field>
-        </section>
-      )}
-
-      {/* PART 5 */}
-      {step === 5 && (
-        <section className="space-y-6">
-          <div>
-            <h2 className="t-h3 text-ink">
-              Part 5 — Context for Voters
-            </h2>
-            <p className="mt-1 text-sm text-meta">
-              This section is read by active Cycle participants during the
-              voting window. Give them enough to make a real decision — about
-              whether the situation matters and whether they want to work on
-              it. Everything here is optional.
-            </p>
-          </div>
-
-          <Field
-            label="What has already been tried?"
-            hint={"Programs, tools, workarounds — even if they partially work. “Nothing I know of” is a valid answer."}
-          >
-            <textarea
-              value={tried}
-              onChange={(e) => setTried(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              className={textareaClass}
-            />
-          </Field>
-
-          <Field
-            label="Why does this matter beyond the individual?"
-            hint={"Who else is affected — a neighborhood, a sector, a workforce? What’s the scale?"}
-          >
-            <textarea
-              value={scale}
-              onChange={(e) => setScale(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              className={textareaClass}
-            />
-          </Field>
-
-          <Field
-            label="What would this Research Pod actually do together?"
-            hint="A pilot, a toolkit, a guide, a mapped process, a prototype — give voters a picture of the work, even a rough one."
-          >
-            <textarea
-              value={podWork}
-              onChange={(e) => setPodWork(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              className={textareaClass}
-            />
-          </Field>
-
-          <Field
-            label="What kinds of people or skills would make this Research Pod stronger?"
-            hint={"Be specific — “someone who has worked in city government,” “a designer,” “someone who has used this system themselves.”"}
-          >
-            <textarea
-              value={skillsNeeded}
-              onChange={(e) => setSkillsNeeded(e.target.value)}
-              maxLength={2000}
-              rows={3}
-              className={textareaClass}
-            />
-          </Field>
-
-          <Field label="Impact Track" hint="Optional — helps us connect your Pod to the right mentors and advisors. If it cuts across more than one, pick the primary.">
-            <div className="space-y-2">
-              {IMPACT_TRACKS.map((track) => (
-                <label
-                  key={track}
-                  className="flex cursor-pointer items-center gap-2 text-sm text-charcoal transition-colors duration-150 hover:text-ink"
-                >
-                  <input
-                    type="radio"
-                    name="impact_track"
-                    value={track}
-                    checked={impactTrack === track}
-                    onChange={() => setImpactTrack(track)}
-                    className="h-4 w-4 accent-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
-                  />
-                  {track}
-                </label>
-              ))}
-              <label className="flex cursor-pointer items-center gap-2 text-sm text-charcoal transition-colors duration-150 hover:text-ink">
-                <input
-                  type="radio"
-                  name="impact_track"
-                  value="Other"
-                  checked={impactTrack === "Other"}
-                  onChange={() => setImpactTrack("Other")}
-                  className="accent-teal"
-                />
-                Other
-              </label>
-              {impactTrack === "Other" && (
-                <input
-                  type="text"
-                  value={impactTrackOther}
-                  onChange={(e) => setImpactTrackOther(e.target.value)}
-                  placeholder="Specify..."
-                  className={`ml-6 ${inputClass}`}
-                />
-              )}
-            </div>
-          </Field>
-
-          <Field label="Cycle Theme Alignment" hint="Each Cycle recruits mentors and advisors around a specific industry theme. If your situation connects to the current theme, note it here.">
-            <div className="space-y-2">
-              <label className="flex cursor-pointer items-center gap-2 text-sm text-charcoal transition-colors duration-150 hover:text-ink">
-                <input
-                  type="radio"
-                  name="theme"
-                  checked={themeAlignment === "none"}
-                  onChange={() => setThemeAlignment("none")}
-                  className="accent-teal"
-                />
-                No particular connection
-              </label>
-              <label className="flex cursor-pointer items-center gap-2 text-sm text-charcoal transition-colors duration-150 hover:text-ink">
-                <input
-                  type="radio"
-                  name="theme"
-                  checked={themeAlignment === "direct"}
-                  onChange={() => setThemeAlignment("direct")}
-                  className="accent-teal"
-                />
-                My situation sits directly inside this theme
-              </label>
-              <label className="flex cursor-pointer items-center gap-2 text-sm text-charcoal transition-colors duration-150 hover:text-ink">
-                <input
-                  type="radio"
-                  name="theme"
-                  checked={themeAlignment === "adjacent"}
-                  onChange={() => setThemeAlignment("adjacent")}
-                  className="accent-teal"
-                />
-                My situation touches this theme from an adjacent angle
-              </label>
-            </div>
-            {themeAlignment !== "none" && (
-              <textarea
-                value={themeConnection}
-                onChange={(e) => setThemeConnection(e.target.value)}
-                maxLength={1000}
-                rows={2}
-                placeholder="Describe the connection briefly..."
-                className={`mt-3 ${textareaClass}`}
-              />
-            )}
-          </Field>
-        </section>
-      )}
-
-      {/* PART 6 — the tool's own rules, as a self-check */}
-      {step === 6 && (
-        <section className="space-y-6">
-          <div>
-            <h2 className="t-h3 text-ink">
-              Part 6 — Before You Submit
-            </h2>
-            <p className="mt-1 text-sm text-meta">
-              Read your distilled situation one more time. These are the same
-              rules the Triangulator held you to — check each box honestly.
-            </p>
-          </div>
-
-          <div className="rounded-card border border-ink/10 bg-white p-4">
-            {sitTitle.trim() && (
-              <p className="mb-1 text-sm font-semibold text-ink">
-                {sitTitle.trim()}
-              </p>
-            )}
-            <p className="text-sm italic text-charcoal">
-              &ldquo;{statementText}&rdquo;
-            </p>
-          </div>
-
-          <div className="space-y-3">
-            <CheckItem
-              checked={checkGrounded}
-              onChange={setCheckGrounded}
-              label="Every claim traces back to extracts on my map — evidence, not vibes"
-            />
-            <CheckItem
-              checked={checkActors}
-              onChange={setCheckActors}
-              label={"It points at real, specific actors — people I could name or find, not “society”"}
-            />
-            <CheckItem
-              checked={checkNoSolution}
-              onChange={setCheckNoSolution}
-              label="It proposes no solution — the situation stays open for the pod to frame"
-            />
-            <CheckItem
-              checked={checkParadox}
-              onChange={setCheckParadox}
-              label={"The paradox is self-undoing (X requires not-X) — not a mere trade-off or “it's complicated”"}
-            />
-            <CheckItem
-              checked={checkSamePicture}
-              onChange={setCheckSamePicture}
-              label="Two strangers reading this would picture the same situation"
-            />
-          </div>
-
-          {!allChecked && (
-            <p className="text-sm text-meta">
-              If any box is unchecked, revise before submitting — the workbook
-              is one tab away. A sharper situation earns more votes.
-            </p>
-          )}
-        </section>
-      )}
-
-      {/* Error */}
       {error && (
         <p
           role="alert"
@@ -788,37 +241,14 @@ export default function ProposeForm({
         </p>
       )}
 
-      {/* Navigation */}
-      <div className="mt-8 flex items-center justify-between border-t border-ink/10 pt-6">
-        <div>
-          {step > 1 && (
-            <button
-              onClick={() => goToStep((step - 1) as Step)}
-              className="btn btn-ghost btn-sm"
-            >
-              Back
-            </button>
-          )}
-        </div>
-        <div className="flex items-center gap-3">
-          {step < 6 ? (
-            <button
-              onClick={() => goToStep((step + 1) as Step)}
-              disabled={!canAdvance()}
-              className="btn btn-teal btn-sm"
-            >
-              Continue
-            </button>
-          ) : (
-            <button
-              onClick={handleSubmit}
-              disabled={submitting || !allChecked}
-              className="btn btn-teal btn-sm"
-            >
-              {submitting ? "Submitting..." : "Submit problem situation"}
-            </button>
-          )}
-        </div>
+      <div className="flex items-center justify-end border-t border-ink/10 pt-6">
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || !canSubmit}
+          className="btn btn-teal btn-sm"
+        >
+          {submitting ? "Submitting..." : "Submit problem situation"}
+        </button>
       </div>
     </div>
   );
@@ -835,13 +265,11 @@ const textareaClass =
 function Field({
   label,
   hint,
-  example,
   required,
   children,
 }: {
   label: string;
   hint?: string;
-  example?: string;
   required?: boolean;
   children: React.ReactNode;
 }) {
@@ -858,11 +286,6 @@ function Field({
       {hint && (
         <p className="text-xs leading-relaxed text-meta">{hint}</p>
       )}
-      {example && (
-        <p className="rounded-card border border-ink/10 bg-ink/[0.02] px-3 py-2 text-xs italic leading-relaxed text-meta">
-          {example}
-        </p>
-      )}
       {children}
     </div>
   );
@@ -873,27 +296,5 @@ function CharCount({ value, max }: { value: string; max: number }) {
     <p className="mt-1 text-right text-xs text-meta tabular-nums">
       {value.length}/{max}
     </p>
-  );
-}
-
-function CheckItem({
-  checked,
-  onChange,
-  label,
-}: {
-  checked: boolean;
-  onChange: (v: boolean) => void;
-  label: string;
-}) {
-  return (
-    <label className="flex cursor-pointer items-start gap-3 text-sm text-charcoal transition-colors duration-150 hover:text-ink">
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        className="mt-0.5 h-4 w-4 rounded border-ink/20 bg-white accent-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
-      />
-      <span>{label}</span>
-    </label>
   );
 }

--- a/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
@@ -140,7 +140,9 @@ export default function PodRegistration({
     return (
       <div className="rounded-card border border-dashed border-meta-soft bg-white p-12">
         <p className="text-sm text-meta">
-          No pods available for registration yet.
+          No pods here yet — the vote is still being finalized into a
+          shortlist. Check back shortly; when the pods are announced, this is
+          where you&apos;ll join one.
         </p>
       </div>
     );

--- a/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
@@ -77,7 +77,7 @@ export default async function VotePage({
           {cycle.name}
         </Link>
         <h1 className="t-h1 mt-2 text-ink">
-          Vote on problem statements
+          Vote on problem situations
         </h1>
         <p className="mt-1 text-sm text-charcoal">
           Allocate your votes to the problems you want the community to tackle.

--- a/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/page.tsx
@@ -27,7 +27,9 @@ export default async function VotePage({
   const serviceClient = createServiceClient();
   const { data: config } = await serviceClient
     .from("cycle_config")
-    .select("voting_open, voting_close, submitter_votes, non_submitter_votes")
+    .select(
+      "voting_open, voting_close, submitter_votes, non_submitter_votes, pod_registration_open, pod_registration_close"
+    )
     .eq("cycle_id", cycleId)
     .maybeSingle();
 
@@ -80,6 +82,12 @@ export default async function VotePage({
         <p className="mt-1 text-sm text-charcoal">
           Allocate your votes to the problems you want the community to tackle.
         </p>
+        <Link
+          href={`/cycles/${cycle.id}/proposals`}
+          className="mt-2 inline-block text-sm font-semibold text-teal-deep hover:text-teal"
+        >
+          Read the full proposals in the gallery →
+        </Link>
       </div>
 
       {isOpen ? (
@@ -92,9 +100,12 @@ export default async function VotePage({
       ) : (
         <div className="rounded-card border border-ink/10 bg-white p-6 shadow-card">
           <p className="text-charcoal">
-            {config
-              ? "Voting is not currently open."
-              : "This cycle isn't fully configured yet — the voting window hasn't been scheduled. If you expected it to be open, let an organizer know."}
+            {!config
+              ? "This cycle isn't fully configured yet — the voting window hasn't been scheduled. If you expected it to be open, let an organizer know."
+              : config.voting_close &&
+                  now > (parseWindow(config.voting_close) as Date)
+                ? "Voting has closed. The top-voted statements become the cycle's pods."
+                : "Voting is not currently open."}
           </p>
           {config?.voting_open &&
             now < (parseWindow(config.voting_open) as Date) && (
@@ -102,6 +113,28 @@ export default async function VotePage({
                 Opens {fmtLabDateTime(config.voting_open)}
               </p>
             )}
+          {config?.voting_close &&
+            now > (parseWindow(config.voting_close) as Date) &&
+            (windowOpen(
+              config.pod_registration_open,
+              config.pod_registration_close,
+              now
+            ) ? (
+              <Link
+                href={`/cycles/${cycle.id}/register-pods`}
+                className="mt-3 inline-block text-sm font-semibold text-teal-deep hover:text-teal"
+              >
+                Pod registration is open — join a pod →
+              </Link>
+            ) : (
+              <p className="mt-2 text-sm text-meta">
+                Pod registration opens once the shortlist is finalized
+                {config.pod_registration_open
+                  ? ` — ${fmtLabDateTime(config.pod_registration_open)}`
+                  : ""}
+                .
+              </p>
+            ))}
         </div>
       )}
     </div>

--- a/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
@@ -5,6 +5,16 @@ import { ExternalLink } from "lucide-react";
 
 interface ProposalData {
   about?: { background?: string; experience?: string };
+  // Triangulator-aligned shape (current submissions)…
+  situation?: {
+    title?: string;
+    description?: string;
+    openness?: string;
+    paradox?: string;
+    beneficiaries?: string;
+    problematization?: string;
+  };
+  // …and the legacy who/need/barrier/success block (pre-alignment rows).
   problem?: { who?: string; need?: string; barrier?: string; success?: string };
   statement?: { text?: string; question?: string; repo_url?: string };
   voter_context?: {
@@ -198,7 +208,7 @@ export default function VoteBallot({
     return (
       <div className="rounded-card border border-dashed border-meta-soft bg-white p-12">
         <p className="text-sm text-meta">
-          No problem statements have been submitted yet.
+          No problem situations have been submitted yet.
         </p>
       </div>
     );
@@ -249,7 +259,7 @@ export default function VoteBallot({
         {statements.map((stmt) => {
           const pd = stmt.proposal_data;
           const isExpanded = expandedId === stmt.id;
-          const hasDetails = pd?.problem || pd?.voter_context;
+          const hasDetails = pd?.situation || pd?.problem || pd?.voter_context;
           // Scheme-checked before rendering as an href — rows written before
           // the schema restricted repo_url to http(s) are untrusted here.
           const rawRepo = pd?.statement?.repo_url;
@@ -271,7 +281,10 @@ export default function VoteBallot({
               className="rounded-card border border-ink/10 bg-white shadow-card transition-colors duration-150 hover:border-ink/20"
             >
               <div className="p-4">
-                {/* Problem statement */}
+                {/* The problem situation, distilled */}
+                {pd?.situation?.title && (
+                  <p className="lbl lbl-teal mb-1">{pd.situation.title}</p>
+                )}
                 <p className="font-semibold tracking-tight text-ink">
                   {stmt.statement_text}
                 </p>
@@ -320,6 +333,36 @@ export default function VoteBallot({
                 {/* Expanded details */}
                 {isExpanded && pd && (
                   <div className="mt-4 space-y-3 border-t border-ink/10 pt-4">
+                    {pd.situation?.description && (
+                      <DetailBlock
+                        label="The situation"
+                        text={pd.situation.description}
+                      />
+                    )}
+                    {pd.situation?.openness && (
+                      <DetailBlock
+                        label="What makes it open"
+                        text={pd.situation.openness}
+                      />
+                    )}
+                    {pd.situation?.paradox && (
+                      <DetailBlock
+                        label="The paradox"
+                        text={pd.situation.paradox}
+                      />
+                    )}
+                    {pd.situation?.beneficiaries && (
+                      <DetailBlock
+                        label="Who benefits from its persistence"
+                        text={pd.situation.beneficiaries}
+                      />
+                    )}
+                    {pd.situation?.problematization && (
+                      <DetailBlock
+                        label="Pressure-test"
+                        text={pd.situation.problematization}
+                      />
+                    )}
                     {pd.problem?.who && (
                       <DetailBlock
                         label="Who is struggling"

--- a/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/vote/vote-ballot.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { ExternalLink } from "lucide-react";
 
 interface ProposalData {
   about?: { background?: string; experience?: string };
   problem?: { who?: string; need?: string; barrier?: string; success?: string };
-  statement?: { text?: string; question?: string };
+  statement?: { text?: string; question?: string; repo_url?: string };
   voter_context?: {
     tried?: string;
     scale?: string;
@@ -249,6 +250,11 @@ export default function VoteBallot({
           const pd = stmt.proposal_data;
           const isExpanded = expandedId === stmt.id;
           const hasDetails = pd?.problem || pd?.voter_context;
+          // Scheme-checked before rendering as an href — rows written before
+          // the schema restricted repo_url to http(s) are untrusted here.
+          const rawRepo = pd?.statement?.repo_url;
+          const mapUrl =
+            rawRepo && /^https?:\/\//i.test(rawRepo) ? rawRepo : null;
 
           const mine = myVotes[stmt.id] ?? 0;
           // Zero-state cards show the stepper directly so votes can be added;
@@ -275,6 +281,20 @@ export default function VoteBallot({
                   <p className="mt-2 text-sm italic text-slate">
                     {pd.statement.question}
                   </p>
+                )}
+
+                {/* Triangulator map — always visible, not behind the expand:
+                    the evidence trail is what voters are being asked to weigh */}
+                {mapUrl && (
+                  <a
+                    href={mapUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-flex items-center gap-1 text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline"
+                  >
+                    View the map
+                    <ExternalLink className="h-3 w-3" aria-hidden />
+                  </a>
                 )}
 
                 {/* Submitter background */}

--- a/app/(dashboard)/cycles/cycle-phase-indicator.tsx
+++ b/app/(dashboard)/cycles/cycle-phase-indicator.tsx
@@ -60,7 +60,7 @@ const PHASES = [
 /* ── Helpers ───────────────────────────────────────────────────────── */
 
 const OPERATIONAL_WINDOWS = [
-  { label: "Problem Statements", field: "problem_statement", route: "propose" },
+  { label: "Problem Situations", field: "problem_statement", route: "propose" },
   { label: "Voting", field: "voting", route: "vote" },
   { label: "Pod Registration", field: "pod_registration", route: "register-pods" },
   { label: "Solution Proposals", field: "solution_proposal", route: "solutions" },

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -824,8 +824,8 @@ export default async function DashboardPage() {
     return nowMs >= open.getTime() && nowMs <= close.getTime() ? c : null;
   };
   const WINDOW_TODOS = [
-    { k: "problem_statement", title: "Submit a problem statement", cta: "Propose", sub: "propose" },
-    { k: "voting", title: "Vote on problem statements", cta: "Vote", sub: "vote" },
+    { k: "problem_statement", title: "Submit a problem situation", cta: "Propose", sub: "propose" },
+    { k: "voting", title: "Vote on problem situations", cta: "Vote", sub: "vote" },
     { k: "pod_registration", title: "Register for a pod", cta: "Choose pod", sub: "register-pods" },
     { k: "solution_proposal", title: "Submit your solution proposal", cta: "Propose", sub: "solutions" },
     { k: "solution_voting", title: "Cast your solution ballot", cta: "Vote", sub: "solution-vote" },

--- a/app/(dashboard)/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/pods/[pod_id]/page.tsx
@@ -140,7 +140,7 @@ export default async function PodDetailPage({
       {ps?.statement_text && (
         <div className="mb-6 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card">
           <h3 className="lbl mb-1">
-            Problem statement
+            Problem situation
           </h3>
           <p className="text-charcoal">{ps.statement_text}</p>
         </div>

--- a/app/(dashboard)/survey/[slug]/results/page.tsx
+++ b/app/(dashboard)/survey/[slug]/results/page.tsx
@@ -203,9 +203,9 @@ export default async function SurveyResultsPage({
           sublabel={`toward ${RESPONSE_GOAL.toLocaleString()}`}
         />
         <StatCard
-          label="Shared for the commons"
-          value={agg.observations.length.toLocaleString()}
-          sublabel="approved & visible below"
+          label="Curated for the commons"
+          value={agg.approved.toLocaleString()}
+          sublabel="reviewed & approved"
         />
       </div>
 
@@ -241,18 +241,21 @@ export default async function SurveyResultsPage({
         </div>
         {agg.observations.length === 0 ? (
           <p className="text-sm text-meta">
-            No observations have been published yet — check back as the cohort
-            reviews what&apos;s come in.
+            No observations have come in yet — take the survey and share it
+            with someone close to the problem.
           </p>
         ) : (
           <div className="grid gap-4">
-            {agg.observations.map((o, i) => (
+            {/* id anchors (#r-<response id>) are the citation targets the
+                Triangulator's pre-loaded extract cards deep-link back to. */}
+            {agg.observations.map((o) => (
               <div
-                key={i}
-                className="rounded-card border border-ink/10 bg-white p-5 shadow-card"
+                key={o.id}
+                id={`r-${o.id}`}
+                className="scroll-mt-24 rounded-card border border-ink/10 bg-white p-5 shadow-card target:ring-2 target:ring-teal"
               >
                 <p className="text-sm text-charcoal">{o.observation}</p>
-                <div className="mt-2 flex flex-wrap gap-2 text-xs text-meta">
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-meta">
                   {o.standpoint
                     .map((s) => standpointLabels.get(s) ?? s)
                     .map((label) => (
@@ -263,7 +266,14 @@ export default async function SurveyResultsPage({
                         {label}
                       </span>
                     ))}
-                  <span className="ml-auto">{fmtDate(o.created_at)}</span>
+                  {o.pending && (
+                    <span className="rounded-full border border-ink/15 px-2 py-0.5 text-meta">
+                      awaiting review
+                    </span>
+                  )}
+                  <span className="ml-auto">
+                    #{o.id} · {fmtDate(o.created_at)}
+                  </span>
                 </div>
               </div>
             ))}

--- a/lib/content/survey-results.test.ts
+++ b/lib/content/survey-results.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { redactContactInfo } from "./survey-results";
+
+// The participant aggregate never selects the envelope's contact columns, but
+// respondents sometimes type contact details into the observation body itself.
+// This pins the scrub that keeps them off the participant surface.
+describe("redactContactInfo", () => {
+  it("strips email addresses", () => {
+    expect(redactContactInfo("reach me at jane.doe+tag@example.org please")).toBe(
+      "reach me at [contact removed] please"
+    );
+  });
+
+  it("strips phone numbers in common shapes", () => {
+    expect(redactContactInfo("call 301-635-9754")).toBe("call [contact removed]");
+    expect(redactContactInfo("call (502) 451-4564 or 5024190426")).toBe(
+      "call [contact removed] or [contact removed]"
+    );
+    expect(redactContactInfo("at +1 914 826 7312 today")).toBe(
+      "at [contact removed] today"
+    );
+  });
+
+  it("leaves ordinary text, years, and counts alone", () => {
+    const text =
+      "In 2026, 40 participants met at the library; turnout rose 15% over 2024.";
+    expect(redactContactInfo(text)).toBe(text);
+  });
+});

--- a/lib/content/survey-results.ts
+++ b/lib/content/survey-results.ts
@@ -125,6 +125,19 @@ export function buildSurveyExportTable(data: SurveyExportData): {
   return { columns, records };
 }
 
+/**
+ * Strip email addresses and phone-number-shaped sequences from free text
+ * before it reaches the participant aggregate. The envelope's contact columns
+ * are never selected there, but respondents sometimes type contact details
+ * into the observation itself — the participant surface must not carry them.
+ * (The admin/poderator table intentionally keeps the raw text.)
+ */
+export function redactContactInfo(text: string): string {
+  return text
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "[contact removed]")
+    .replace(/(\+?1[-. ]?)?\(?\d{3}\)?[-. ]?\d{3}[-. ]?\d{4}\b/g, "[contact removed]");
+}
+
 export interface SurveyAggregate {
   total: number; // non-rejected responses
   approved: number; // curated into the commons
@@ -187,7 +200,7 @@ export async function getSurveyAggregate(
     .slice(0, 100)
     .map((r) => ({
       id: r.id as number,
-      observation: r.observation as string,
+      observation: redactContactInfo(r.observation as string),
       standpoint: (r.standpoint as string[] | null) ?? [],
       salience: r.salience as number | null,
       created_at: r.created_at as string,

--- a/lib/content/survey-results.ts
+++ b/lib/content/survey-results.ts
@@ -127,19 +127,26 @@ export function buildSurveyExportTable(data: SurveyExportData): {
 
 export interface SurveyAggregate {
   total: number; // non-rejected responses
+  approved: number; // curated into the commons
   salience: number[]; // counts indexed 0..4 for values 1..5
   standpointCounts: { key: string; label: string; count: number }[];
   observations: {
+    id: number;
     observation: string;
     standpoint: string[];
     salience: number | null;
     created_at: string;
+    pending: boolean;
   }[];
 }
 
 /**
- * The privacy-safe participant view: distribution signals over non-rejected
- * responses + the approved observations only. Never selects contact fields.
+ * The privacy-safe participant view: distribution signals + observation text
+ * over non-rejected responses. Never selects contact fields. Pending rows are
+ * included (flagged, so the page can mark them "awaiting review") — the cycle
+ * runs on the full field of observations, and the Triangulator's pre-loaded
+ * cards cite them by anchor (#r-<id>); only rejection hides a row. The
+ * moderation overlay keeps its meaning through `approved` (the commons count).
  */
 export async function getSurveyAggregate(
   surveyId: number,
@@ -148,7 +155,9 @@ export async function getSurveyAggregate(
   const supabase = createServiceClient();
   const { data } = await supabase
     .from("survey_responses")
-    .select("observation, standpoint, salience, created_at, moderation_status")
+    .select(
+      "id, observation, standpoint, salience, created_at, moderation_status"
+    )
     .eq("field_survey_id", surveyId)
     .neq("moderation_status", "rejected")
     .order("created_at", { ascending: false });
@@ -174,14 +183,22 @@ export async function getSurveyAggregate(
   }
 
   const observations = rows
-    .filter((r) => r.moderation_status === "approved" && r.observation)
-    .slice(0, 50)
+    .filter((r) => r.observation)
+    .slice(0, 100)
     .map((r) => ({
+      id: r.id as number,
       observation: r.observation as string,
       standpoint: (r.standpoint as string[] | null) ?? [],
       salience: r.salience as number | null,
       created_at: r.created_at as string,
+      pending: r.moderation_status === "pending",
     }));
 
-  return { total: rows.length, salience, standpointCounts, observations };
+  return {
+    total: rows.length,
+    approved: rows.filter((r) => r.moderation_status === "approved").length,
+    salience,
+    standpointCounts,
+    observations,
+  };
 }

--- a/lib/validations/votes.test.ts
+++ b/lib/validations/votes.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { problemStatementSchema } from "./votes";
+
+/* Pins the proposal_data.statement.repo_url contract: optional, but when
+   present it must be a real http(s) URL — it is rendered as an href on the
+   ballot, the gallery, and the cycle page, so javascript:/data: schemes
+   must fail at the schema, not at render time. */
+
+const base = {
+  cycle_id: 3,
+  statement_text: "A food truck operator needs to navigate procurement.",
+  proposal_data: {
+    problem: {
+      who: "a food truck operator",
+      need: "navigate procurement",
+      barrier: "the form assumes a registered entity",
+      success: "she reaches the review stage",
+    },
+    statement: {
+      text: "A food truck operator needs to navigate procurement.",
+      question: "How might we make procurement navigable?",
+    },
+  },
+};
+
+function withRepoUrl(repo_url?: string) {
+  return {
+    ...base,
+    proposal_data: {
+      ...base.proposal_data,
+      statement: { ...base.proposal_data.statement, repo_url },
+    },
+  };
+}
+
+describe("problemStatementSchema repo_url", () => {
+  it("accepts a submission without repo_url", () => {
+    expect(problemStatementSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("accepts an https GitHub URL and keeps it through parse", () => {
+    const parsed = problemStatementSchema.parse(
+      withRepoUrl("https://github.com/some-org/some-triad-repo")
+    );
+    expect(parsed.proposal_data?.statement.repo_url).toBe(
+      "https://github.com/some-org/some-triad-repo"
+    );
+  });
+
+  it("rejects non-http(s) schemes even when they parse as URLs", () => {
+    expect(
+      problemStatementSchema.safeParse(withRepoUrl("javascript:alert(1)"))
+        .success
+    ).toBe(false);
+    expect(
+      problemStatementSchema.safeParse(withRepoUrl("data:text/html,hi"))
+        .success
+    ).toBe(false);
+  });
+
+  it("rejects strings that are not URLs at all", () => {
+    expect(
+      problemStatementSchema.safeParse(withRepoUrl("github dot com")).success
+    ).toBe(false);
+  });
+
+  it("rejects URLs over 500 characters", () => {
+    expect(
+      problemStatementSchema.safeParse(
+        withRepoUrl("https://github.com/" + "a".repeat(500))
+      ).success
+    ).toBe(false);
+  });
+});

--- a/lib/validations/votes.test.ts
+++ b/lib/validations/votes.test.ts
@@ -37,17 +37,26 @@ function withRepoUrl(repo_url?: string) {
 }
 
 describe("problemStatementSchema situation block", () => {
-  it("requires the Triangulator workbook fields (title/description/openness/paradox)", () => {
-    const missingParadox = {
+  it("requires a situation title, the one field the lean form collects", () => {
+    const missingTitle = {
       ...base,
       proposal_data: {
         ...base.proposal_data,
-        situation: { ...base.proposal_data.situation, paradox: "" },
+        situation: { ...base.proposal_data.situation, title: "" },
       },
     };
-    expect(problemStatementSchema.safeParse(missingParadox).success).toBe(
-      false
-    );
+    expect(problemStatementSchema.safeParse(missingTitle).success).toBe(false);
+  });
+
+  it("accepts a lean submission — title only, depth lives in the map", () => {
+    const lean = {
+      ...base,
+      proposal_data: {
+        ...base.proposal_data,
+        situation: { title: "Procurement locks out the informal economy" },
+      },
+    };
+    expect(problemStatementSchema.safeParse(lean).success).toBe(true);
   });
 
   it("accepts the optional pressure-test and beneficiaries fields", () => {

--- a/lib/validations/votes.test.ts
+++ b/lib/validations/votes.test.ts
@@ -10,11 +10,14 @@ const base = {
   cycle_id: 3,
   statement_text: "A food truck operator needs to navigate procurement.",
   proposal_data: {
-    problem: {
-      who: "a food truck operator",
-      need: "navigate procurement",
-      barrier: "the form assumes a registered entity",
-      success: "she reaches the review stage",
+    situation: {
+      title: "Procurement locks out the informal economy",
+      description:
+        "An open, networked condition: city contracts assume a formal back office.",
+      openness:
+        "Many actors (agencies, operators, banks), no single owner, no known path.",
+      paradox:
+        "Winning a contract requires the formal infrastructure that only contract revenue would fund.",
     },
     statement: {
       text: "A food truck operator needs to navigate procurement.",
@@ -32,6 +35,52 @@ function withRepoUrl(repo_url?: string) {
     },
   };
 }
+
+describe("problemStatementSchema situation block", () => {
+  it("requires the Triangulator workbook fields (title/description/openness/paradox)", () => {
+    const missingParadox = {
+      ...base,
+      proposal_data: {
+        ...base.proposal_data,
+        situation: { ...base.proposal_data.situation, paradox: "" },
+      },
+    };
+    expect(problemStatementSchema.safeParse(missingParadox).success).toBe(
+      false
+    );
+  });
+
+  it("accepts the optional pressure-test and beneficiaries fields", () => {
+    const full = {
+      ...base,
+      proposal_data: {
+        ...base.proposal_data,
+        situation: {
+          ...base.proposal_data.situation,
+          beneficiaries: "Incumbent vendors; the compliance industry.",
+          problematization: "Assumes operators want city contracts at all.",
+        },
+      },
+    };
+    expect(problemStatementSchema.safeParse(full).success).toBe(true);
+  });
+
+  it("still accepts the legacy problem block on old rows (read-only compat)", () => {
+    const legacy = {
+      ...base,
+      proposal_data: {
+        ...base.proposal_data,
+        problem: {
+          who: "a food truck operator",
+          need: "navigate procurement",
+          barrier: "the form assumes a registered entity",
+          success: "she reaches the review stage",
+        },
+      },
+    };
+    expect(problemStatementSchema.safeParse(legacy).success).toBe(true);
+  });
+});
 
 describe("problemStatementSchema repo_url", () => {
   it("accepts a submission without repo_url", () => {

--- a/lib/validations/votes.ts
+++ b/lib/validations/votes.ts
@@ -14,6 +14,15 @@ export const proposalDataSchema = z.object({
   statement: z.object({
     text: z.string().min(1).max(2000),
     question: z.string().min(1).max(2000),
+    // Where the submitter's Triangulator working folder lives (usually a
+    // GitHub repo). Scheme-restricted: .url() alone admits javascript:/data:
+    // URLs, and this value is rendered as an href on the ballot and gallery.
+    repo_url: z
+      .string()
+      .url("Must be a valid URL")
+      .max(500)
+      .regex(/^https?:\/\//i, "Must be an http(s) URL")
+      .optional(),
   }),
   context: z.object({
     impact_track: z.string().max(200).optional(),

--- a/lib/validations/votes.ts
+++ b/lib/validations/votes.ts
@@ -5,12 +5,28 @@ export const proposalDataSchema = z.object({
     background: z.string().max(500).optional(),
     experience: z.enum(["lived", "witnessed", "both"]).optional(),
   }).optional(),
-  problem: z.object({
-    who: z.string().min(1).max(2000),
-    need: z.string().min(1).max(2000),
-    barrier: z.string().min(1).max(2000),
-    success: z.string().min(1).max(2000),
+  // The Problem Situation, in the Triangulator workbook's own fields — the
+  // wizard asks for exactly what the Deepen stages made the submitter write
+  // (title/description/openness from Stage 1, paradox + pressure-test from
+  // Stage 5), so submission is a paste, not a re-derivation. The legacy
+  // `problem` block (who/need/barrier/success) is accepted read-only for old
+  // rows but no longer collected.
+  situation: z.object({
+    title: z.string().min(1).max(200),
+    description: z.string().min(1).max(2000),
+    openness: z.string().min(1).max(2000),
+    paradox: z.string().min(1).max(2000),
+    beneficiaries: z.string().max(2000).optional(),
+    problematization: z.string().max(2000).optional(),
   }),
+  problem: z
+    .object({
+      who: z.string().min(1).max(2000),
+      need: z.string().min(1).max(2000),
+      barrier: z.string().min(1).max(2000),
+      success: z.string().min(1).max(2000),
+    })
+    .optional(),
   statement: z.object({
     text: z.string().min(1).max(2000),
     question: z.string().min(1).max(2000),
@@ -35,13 +51,17 @@ export const proposalDataSchema = z.object({
     pod_work: z.string().max(2000).optional(),
     skills_needed: z.string().max(2000).optional(),
   }).optional(),
-  checklist: z.object({
-    real_person: z.boolean(),
-    action_not_thing: z.boolean(),
-    no_solution: z.boolean(),
-    specific_outcome: z.boolean(),
-    same_picture: z.boolean(),
-  }).optional(),
+  // Pre-submit self-check, in the Triangulator's own rules: evidence-grounded,
+  // real actors, no solutions, a self-undoing paradox, one shared picture.
+  checklist: z
+    .object({
+      grounded_in_evidence: z.boolean(),
+      real_actors: z.boolean(),
+      no_solution: z.boolean(),
+      paradox_self_undoing: z.boolean(),
+      same_picture: z.boolean(),
+    })
+    .optional(),
 });
 
 export const problemStatementSchema = z.object({

--- a/lib/validations/votes.ts
+++ b/lib/validations/votes.ts
@@ -5,17 +5,17 @@ export const proposalDataSchema = z.object({
     background: z.string().max(500).optional(),
     experience: z.enum(["lived", "witnessed", "both"]).optional(),
   }).optional(),
-  // The Problem Situation, in the Triangulator workbook's own fields — the
-  // wizard asks for exactly what the Deepen stages made the submitter write
-  // (title/description/openness from Stage 1, paradox + pressure-test from
-  // Stage 5), so submission is a paste, not a re-derivation. The legacy
-  // `problem` block (who/need/barrier/success) is accepted read-only for old
-  // rows but no longer collected.
+  // The Problem Situation, named in the Triangulator's own grammar. The form
+  // leans on the map link for depth — openness, paradox, and evidence live in
+  // the linked working folder, so only the name is required here; everything
+  // else is optional context for voters who won't open the repo. The fields
+  // keep the workbook's names so a fuller submission (or an older row) still
+  // renders under the same labels.
   situation: z.object({
     title: z.string().min(1).max(200),
-    description: z.string().min(1).max(2000),
-    openness: z.string().min(1).max(2000),
-    paradox: z.string().min(1).max(2000),
+    description: z.string().max(2000).optional(),
+    openness: z.string().max(2000).optional(),
+    paradox: z.string().max(2000).optional(),
     beneficiaries: z.string().max(2000).optional(),
     problematization: z.string().max(2000).optional(),
   }),


### PR DESCRIPTION
## What

Promotes today&#39;s sprint-day work to production (theupskillinglabs.org) — the range `d260022..07c59b5`, i.e. PRs #300–#304 merged to dev with green CI.

## Changes

- **#302** — read-only proposal gallery (all phases); Triangulator repo links on submissions, ballot, gallery; civics survey results opened to cycle participants: non-rejected observations with &#34;awaiting review&#34; chips, stable `#r-<id>` anchors (cited by the Triangulator&#39;s 48 pre-loaded cards), contact columns never selected.
- **#302 (3rd commit)** — propose→vote→pods arc fixes: confirmation links to gallery/cycle, phase-aware vote-closed state, voting→registration interlude card, explained pods empty state; `redactContactInfo` scrubs emails/phone shapes from the participant aggregate (unit-tested).
- **#303** — submission renamed **problem situation** on every participant/admin surface; wizard restructured around the Triangulator workbook&#39;s fields; gallery/ballot lead with the situation title.
- **#304** — the wizard collapsed to one short page: map link (required, first), situation name, one distilled sentence, optional How-Might-We + context, single self-check box. `situation.title` required in the schema; depth fields optional (the map holds them).
- **#300/#301 range** — profile save fixes + pod activity feed (already reviewed on their own PRs).

## Verify

- [x] `npm run lint` passes (pre-existing warnings only)
- [x] `npm run test` passes — 411 tests at `07c59b5`
- [x] `npm run build` passes
- [x] `ci` check green on every constituent PR

## Manual testing

1. `/survey/civics/results` as an enrolled participant → full observation list, &#34;awaiting review&#34; chips, `#r-<id>` anchor highlight on deep links, no contact info.
2. `/cycles/{id}/propose` → one-page form; submit gated on map link + name + sentence + self-check.
3. `/cycles/{id}/proposals` and `/vote` → situation title above the distilled sentence; map links open the triad repo.

## Database

- [x] No schema change — no new migrations in this range; JSON-contract changes inside the existing `proposal_data` column only.

https://claude.ai/code/session_01SAc8xUJEjNMKrutoCZVHwe