### PR TITLE
Add Learning Library admin interface and resource management

### DIFF
--- a/app/(dashboard)/admin/content/library-admin.tsx
+++ b/app/(dashboard)/admin/content/library-admin.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useState } from "react";
+import { formatDate } from "@/lib/format/date";
+import { RESOURCE_CONTENT_TYPES } from "@/lib/validations/resource-admin";
+
+/* The /admin/content Library surface — add a resource (a link-out to a
+   view-only Google Doc, a recording, a course, …) and manage the catalog.
+   Each row is metadata + an external `url`; the public /library grid links
+   straight out to that url. Add-form on top, then the list grouped by status.
+   Mirrors StoriesAdmin: the parent holds the list, each row owns its edit
+   state and reconciles from the API response. */
+
+export interface AdminResource {
+  id: number;
+  slug: string;
+  title: string;
+  content_type: (typeof RESOURCE_CONTENT_TYPES)[number];
+  url: string | null;
+  summary: string | null;
+  meta: string | null;
+  author: string | null;
+  status: "published" | "draft";
+  created_at: string;
+}
+
+const TYPES: [AdminResource["content_type"], string][] = [
+  ["guide", "Guide"],
+  ["recording", "Recording"],
+  ["template", "Template"],
+  ["course", "Course"],
+  ["playbook", "Playbook"],
+];
+
+const inputCls =
+  "w-full rounded-card border border-ink/15 bg-white px-3 py-2 text-sm text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal";
+
+export default function LibraryAdmin({ initial }: { initial: AdminResource[] }) {
+  const [rows, setRows] = useState<AdminResource[]>(initial);
+
+  function upsertRow(row: AdminResource) {
+    setRows((prev) => {
+      const i = prev.findIndex((r) => r.id === row.id);
+      if (i === -1) return [row, ...prev];
+      const next = [...prev];
+      next[i] = row;
+      return next;
+    });
+  }
+
+  async function patch(id: number, body: Record<string, unknown>) {
+    const res = await fetch(`/api/admin/resources/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}));
+      throw new Error(d.error || "Save failed");
+    }
+    upsertRow((await res.json()) as AdminResource);
+  }
+
+  async function remove(id: number) {
+    const res = await fetch(`/api/admin/resources/${id}`, { method: "DELETE" });
+    if (res.ok) setRows((prev) => prev.filter((r) => r.id !== id));
+  }
+
+  const groups: [string, AdminResource["status"]][] = [
+    ["Published", "published"],
+    ["Drafts", "draft"],
+  ];
+
+  return (
+    <div className="space-y-10">
+      <AddResourceForm onCreated={upsertRow} />
+
+      {groups.map(([label, status]) => {
+        const g = rows.filter((r) => r.status === status);
+        return (
+          <section key={status}>
+            <h3 className="lbl mb-3">
+              {label} · {g.length}
+            </h3>
+            {g.length ? (
+              <div className="space-y-4">
+                {g.map((r) => (
+                  <ResourceRow key={r.id} row={r} onPatch={patch} onRemove={remove} />
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-meta">None yet.</p>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function AddResourceForm({
+  onCreated,
+}: {
+  onCreated: (row: AdminResource) => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [url, setUrl] = useState("");
+  const [contentType, setContentType] =
+    useState<AdminResource["content_type"]>("guide");
+  const [summary, setSummary] = useState("");
+  const [meta, setMeta] = useState("");
+  const [author, setAuthor] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(status: "published" | "draft") {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/resources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          url: url.trim(),
+          content_type: contentType,
+          summary: summary.trim() || null,
+          meta: meta.trim() || null,
+          author: author.trim() || null,
+          status,
+        }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        throw new Error(d.error || "Could not add resource");
+      }
+      onCreated((await res.json()) as AdminResource);
+      setTitle("");
+      setUrl("");
+      setContentType("guide");
+      setSummary("");
+      setMeta("");
+      setAuthor("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const canSubmit = title.trim().length > 0 && url.trim().length > 0 && !busy;
+
+  return (
+    <div className="rounded-card border border-ink/10 bg-white p-5 shadow-card">
+      <h3 className="mb-1 t-h4 text-ink">Add a resource</h3>
+      <p className="mb-4 text-sm text-meta">
+        Paste a link (a view-only Google Doc works well) and a title. It appears
+        on the public Library the moment it&apos;s published.
+      </p>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block sm:col-span-2">
+          <span className="lbl mb-1 block">Title</span>
+          <input
+            className={inputCls}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Prompting basics for benefits casework"
+          />
+        </label>
+        <label className="block sm:col-span-2">
+          <span className="lbl mb-1 block">Link (URL)</span>
+          <input
+            className={inputCls}
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://docs.google.com/document/d/…"
+          />
+        </label>
+        <label className="block">
+          <span className="lbl mb-1 block">Type</span>
+          <select
+            className={inputCls}
+            value={contentType}
+            onChange={(e) =>
+              setContentType(e.target.value as AdminResource["content_type"])
+            }
+          >
+            {TYPES.map(([v, l]) => (
+              <option key={v} value={v}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="lbl mb-1 block">Label (optional)</span>
+          <input
+            className={inputCls}
+            value={meta}
+            onChange={(e) => setMeta(e.target.value)}
+            placeholder="10 min read"
+          />
+        </label>
+        <label className="block">
+          <span className="lbl mb-1 block">Author (optional)</span>
+          <input
+            className={inputCls}
+            value={author}
+            onChange={(e) => setAuthor(e.target.value)}
+            placeholder="The Upskilling Labs"
+          />
+        </label>
+      </div>
+
+      <label className="mt-3 block">
+        <span className="lbl mb-1 block">Summary (optional)</span>
+        <textarea
+          className={inputCls}
+          rows={2}
+          value={summary}
+          onChange={(e) => setSummary(e.target.value)}
+          placeholder="One line describing what this is."
+        />
+      </label>
+
+      {error && (
+        <p className="mt-2 text-sm" style={{ color: "var(--red)" }} role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <button
+          className="btn btn-teal px-4 py-2 text-sm"
+          type="button"
+          disabled={!canSubmit}
+          onClick={() => submit("published")}
+        >
+          {busy ? "…" : "Add & publish"}
+        </button>
+        <button
+          className="btn btn-ghost px-4 py-2 text-sm"
+          type="button"
+          disabled={!canSubmit}
+          onClick={() => submit("draft")}
+        >
+          Save as draft
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ResourceRow({
+  row,
+  onPatch,
+  onRemove,
+}: {
+  row: AdminResource;
+  onPatch: (id: number, body: Record<string, unknown>) => Promise<void>;
+  onRemove: (id: number) => Promise<void>;
+}) {
+  const [title, setTitle] = useState(row.title);
+  const [url, setUrl] = useState(row.url ?? "");
+  const [contentType, setContentType] = useState(row.content_type);
+  const [summary, setSummary] = useState(row.summary ?? "");
+  const [meta, setMeta] = useState(row.meta ?? "");
+  const [author, setAuthor] = useState(row.author ?? "");
+  const [busy, setBusy] = useState(false);
+  const [confirmDel, setConfirmDel] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function editedFields() {
+    return {
+      title: title.trim(),
+      url: url.trim(),
+      content_type: contentType,
+      summary: summary.trim() || null,
+      meta: meta.trim() || null,
+      author: author.trim() || null,
+    };
+  }
+
+  async function act(body: Record<string, unknown>) {
+    setBusy(true);
+    setError(null);
+    try {
+      await onPatch(row.id, body);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-card border border-ink/10 bg-white p-5 shadow-card">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <span className="text-xs text-meta tabular-nums">
+          #{row.id} · added {formatDate(row.created_at)} · /library/{row.slug}
+        </span>
+        {row.url && (
+          <a
+            className="text-xs text-teal underline"
+            href={row.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open link ↗
+          </a>
+        )}
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="block sm:col-span-2">
+          <span className="lbl mb-1 block">Title</span>
+          <input className={inputCls} value={title} onChange={(e) => setTitle(e.target.value)} />
+        </label>
+        <label className="block sm:col-span-2">
+          <span className="lbl mb-1 block">Link (URL)</span>
+          <input className={inputCls} value={url} onChange={(e) => setUrl(e.target.value)} />
+        </label>
+        <label className="block">
+          <span className="lbl mb-1 block">Type</span>
+          <select
+            className={inputCls}
+            value={contentType}
+            onChange={(e) =>
+              setContentType(e.target.value as AdminResource["content_type"])
+            }
+          >
+            {TYPES.map(([v, l]) => (
+              <option key={v} value={v}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="lbl mb-1 block">Label</span>
+          <input className={inputCls} value={meta} onChange={(e) => setMeta(e.target.value)} />
+        </label>
+        <label className="block sm:col-span-2">
+          <span className="lbl mb-1 block">Author</span>
+          <input className={inputCls} value={author} onChange={(e) => setAuthor(e.target.value)} />
+        </label>
+      </div>
+
+      <label className="mt-3 block">
+        <span className="lbl mb-1 block">Summary</span>
+        <textarea
+          className={inputCls}
+          rows={2}
+          value={summary}
+          onChange={(e) => setSummary(e.target.value)}
+        />
+      </label>
+
+      {error && (
+        <p className="mt-2 text-sm" style={{ color: "var(--red)" }} role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <button
+          className="btn btn-ghost px-4 py-2 text-sm"
+          type="button"
+          disabled={busy}
+          onClick={() => act(editedFields())}
+        >
+          Save
+        </button>
+        {row.status === "draft" ? (
+          <button
+            className="btn btn-teal px-4 py-2 text-sm"
+            type="button"
+            disabled={busy}
+            onClick={() => act({ ...editedFields(), status: "published" })}
+          >
+            {busy ? "…" : "Publish"}
+          </button>
+        ) : (
+          <button
+            className="btn btn-ghost px-4 py-2 text-sm"
+            type="button"
+            disabled={busy}
+            onClick={() => act({ status: "draft" })}
+          >
+            Unpublish
+          </button>
+        )}
+        <button
+          className="btn btn-ghost px-4 py-2 text-sm"
+          type="button"
+          disabled={busy}
+          style={{ color: "var(--red)", marginLeft: "auto" }}
+          onClick={() => (confirmDel ? onRemove(row.id) : setConfirmDel(true))}
+        >
+          {confirmDel ? "Tap again to delete" : "Delete"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/content/page.tsx
+++ b/app/(dashboard)/admin/content/page.tsx
@@ -1,24 +1,35 @@
 import { requireAdmin } from "@/lib/auth/guards";
 import StoriesAdmin, { type AdminSpotlight } from "./stories-admin";
+import LibraryAdmin, { type AdminResource } from "./library-admin";
 import SyncEventsButton from "./sync-events-button";
 
-/* Public content admin — Upskiller Spotlights (submissions land as 'submitted';
-   the Labs team enriches and publishes to /stories) plus the manual Luma events
-   sync (a cron also runs every 6h). */
+/* Public content admin — the Learning Library (link-out resources: guides,
+   recordings, Google Docs, …), Upskiller Spotlights (submissions land as
+   'submitted'; the Labs team enriches and publishes to /stories), and the
+   manual Luma events sync (a cron also runs every 6h). */
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminContentPage() {
   const { serviceClient } = await requireAdmin();
 
-  const { data } = await serviceClient
-    .from("spotlights")
-    .select(
-      "id, slug, name, role, tag, tag_label, quote, story, grad, submitter_email, status, sort_order, created_at"
-    )
-    .order("created_at", { ascending: false });
+  const [{ data: spotlightData }, { data: resourceData }] = await Promise.all([
+    serviceClient
+      .from("spotlights")
+      .select(
+        "id, slug, name, role, tag, tag_label, quote, story, grad, submitter_email, status, sort_order, created_at"
+      )
+      .order("created_at", { ascending: false }),
+    serviceClient
+      .from("resources")
+      .select(
+        "id, slug, title, content_type, url, summary, meta, author, status, created_at"
+      )
+      .order("created_at", { ascending: false }),
+  ]);
 
-  const rows = (data as AdminSpotlight[]) ?? [];
+  const rows = (spotlightData as AdminSpotlight[]) ?? [];
+  const resources = (resourceData as AdminResource[]) ?? [];
 
   return (
     <div>
@@ -28,6 +39,18 @@ export default async function AdminContentPage() {
           Public content — Upskiller Spotlights and the Luma events cache.
         </p>
       </div>
+
+      <section className="mb-10">
+        <h2 className="mb-1 t-h3 text-ink">Learning Library</h2>
+        <p className="mb-4 text-sm text-meta">
+          Add and manage resources — guides, recordings, templates, and links
+          out to view-only Google Docs. Published resources show on the public
+          /library and in members&apos; Learning tab.
+        </p>
+        <LibraryAdmin initial={resources} />
+      </section>
+
+      <hr className="mb-10 border-ink/10" />
 
       <section className="mb-10">
         <h2 className="mb-1 t-h3 text-ink">Events</h2>

--- a/app/api/admin/resources/[id]/route.ts
+++ b/app/api/admin/resources/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  withAdminAuth,
+  type AuthenticatedRequest,
+} from "@/lib/auth/middleware";
+import { createServiceClient } from "@/lib/supabase/server";
+import { parseIntParam } from "@/lib/api/params";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { dbError } from "@/lib/api/errors";
+import { resourceUpdateSchema } from "@/lib/validations/resource-admin";
+
+// Edit / publish-toggle / delete a Learning Library resource. Admin-gated,
+// service-role. PATCH sends only changed fields (status flips publish/draft);
+// the resources updated_at trigger (00037) stamps the timestamp. DELETE drops
+// the row — saved_items rows referencing it are cleaned up by the caller's
+// own re-read (a dangling bookmark is a no-op on the /learning grid). The slug
+// is immutable once created so the /library/[slug] URL contract stays stable.
+
+export const PATCH = withAdminAuth(
+  async (
+    request: NextRequest,
+    _auth: AuthenticatedRequest,
+    params: Record<string, string>
+  ) => {
+    const id = parseIntParam(params.id, "id");
+    if (id instanceof NextResponse) return id;
+
+    const body = await parseBody(request, resourceUpdateSchema);
+    if (isErrorResponse(body)) return body;
+
+    const service = createServiceClient();
+    const { data, error } = await service
+      .from("resources")
+      .update(body)
+      .eq("id", id)
+      .select(
+        "id, slug, title, content_type, url, summary, meta, author, status, created_at"
+      )
+      .single();
+    if (error) return dbError(error, "resource-update");
+
+    return NextResponse.json(data);
+  }
+);
+
+export const DELETE = withAdminAuth(
+  async (
+    _request: NextRequest,
+    _auth: AuthenticatedRequest,
+    params: Record<string, string>
+  ) => {
+    const id = parseIntParam(params.id, "id");
+    if (id instanceof NextResponse) return id;
+
+    const service = createServiceClient();
+    const { error } = await service.from("resources").delete().eq("id", id);
+    if (error) return dbError(error, "resource-delete");
+
+    return NextResponse.json({ deleted: true });
+  }
+);

--- a/app/api/admin/resources/route.ts
+++ b/app/api/admin/resources/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdminAuth } from "@/lib/auth/middleware";
+import { createServiceClient } from "@/lib/supabase/server";
+import { parseBody, isErrorResponse } from "@/lib/api/request";
+import { dbError } from "@/lib/api/errors";
+import { resourceCreateSchema } from "@/lib/validations/resource-admin";
+import { slugifyHandle } from "@/lib/participants/handle";
+
+// Create a Learning Library resource (the /admin/content Library surface).
+// Admin-gated, service-role. The slug is the /library/[slug] URL contract —
+// derived from the title (or an explicit override) and made unique so two
+// docs with the same title don't collide. Everything else maps straight to
+// the resources columns (migration 00033).
+
+/** First free slug in the `base`, `base-2`, `base-3`, … series. */
+async function uniqueSlug(
+  service: ReturnType<typeof createServiceClient>,
+  base: string
+): Promise<string> {
+  const { data } = await service
+    .from("resources")
+    .select("slug")
+    .like("slug", `${base}%`);
+  const taken = new Set((data ?? []).map((r) => (r as { slug: string }).slug));
+  if (!taken.has(base)) return base;
+  for (let n = 2; ; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+export const POST = withAdminAuth(async (request: NextRequest) => {
+  const body = await parseBody(request, resourceCreateSchema);
+  if (isErrorResponse(body)) return body;
+
+  const service = createServiceClient();
+  const base = slugifyHandle(body.slug || body.title);
+  const slug = await uniqueSlug(service, base);
+
+  const { data, error } = await service
+    .from("resources")
+    .insert({
+      slug,
+      title: body.title,
+      url: body.url,
+      content_type: body.content_type,
+      summary: body.summary ?? null,
+      meta: body.meta ?? null,
+      author: body.author ?? null,
+      status: body.status,
+    })
+    .select(
+      "id, slug, title, content_type, url, summary, meta, author, status, created_at"
+    )
+    .single();
+  if (error) return dbError(error, "resource-create");
+
+  return NextResponse.json(data, { status: 201 });
+});

--- a/app/components/content/teasers.tsx
+++ b/app/components/content/teasers.tsx
@@ -89,8 +89,8 @@ export function ResourceTeaser({
   corner?: ReactNode;
 }) {
   const typeLabel = CONTENT_TYPE_LABEL[r.content_type] || "Guide";
-  return (
-    <Link className="card tappable" href={`/library/${r.slug}`}>
+  const body = (
+    <>
       <MediaFrame img={r.img} grad={r.grad} tag={typeLabel} square corner={corner} />
       <div className="card-body">
         <div className="lbl lbl-teal">{r.meta || ""}</div>
@@ -99,6 +99,24 @@ export function ResourceTeaser({
         </div>
         <p className="t-small">{r.summary || ""}</p>
       </div>
+    </>
+  );
+  // Owner decision: a library card links straight out to its resource (e.g. a
+  // view-only Google Doc) in a new tab. When a row has no url yet, fall back to
+  // the in-app detail page so the card still leads somewhere. An interactive
+  // `corner` (the /learning heart) stops its own click from navigating.
+  return r.url ? (
+    <a
+      className="card tappable"
+      href={r.url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {body}
+    </a>
+  ) : (
+    <Link className="card tappable" href={`/library/${r.slug}`}>
+      {body}
     </Link>
   );
 }

--- a/lib/validations/resource-admin.ts
+++ b/lib/validations/resource-admin.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+// Admin create/edit of a Learning Library resource (the /admin/content Library
+// surface). The library is a link-out catalog: each row is metadata + an
+// external `url` (a view-only Google Doc, a recording, a course, …). The five
+// content_type values match the CHECK in migration 00033; `status` is a free
+// VARCHAR there ('published' shows publicly via resources_public_read + the
+// getResources filter; 'draft' hides it), so no CHECK/migration is needed for
+// the two states the admin toggles between.
+
+export const RESOURCE_CONTENT_TYPES = [
+  "guide",
+  "recording",
+  "template",
+  "course",
+  "playbook",
+] as const;
+
+// Create: title + url are the load-bearing fields; everything else is optional.
+// content_type / status carry the table's defaults when omitted.
+export const resourceCreateSchema = z.object({
+  title: z.string().trim().min(1).max(255),
+  url: z.string().trim().url().max(500),
+  content_type: z.enum(RESOURCE_CONTENT_TYPES).default("guide"),
+  summary: z.string().trim().max(4000).nullable().optional(),
+  meta: z.string().trim().max(100).nullable().optional(),
+  author: z.string().trim().max(255).nullable().optional(),
+  status: z.enum(["published", "draft"]).default("published"),
+  // Optional override; when absent the route derives the slug from the title.
+  slug: z.string().trim().min(1).max(100).optional(),
+});
+
+// Edit: a PATCH sends only what changed, so every field is optional.
+export const resourceUpdateSchema = z.object({
+  title: z.string().trim().min(1).max(255).optional(),
+  url: z.string().trim().url().max(500).optional(),
+  content_type: z.enum(RESOURCE_CONTENT_TYPES).optional(),
+  summary: z.string().trim().max(4000).nullable().optional(),
+  meta: z.string().trim().max(100).nullable().optional(),
+  author: z.string().trim().max(255).nullable().optional(),
+  status: z.enum(["published", "draft"]).optional(),
+});
+
+export type ResourceCreateInput = z.infer<typeof resourceCreateSchema>;
+export type ResourceUpdateInput = z.infer<typeof resourceUpdateSchema>;


### PR DESCRIPTION
## What

Adds a complete admin interface for managing the Learning Library — a catalog of link-out resources (guides, recordings, templates, courses, playbooks). Admins can create, edit, publish/draft, and delete resources from `/admin/content`. Published resources appear on the public `/library` grid and link directly to their external URLs.

## Changes

- **`app/(dashboard)/admin/content/library-admin.tsx`** — New admin UI component with:
  - `AddResourceForm` to create resources with title, URL, type, summary, author, and optional label
  - `ResourceRow` to edit existing resources and toggle publish/draft status
  - Grouped display (Published / Drafts) with counts
  - Mirrors the existing `StoriesAdmin` pattern (parent holds list state, rows own edit state)

- **`app/api/admin/resources/route.ts`** — POST endpoint to create resources:
  - Validates input against `resourceCreateSchema`
  - Auto-generates unique slugs from title (or explicit override) using `slugifyHandle`
  - Handles slug collisions with `-2`, `-3`, etc. suffix pattern

- **`app/api/admin/resources/[id]/route.ts`** — PATCH and DELETE endpoints:
  - PATCH updates only changed fields; status flips toggle publish/draft
  - DELETE removes the resource (dangling bookmarks are no-ops on the public grid)
  - Both admin-gated with service-role auth

- **`lib/validations/resource-admin.ts`** — Zod schemas:
  - `resourceCreateSchema` — title and URL required; content_type, status, summary, meta, author optional
  - `resourceUpdateSchema` — all fields optional for PATCH requests
  - Exports `RESOURCE_CONTENT_TYPES` constant (guide, recording, template, course, playbook)

- **`app/(dashboard)/admin/content/page.tsx`** — Updated to:
  - Fetch resources alongside spotlights in parallel
  - Render new `LibraryAdmin` section above the Events section
  - Updated intro text to mention the Learning Library

- **`app/components/content/teasers.tsx`** — Updated `ResourceTeaser`:
  - Links with `url` now open directly in a new tab (external link behavior)
  - Falls back to in-app `/library/[slug]` detail page when `url` is absent
  - Preserves interactive `corner` element (e.g., save heart) without triggering navigation

## Verify

- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run build` passes

## Manual testing

1. **Create a resource** (local dev):
   - Navigate to `/admin/content`
   - Fill in "Add a resource" form: title, URL (e.g., a Google Doc), type, optional label/author/summary
   - Click "Add & publish" → resource appears in Published section with ID, slug, and "Open link ↗"
   - Click "Save as draft" → resource appears in Drafts section instead

2. **Edit and publish**:
   - In Drafts, edit a resource's title or other fields
   - Click "Save" → changes persist
   - Click "Publish" → moves to Published section
   - In Published, click "Unpublish" → moves back to Drafts

3. **Delete**:
   - Click "Delete" → button text changes to "Tap again to delete"
   - Click again → resource removed from list

4. **Public library behavior**:
   - Visit `/library` (public page)
   - Published resources with URLs appear as cards linking directly to their external URL (new tab)
   - Resources without URLs (if any) link to in-app detail page `/library/[slug]`
   - Verify the save heart (or other interactive corner) doesn't trigger navigation

5. **Error handling**:
   - Try creating a resource with invalid URL → expect friendly error message
   - Try creating without title or URL → buttons remain disabled
   - Network failure during save → error displays in red

## Database

- [ ] No schema change — resources table and migrations already exist (00033)

https://claude.ai/code/session_01L7QFMQFrgp1cqTrWqgk9nv