### PR TITLE
Migrate revocation cron to Learning Log cadence (migration 00092)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -210,6 +210,8 @@ erDiagram
 
 Participants join cycles via `cycle_enrollments`. Authority (owner/admin/developer/observer + scoped poderator/lab_lead) resolves from `participant_roles` — see the authorization note below. `access_revocations` is the audit trail for removals. `pulse_checks` tracks weekly engagement.
 
+> **`cycle_enrollments.status` — membership vs. pod-activation (migration `00092`).** The status splits two axes. `registered` = committed member with no active pod yet (the self-service resting state and column default; grants the `participant` role and can submit learning logs). `active` = member **with** an active pod (unchanged meaning; only these members are under the weekly-log cadence). `inactive` = the one true exit — was `active`, fell behind the weekly logs — and always carries an `access_revocations` audit row. `revoked` = hard erasure/archive (`lib/owner/archive.ts`). The reconciler (`lib/enrollment/reconciler.ts`) owns only `registered ⇄ active` (promote on a pod becoming active, demote to `registered` on leaving the last pod) and **never** writes `inactive`; the engagement cron / admin sweep are the sole writers of `inactive`. A member who never joins a pod stays `registered` indefinitely; an `inactive` member auto-recovers on their next qualifying log. (`interested`/`stepped_back`/`completed` remain in the CHECK vocabulary from earlier migrations but are not written by the current flow.)
+
 ```mermaid
 erDiagram
     participants {

--- a/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/page.tsx
@@ -39,11 +39,13 @@ export type ParticipantRow = {
   pods: number[];
   roles: string[];
   // True when an access_revocations row exists for this (participant, cycle).
-  // Combined with status='inactive', has_revocation=false identifies
-  // 'stuck inactive' participants — never legitimately revoked, just
-  // never activated in the first place (architecture review broken edge
-  // #15). The participants-table filter uses this to surface them.
   has_revocation: boolean;
+  // True when the participant holds an active pod membership in a pod that is
+  // itself status='active'. Combined with status='registered', this identifies
+  // 'stuck registered' participants — they should be 'active' but the
+  // reconciler never fired (architecture review broken edge #15). The
+  // participants-table filter surfaces them and offers a Run-reconciler fix.
+  has_active_pod: boolean;
 };
 
 export default async function AdminCycleDetailPage({
@@ -114,6 +116,12 @@ export default async function AdminCycleDetailPage({
     (podsByParticipant[m.participant_id] ??= []).push(m.pod_id);
   }
 
+  // Pods that are themselves status='active' — used to flag 'stuck registered'
+  // members (an active pod membership but still status='registered').
+  const activePodIds = new Set(
+    (pods ?? []).filter((p) => p.status === "active").map((p) => p.id)
+  );
+
   // Fetch moderator assignments for all pods in this cycle
   const { data: modAssignments } = podIds.length
     ? await serviceClient
@@ -176,10 +184,16 @@ export default async function AdminCycleDetailPage({
       pods: podsByParticipant[e.participant_id] ?? [],
       roles: rolesByParticipant[e.participant_id] ?? [],
       has_revocation: revokedParticipantIds.has(e.participant_id),
+      has_active_pod: (podsByParticipant[e.participant_id] ?? []).some((pid) =>
+        activePodIds.has(pid)
+      ),
     };
   });
 
   const activeCount = participants.filter((p) => p.status === "active").length;
+  const registeredCount = participants.filter(
+    (p) => p.status === "registered"
+  ).length;
 
   // Participant list for the moderator + add-member dropdowns.
   const participantOptions = participants.map((p) => ({
@@ -314,6 +328,13 @@ export default async function AdminCycleDetailPage({
         <StatCard
           label="Active"
           value={<span className="text-teal-deep">{activeCount}</span>}
+          sublabel={
+            isOrg ? undefined : (
+              <span className="text-meta">
+                {registeredCount} registered (pre-pod)
+              </span>
+            )
+          }
         />
         <StatCard label={podNoun(cycle.mode, true)} value={pods?.length ?? 0} />
       </div>

--- a/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
+++ b/app/(dashboard)/admin/cycles/[cycle_id]/participants-table.tsx
@@ -19,7 +19,7 @@ export default function ParticipantsTable({
   mode,
 }: Props) {
   // Org core contributors are invite-only: enrollments never go through the activation
-  // pipeline the reconciler + stuck-inactive tooling exist for, so those
+  // pipeline the reconciler + stuck-registered tooling exist for, so those
   // affordances only render for participant cycles.
   const isOrg = mode === "org";
   const router = useRouter();
@@ -34,9 +34,14 @@ export default function ParticipantsTable({
     null
   );
 
+  // 'Stuck registered': a committed member who already holds an active pod
+  // membership but whose enrollment never got promoted to 'active' (the
+  // reconciler didn't fire). Running the reconciler fixes them. A registered
+  // member with no active pod is NOT stuck — that's the normal pre-pod
+  // resting state.
   const stuckCount = useMemo(
     () =>
-      participants.filter((p) => p.status === "inactive" && !p.has_revocation)
+      participants.filter((p) => p.status === "registered" && p.has_active_pod)
         .length,
     [participants]
   );
@@ -44,7 +49,7 @@ export default function ParticipantsTable({
   const visible = useMemo(() => {
     if (!stuckOnly) return participants;
     return participants.filter(
-      (p) => p.status === "inactive" && !p.has_revocation
+      (p) => p.status === "registered" && p.has_active_pod
     );
   }, [participants, stuckOnly]);
 
@@ -105,7 +110,7 @@ export default function ParticipantsTable({
               className="h-3.5 w-3.5 rounded border-ink/10 bg-white text-teal focus:ring-1 focus:ring-teal focus:ring-offset-0"
             />
             <span>
-              Show only stuck-inactive
+              Show only stuck-registered
               <span className="ml-1 text-meta tabular-nums">
                 ({stuckCount})
               </span>
@@ -113,8 +118,8 @@ export default function ParticipantsTable({
           </label>
           {stuckOnly && stuckCount === 0 && (
             <span className="text-xs text-meta">
-              No stuck-inactive participants — every inactive row has an
-              access_revocations entry.
+              No stuck-registered participants — every member with an active pod
+              is already active.
             </span>
           )}
         </div>
@@ -147,7 +152,7 @@ export default function ParticipantsTable({
               const displayName = p.preferred_name
                 ? `${p.preferred_name} ${p.last_name}`
                 : `${p.first_name} ${p.last_name}`;
-              const isStuck = p.status === "inactive" && !p.has_revocation;
+              const isStuck = p.status === "registered" && p.has_active_pod;
               const isReconciling = reconcilingId === p.participant_id;
               const showRowError = rowError?.id === p.participant_id;
 
@@ -160,7 +165,7 @@ export default function ParticipantsTable({
                     {displayName}
                     {!isOrg && isStuck && (
                       <span
-                        title="Inactive with no revocation row — likely never activated"
+                        title="Registered but already in an active pod — reconciler never promoted them to active"
                         className="ml-2 inline-flex items-center rounded-sm bg-red/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red"
                       >
                         stuck
@@ -173,9 +178,11 @@ export default function ParticipantsTable({
                       className={`status ${
                         p.status === "active"
                           ? "active"
-                          : p.status === "revoked"
-                            ? "risk"
-                            : ""
+                          : p.status === "registered"
+                            ? "forming"
+                            : p.status === "revoked"
+                              ? "risk"
+                              : ""
                       }`}
                     >
                       {p.status}
@@ -202,7 +209,7 @@ export default function ParticipantsTable({
                   <td className="px-4 py-3 text-right">
                     <div className="flex flex-col items-end gap-1">
                       <div className="flex items-center gap-2">
-                        {!isOrg && p.status === "inactive" && (
+                        {!isOrg && isStuck && (
                           <button
                             type="button"
                             onClick={() => runReconciler(p.participant_id)}

--- a/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/page.tsx
@@ -271,9 +271,9 @@ function StatusHeader({ detail }: { detail: PodDetail }) {
           <div>
             <ManagedTooltip
               tooltipKey="pod_health_indicator"
-              content="Count of active pod members who haven't submitted this week's pulse. Banded into healthy / warning / critical by cycle-configurable thresholds."
+              content="Count of active pod members who haven't filed this week's Learning Log. Banded into healthy / warning / critical by cycle-configurable thresholds."
             >
-              <div className="mb-1 text-xs text-meta">Pulse this week</div>
+              <div className="mb-1 text-xs text-meta">Logs this week</div>
             </ManagedTooltip>
             <div className="flex items-baseline gap-1.5">
               <span
@@ -327,7 +327,7 @@ function AtRiskSection({
           At-risk · needs attention
         </h2>
         <span className="text-xs text-meta">
-          {threshold}-pulse miss threshold
+          {threshold}-log miss threshold
         </span>
       </div>
       <div className="space-y-3">
@@ -355,7 +355,7 @@ function AtRiskCard({
 }) {
   const lastActiveCopy = member.last_activity_at
     ? `last active ${daysAgo(member.last_activity_at)} days ago`
-    : "no pulse activity yet";
+    : "no log activity yet";
   return (
     <div className="rounded-card border border-red/25 bg-red/[0.04] p-4">
       <div className="flex items-start gap-4">
@@ -382,7 +382,7 @@ function AtRiskCard({
               tooltipKey="at_risk_nudge_type"
               content="At-risk nudge: fires when a member misses the configured consecutive-miss threshold. System flags only — you follow up via Slack or email."
             >
-              <span className="font-medium">Missed consecutive pulses</span>
+              <span className="font-medium">Missed consecutive Learning Logs</span>
             </ManagedTooltip>
             <span className="text-meta-soft">·</span>
             <span className="text-meta">{lastActiveCopy}</span>

--- a/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
+++ b/app/(dashboard)/moderator/pods/[pod_id]/roster-table.tsx
@@ -49,7 +49,7 @@ const SORT_OPTIONS: { value: RosterSort; label: string }[] = [
   { value: "last_activity_asc", label: "Last activity (stale)" },
   { value: "name_asc", label: "Name A→Z" },
   { value: "name_desc", label: "Name Z→A" },
-  { value: "pulse_status", label: "Pulse (at-risk first)" },
+  { value: "pulse_status", label: "Log status (at-risk first)" },
   { value: "ai_level", label: "AI level" },
 ];
 
@@ -227,7 +227,7 @@ export function RosterTable({
               <th className="lbl px-4 py-3">Member</th>
               <th className="lbl px-4 py-3">AI level</th>
               <th className="lbl px-4 py-3">Availability</th>
-              <th className="lbl px-4 py-3">Pulse</th>
+              <th className="lbl px-4 py-3">Learning Log</th>
               <th className="lbl px-4 py-3">Last activity</th>
             </tr>
           </thead>
@@ -274,7 +274,7 @@ export function RosterTable({
                     {m.is_trending_at_risk && (
                       <ManagedTooltip
                         tooltipKey="trending_at_risk"
-                        content="Trending toward at-risk: one more missed pulse and this member crosses the at-risk threshold."
+                        content="Trending toward at-risk: one more missed weekly Learning Log and this member crosses the at-risk threshold."
                       >
                         <span className="inline-flex rounded-sm bg-red/10 px-2 py-0.5 text-xs font-medium text-red">
                           trending
@@ -288,16 +288,16 @@ export function RosterTable({
                     {m.last_activity_at ? (
                       <span>{daysAgo(m.last_activity_at)} days ago</span>
                     ) : (
-                      <span className="text-meta-soft">no pulse yet</span>
+                      <span className="text-meta-soft">no logs yet</span>
                     )}
                     {m.streak >= 2 && (
                       <ManagedTooltip
                         tooltipKey="streak_badge"
-                        content="Consecutive submitted pulses (looking back from the most recent scheduled date)."
+                        content="Consecutive weeks with a Learning Log (looking back from the most recent completed week)."
                       >
                         <span
                           className="inline-flex items-center gap-0.5 rounded-sm bg-teal/10 px-1.5 py-0.5 text-[10px] font-medium text-teal-deep"
-                          title={`${m.streak}-pulse streak`}
+                          title={`${m.streak}-week log streak`}
                         >
                           🔥 {m.streak}
                         </span>
@@ -357,7 +357,7 @@ function RosterControls({
         className="min-w-[220px] flex-1 rounded-card border border-ink/10 bg-white px-3 py-1.5 text-base text-ink placeholder:text-meta-soft focus-visible:border-teal focus-visible:outline-none"
       />
       <FilterGroup
-        label="Pulse"
+        label="Log"
         options={PULSE_STATUSES.map((v) => ({ value: v, label: v.replace("_", " ") }))}
         selected={filters.status ?? []}
         onToggle={onToggleStatus}
@@ -456,12 +456,12 @@ function daysAgo(iso: string): number {
 function pulseStatusTooltip(status: RosterRow["pulse_status"]): string {
   switch (status) {
     case "current":
-      return "Submitted the most recent pulse on time.";
+      return "Filed a Learning Log for the most recent completed week.";
     case "pending":
-      return "Most recent pulse is still in its open window (≤7 days). Not late yet.";
+      return "No Learning Log yet for the current week, but the window is still open.";
     case "late":
-      return "Most recent pulse missed and the window has closed.";
+      return "Missed the most recent completed week's Learning Log.";
     case "at_risk":
-      return "Missed the consecutive-pulse threshold. Surfaces in the at-risk nudge list.";
+      return "Missed the consecutive-week Learning Log threshold. Surfaces in the at-risk nudge list.";
   }
 }

--- a/app/(dashboard)/profile/member-profile-view.tsx
+++ b/app/(dashboard)/profile/member-profile-view.tsx
@@ -250,7 +250,15 @@ export default function MemberProfileView({
                       {e.cycle_name || `Cycle ${e.cycle_id}`}
                     </span>
                     <StatusBadge
-                      variant={e.status === "active" ? "active" : "inactive"}
+                      variant={
+                        e.status === "active"
+                          ? "active"
+                          : e.status === "registered"
+                            ? "forming"
+                            : e.status === "revoked"
+                              ? "revoked"
+                              : "inactive"
+                      }
                     >
                       {e.status}
                     </StatusBadge>

--- a/app/api/admin/participants/[participant_id]/reconcile/route.ts
+++ b/app/api/admin/participants/[participant_id]/reconcile/route.ts
@@ -11,26 +11,27 @@ import type { AuthenticatedRequest } from "@/lib/auth/middleware";
  *
  * Operator-driven trigger for the Phase A reconciler. Used by the
  * "Run reconciler" button on the admin participants-table filter for
- * "stuck inactive" enrollments — participants whose cycle_enrollments
- * row is 'inactive' AND who have no access_revocations entry, meaning
- * they were never legitimately revoked, just never activated in the
- * first place (architecture review broken edge #15).
+ * "stuck registered" enrollments — participants whose cycle_enrollments
+ * row is 'registered' despite already holding an active pod membership,
+ * meaning the reconciler never fired for them (architecture review broken
+ * edge #15).
  *
  * Body: { cycle_id: number }
  * Auth: withAdminAuth
- * Returns: { participantId, cycleId, before, after, mutated, audited }
+ * Returns: { participantId, cycleId, before, after, mutated }
  *          (the full ReconcileResult so the UI can show what changed)
  *
  * Behavior
  * --------
- * Calls reconcileEnrollmentActivation with no logRevocation flag. The
+ * Calls reconcileEnrollmentActivation with no recover flag. The
  * reconciler is idempotent:
  *   - If the participant has at least one active pod_membership in an
  *     active pod, status flips to 'active' and the result reports
  *     mutated=true, after='active'
- *   - If they have no active memberships, the reconciler leaves status
- *     as-is (also no-op) OR demotes to 'inactive' depending on current
- *     state. Either way it's safe to call.
+ *   - If they have no active memberships, the reconciler settles them at
+ *     'registered' (never 'inactive' — that is an engagement exit owned by
+ *     the revocation cron). An 'inactive'/'revoked' row is left untouched
+ *     (exits are sticky; use the reactivate route to recover). Safe to call.
  *
  * Architecture alignment
  * ----------------------
@@ -40,8 +41,9 @@ import type { AuthenticatedRequest } from "@/lib/auth/middleware";
  *     active, downstream resource provisioning would fire if/when that
  *     code lands. Same gap as B.7's pod-status override; not coded
  *     anywhere yet.
- *   - Brief invariant #5 (audit): reconciler writes access_revocations
- *     only on demotion + opts.logRevocation. Admin-triggered activation
+ *   - Brief invariant #5 (audit): the reconciler no longer writes
+ *     access_revocations at all — engagement exits (and their audit rows)
+ *     are owned by the cron / admin sweep. Admin-triggered activation
  *     doesn't need a revocation row; the StatusBadge in the UI is
  *     itself the visible record.
  *

--- a/app/api/cron/revocation-check/route.ts
+++ b/app/api/cron/revocation-check/route.ts
@@ -7,13 +7,11 @@ import {
   revocationWarningSubject,
   type RevocationWarningReason,
 } from "@/lib/email/revocation-warning-template";
-// Intentional cross-module import: the at-risk predicate is canonical in
-// lib/moderator/nudges.ts (it powers the poderator dashboard's nudge
-// surface). Reusing it here means the cron's revocation-candidate
-// identification matches what the moderator already sees flagged. If a
-// third caller emerges, extract to lib/engagement/at-risk.ts; YAGNI for
-// now. See roadmap §3.7 (Phase C design decisions).
-import { deriveAtRiskRun } from "@/lib/moderator/nudges";
+// The engagement signal is missed weekly Learning Log windows — the cadence
+// with teeth under the registered/active model. consecutiveMissedLogWeeks
+// reconstructs the weekly windows from the cycle calendar (the Learning Log
+// has no per-window schedule table like pulse_checks).
+import { consecutiveMissedLogWeeks } from "@/lib/learning-logs/at-risk";
 
 const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
 const SEND_DELAY_MS = 200;
@@ -45,15 +43,16 @@ type Outcome = {
  *
  * What's different from the old route
  * -----------------------------------
- *   1. Cycle-scoped queries. The old route's pod check counted
- *      pod_memberships across ALL cycles; this one joins to
- *      pods.cycle_id = current_cycle.id (broken edge #1).
- *   2. deriveAtRiskRun-driven missed-cadence detection. Uses the canonical
- *      predicate from lib/moderator/nudges.ts compared against
- *      cycle_config.at_risk_consecutive_misses (default 2). (Signal
- *      follow-up: this still measures missed PULSE windows; the cadence
- *      with teeth is now the weekly Learning Log — moving the detector
- *      onto missed log windows is tracked separately.)
+ *   1. Cycle-scoped queries. All per-participant reads join to
+ *      cycle_id = current_cycle.id (broken edge #1).
+ *   2. Missed-weekly-Learning-Log detection. consecutiveMissedLogWeeks
+ *      (lib/learning-logs/at-risk.ts) reconstructs the weekly windows from
+ *      the cycle calendar (getCycleWeek) and counts completed weeks with no
+ *      cycle-attributed learning_logs row, compared against
+ *      cycle_config.at_risk_consecutive_misses (default 2). A cycle whose
+ *      log gate is paused (log_gate_paused) is skipped — the whole cohort is
+ *      on holiday. This is the cadence with teeth under the log-gate model,
+ *      replacing the earlier pulse-check signal.
  *   3. Two-stage warn → revoke with 3-day grace. The cron sends a
  *      warning email and stamps warned_at on the first hit; subsequent
  *      ticks check whether warned_at + 3 days has passed before revoking.
@@ -110,18 +109,19 @@ export async function GET(request: NextRequest) {
   const now = new Date();
   const nowIso = now.toISOString();
   const dashboardUrl = `${appUrl}/dashboard`;
-  const pulseUrl = `${appUrl}/pulse-check`;
   const resend = getResendClient();
 
   const outcomes: Outcome[] = [];
 
-  // Active cycles with their config (cadence-miss threshold). mode='open'
-  // only — org cycles have no pulse rows, so the ladder below is structurally
-  // inert for them, but scoping here means the warning/revocation emails can
-  // never reach staff.
+  // Active cycles with their calendar (for weekly-window reconstruction) and
+  // config (miss threshold + gate-pause holiday toggle). mode='open' only —
+  // org cycles run the Leadership Log cadence, not this one, so scoping here
+  // means the warning/revocation emails can never reach staff.
   const { data: cycles } = await supabase
     .from("cycles")
-    .select("id, cycle_config(at_risk_consecutive_misses)")
+    .select(
+      "id, start_date, end_date, cycle_config(at_risk_consecutive_misses, log_gate_paused)"
+    )
     .eq("status", "active")
     .eq("mode", "open");
 
@@ -136,6 +136,14 @@ export async function GET(request: NextRequest) {
       );
       continue;
     }
+    // A cycle whose Learning Log gate is paused is on holiday — no missed-log
+    // revocations while the whole cohort is exempt.
+    if (config.log_gate_paused) continue;
+    // Weekly windows are reconstructed from the cycle calendar; without both
+    // bounds there's no cadence to measure, so skip.
+    if (!cycle.start_date || !cycle.end_date) continue;
+    const cycleStart = new Date(cycle.start_date);
+    const cycleEnd = new Date(cycle.end_date);
     const missThreshold = config.at_risk_consecutive_misses ?? 2;
 
     // Active enrollments in this cycle, with the participant's identity,
@@ -182,44 +190,31 @@ export async function GET(request: NextRequest) {
 
       // === Reason determination ===
 
-      // Cycle-scoped active pod memberships (fixes architecture review
-      // broken edge #1 — old route counted across all cycles)
-      const { data: membershipRows } = await supabase
-        .from("pod_memberships")
-        .select("id, pods!inner(cycle_id)")
-        .eq("participant_id", pid)
-        .eq("pods.cycle_id", cycleId)
-        .is("inactive_at", null);
-      const activePodCount = (membershipRows ?? []).length;
-
-      // Pulse history for at-risk run derivation
-      const { data: pulseRows } = await supabase
-        .from("pulse_checks")
-        .select("scheduled_date, completed_at")
+      // The one revocation reason under the registered/active model: an in-pod
+      // ('active') member who fell behind the weekly Learning Log cadence.
+      // Being pod-less is no longer a revocation — that member is 'registered'
+      // (the reconciler settles them there) and never enters this loop, which
+      // only iterates status='active' enrollments. So the old "not_in_pod"
+      // ladder is gone.
+      //
+      // consecutiveMissedLogWeeks reconstructs the weekly windows from the
+      // cycle calendar and counts completed weeks with no cycle-attributed
+      // learning_logs row, back from the most recently completed week.
+      const { data: logRows } = await supabase
+        .from("learning_logs")
+        .select("created_at")
         .eq("participant_id", pid)
         .eq("cycle_id", cycleId);
+      const missedWeeks = consecutiveMissedLogWeeks(
+        now,
+        cycleStart,
+        cycleEnd,
+        (logRows ?? []).map((r) => new Date(r.created_at))
+      );
 
       let reason: RevocationWarningReason | null = null;
-
-      // The one revocation reason under the registered/active model: an
-      // in-pod ('active') member who fell behind the weekly cadence. Being
-      // pod-less is no longer a revocation — that member is 'registered'
-      // (the reconciler settles them there) and never enters this loop, which
-      // only iterates status='active' enrollments. So the old window-aware
-      // "not_in_pod" ladder is gone; a member here always has a pod, hence
-      // the activePodCount > 0 guard is now merely defensive against drift.
-      //
-      // NOTE (signal): deriveAtRiskRun still measures missed PULSE windows.
-      // The cadence with teeth is now the weekly Learning Log
-      // (lib/learning-logs/gate.ts); moving this detector onto missed
-      // learning-log windows is the tracked follow-up. The cron is currently
-      // UNSCHEDULED, so this dormant path swaps signal without risk when it
-      // lands.
-      if (!reason && activePodCount > 0) {
-        const run = deriveAtRiskRun(pid, pulseRows ?? []);
-        if (run && run.consecutiveMisses >= missThreshold) {
-          reason = "missed_pulses";
-        }
+      if (missedWeeks >= missThreshold) {
+        reason = "missed_logs";
       }
 
       // === Recovery: clear warned_at if no reason applies but warning was set
@@ -247,7 +242,9 @@ export async function GET(request: NextRequest) {
         // Stage 1: send warning + stamp warned_at
         const firstName =
           participant.preferred_name || participant.first_name || "there";
-        const actionUrl = reason === "missed_pulses" ? pulseUrl : dashboardUrl;
+        // The Learning Log composer lives on the dashboard, so every warning
+        // now points there.
+        const actionUrl = dashboardUrl;
         if (!participant.email) {
           outcomes.push({
             participant_id: pid,
@@ -366,17 +363,11 @@ export async function GET(request: NextRequest) {
     recovered_count: recoveredCount,
     skipped_count: skippedCount,
     breakdown: {
-      not_in_pod_warned: outcomes.filter(
-        (o) => o.action === "warned" && o.reason === "not_in_pod"
+      missed_logs_warned: outcomes.filter(
+        (o) => o.action === "warned" && o.reason === "missed_logs"
       ).length,
-      missed_pulses_warned: outcomes.filter(
-        (o) => o.action === "warned" && o.reason === "missed_pulses"
-      ).length,
-      not_in_pod_revoked: outcomes.filter(
-        (o) => o.action === "revoked" && o.reason === "not_in_pod"
-      ).length,
-      missed_pulses_revoked: outcomes.filter(
-        (o) => o.action === "revoked" && o.reason === "missed_pulses"
+      missed_logs_revoked: outcomes.filter(
+        (o) => o.action === "revoked" && o.reason === "missed_logs"
       ).length,
     },
     outcomes,

--- a/app/api/cron/revocation-check/route.ts
+++ b/app/api/cron/revocation-check/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse, NextRequest } from "next/server";
-import { parseWindow } from "@/lib/cycles/lab-time";
 import { createServiceClient } from "@/lib/supabase/server";
 import { getResendClient, FROM_EMAIL } from "@/lib/email";
 import {
@@ -8,7 +7,6 @@ import {
   revocationWarningSubject,
   type RevocationWarningReason,
 } from "@/lib/email/revocation-warning-template";
-import { reconcileEnrollmentActivation } from "@/lib/enrollment/reconciler";
 // Intentional cross-module import: the at-risk predicate is canonical in
 // lib/moderator/nudges.ts (it powers the poderator dashboard's nudge
 // surface). Reusing it here means the cron's revocation-candidate
@@ -37,43 +35,47 @@ type Outcome = {
  * during the May Energy hot-fix). Phase C.3 re-registers it after a
  * ≥48h staging soak.
  *
+ * Registered/active model (migration 00092)
+ * ------------------------------------------
+ * The one revocation reason is the missed weekly cadence for an in-pod
+ * ('active') member. Being pod-less is no longer revocation-worthy — that
+ * member is 'registered', a permanent resting state the reconciler settles
+ * them into, and the loop below only iterates status='active' enrollments,
+ * so the old window-aware "not_in_pod" ladder was removed outright.
+ *
  * What's different from the old route
  * -----------------------------------
- *   1. Cycle-scoped queries. The old route's not_in_pod check counted
+ *   1. Cycle-scoped queries. The old route's pod check counted
  *      pod_memberships across ALL cycles; this one joins to
  *      pods.cycle_id = current_cycle.id (broken edge #1).
- *   2. Window-aware not_in_pod. Only fires AFTER pod_registration_close.
- *      During the open window, being pod-less is expected, not
- *      revocation-worthy. This addresses the launch-time scenario where
- *      late-joiners were getting revoked before they had a chance to
- *      pick a pod.
- *   3. deriveAtRiskRun-driven missed-pulses detection. Uses the canonical
+ *   2. deriveAtRiskRun-driven missed-cadence detection. Uses the canonical
  *      predicate from lib/moderator/nudges.ts compared against
- *      cycle_config.at_risk_consecutive_misses (default 2). Replaces
- *      the old "7 days from created_at fallback" rule.
- *   4. Two-stage warn → revoke with 3-day grace. The cron sends a
+ *      cycle_config.at_risk_consecutive_misses (default 2). (Signal
+ *      follow-up: this still measures missed PULSE windows; the cadence
+ *      with teeth is now the weekly Learning Log — moving the detector
+ *      onto missed log windows is tracked separately.)
+ *   3. Two-stage warn → revoke with 3-day grace. The cron sends a
  *      warning email and stamps warned_at on the first hit; subsequent
- *      ticks check whether warned_at + 3 days has passed before
- *      calling the reconciler.
- *   5. State changes via reconcileEnrollmentActivation. The cron
- *      doesn't directly mutate cycle_enrollments / pod_memberships /
- *      access_revocations — it asks the Phase A reconciler to demote
- *      the enrollment with logRevocation=true, and the reconciler
- *      handles all the side effects atomically via service client.
- *   6. Admin/owner exemption. Admins and owners with active enrollments
+ *      ticks check whether warned_at + 3 days has passed before revoking.
+ *   4. The cron is the SOLE writer of 'inactive'. The reconciler no longer
+ *      produces exits (it only manages registered <-> active), so stage 2
+ *      writes cycle_enrollments.status='inactive' + inactive_date directly
+ *      and records the access_revocations audit row. The member's pod
+ *      membership is left intact — 'inactive' is an engagement flag, and
+ *      their next qualifying log recovers them to 'active'.
+ *   5. Admin/owner exemption. Admins and owners with active enrollments
  *      are never revoked by this cron — admins typically have no pod,
  *      and that's by design. (The proper fix for admin participation
  *      tracking lives in #122.)
- *   7. Recovery clears warned_at. If a previously-warned participant
- *      joins a pod or submits a pulse, the next cron tick clears
- *      warned_at so a future warning starts fresh. This is what makes
- *      admin-driven rescue via POST /api/admin/pods/[id]/memberships
- *      compose correctly with the cron — see #123 for the parallel
- *      moderator-add design question.
- *   8. DB-enforced revocation idempotency. Migration 00030 adds a
+ *   6. Recovery clears warned_at. If a previously-warned participant
+ *      catches up on the cadence, the next cron tick clears warned_at so a
+ *      future warning starts fresh. This is what makes admin-driven rescue
+ *      via POST /api/admin/pods/[id]/memberships compose correctly with the
+ *      cron — see #123 for the parallel moderator-add design question.
+ *   7. DB-enforced revocation idempotency. Migration 00030 adds a
  *      unique partial index on access_revocations(participant_id,
- *      cycle_id, reason) WHERE revocation_scope = 'full' so the
- *      reconciler's INSERT can safely retry.
+ *      cycle_id, reason) WHERE revocation_scope = 'full' so the stage-2
+ *      audit INSERT can safely retry.
  *
  * Auth + observability are unchanged from the existing pattern:
  *   - Bearer CRON_SECRET (same as pulse-check-reminder)
@@ -113,15 +115,13 @@ export async function GET(request: NextRequest) {
 
   const outcomes: Outcome[] = [];
 
-  // Active cycles with their config (pod_registration_close + threshold).
-  // mode='open' only — org cycles have no pod_registration window and no
-  // pulse rows, so the ladders below are structurally inert for them, but
-  // scoping here means the warning/revocation emails can never reach staff.
+  // Active cycles with their config (cadence-miss threshold). mode='open'
+  // only — org cycles have no pulse rows, so the ladder below is structurally
+  // inert for them, but scoping here means the warning/revocation emails can
+  // never reach staff.
   const { data: cycles } = await supabase
     .from("cycles")
-    .select(
-      "id, cycle_config(pod_registration_close, at_risk_consecutive_misses)"
-    )
+    .select("id, cycle_config(at_risk_consecutive_misses)")
     .eq("status", "active")
     .eq("mode", "open");
 
@@ -136,12 +136,6 @@ export async function GET(request: NextRequest) {
       );
       continue;
     }
-    // parseWindow: naive column read explicitly as a UTC instant
-    // (lib/cycles/lab-time.ts) — server-tz-independent.
-    const podRegistrationClosed =
-      config.pod_registration_close !== null &&
-      (parseWindow(config.pod_registration_close) as Date).getTime() <
-        now.getTime();
     const missThreshold = config.at_risk_consecutive_misses ?? 2;
 
     // Active enrollments in this cycle, with the participant's identity,
@@ -207,15 +201,20 @@ export async function GET(request: NextRequest) {
 
       let reason: RevocationWarningReason | null = null;
 
-      // Reason A: not_in_pod — only AFTER pod_registration_close
-      // (window-aware; addresses launch-time late-joiner scenario)
-      if (podRegistrationClosed && activePodCount === 0) {
-        reason = "not_in_pod";
-      }
-
-      // Reason B: missed_pulses — only when the participant DOES have a
-      // pod (otherwise reason A applies first) and the consecutive-miss
-      // run exceeds the cycle's threshold
+      // The one revocation reason under the registered/active model: an
+      // in-pod ('active') member who fell behind the weekly cadence. Being
+      // pod-less is no longer a revocation — that member is 'registered'
+      // (the reconciler settles them there) and never enters this loop, which
+      // only iterates status='active' enrollments. So the old window-aware
+      // "not_in_pod" ladder is gone; a member here always has a pod, hence
+      // the activePodCount > 0 guard is now merely defensive against drift.
+      //
+      // NOTE (signal): deriveAtRiskRun still measures missed PULSE windows.
+      // The cadence with teeth is now the weekly Learning Log
+      // (lib/learning-logs/gate.ts); moving this detector onto missed
+      // learning-log windows is the tracked follow-up. The cron is currently
+      // UNSCHEDULED, so this dormant path swaps signal without risk when it
+      // lands.
       if (!reason && activePodCount > 0) {
         const run = deriveAtRiskRun(pid, pulseRows ?? []);
         if (run && run.consecutiveMisses >= missThreshold) {
@@ -312,25 +311,45 @@ export async function GET(request: NextRequest) {
         continue;
       }
 
-      // Stage 2: grace expired — revoke via the reconciler.
-      // The reconciler reads current pod-membership reality and demotes
-      // cycle_enrollments.status to 'inactive' if appropriate. Setting
-      // logRevocation=true makes it INSERT the access_revocations row.
-      // Migration 00030's unique partial index means the INSERT is
-      // idempotent even if this cron retries.
-      const result = await reconcileEnrollmentActivation(pid, cycleId, {
-        reason,
-        logRevocation: true,
-      });
+      // Stage 2: grace expired — this is the ONE path that writes 'inactive'.
+      // The reconciler no longer produces exits (it only manages
+      // registered <-> active), so the cron writes the status + inactive_date
+      // itself and records the audit row. The pod membership is intentionally
+      // LEFT intact: 'inactive' is an engagement flag on a still-in-pod
+      // member, and their next qualifying log recovers them to 'active'
+      // (app/api/learning-logs/route.ts). Migration 00030's unique partial
+      // index (participant_id, cycle_id, reason) keeps the audit insert
+      // idempotent across cron retries — a duplicate returns an ignored error
+      // rather than a second row.
+      await supabase
+        .from("cycle_enrollments")
+        .update({ status: "inactive", inactive_date: nowIso })
+        .eq("participant_id", pid)
+        .eq("cycle_id", cycleId);
+
+      const { error: auditError } = await supabase
+        .from("access_revocations")
+        .insert({
+          participant_id: pid,
+          cycle_id: cycleId,
+          reason,
+          revocation_scope: "full",
+        });
+      if (auditError && auditError.code !== "23505") {
+        console.error(
+          `[revocation-check] audit insert failed participant_id=${pid} cycle_id=${cycleId} reason=${reason} error=${auditError.message ?? String(auditError)}`
+        );
+      }
+
       console.log(
-        `[revocation-check] revoked participant_id=${pid} cycle_id=${cycleId} reason=${reason} before=${result.before} after=${result.after} audited=${result.audited}`
+        `[revocation-check] revoked participant_id=${pid} cycle_id=${cycleId} reason=${reason} -> inactive`
       );
       outcomes.push({
         participant_id: pid,
         cycle_id: cycleId,
         action: "revoked",
         reason,
-        detail: `before=${result.before} after=${result.after}`,
+        detail: "status=inactive",
       });
     }
   }

--- a/app/api/cycles/[cycle_id]/agreement/route.ts
+++ b/app/api/cycles/[cycle_id]/agreement/route.ts
@@ -163,8 +163,8 @@ export const POST = withAuth(
       return dbError(aError, "cycle-agreement");
     }
 
-    // Ensure the interest enrollment exists (status='inactive' — the same
-    // row the interest endpoint creates; never an activation).
+    // Ensure the interest enrollment exists (status='registered' — the same
+    // row the interest endpoint creates; never an activation — pods do that).
     const { data: existingEnrollment } = await supabase
       .from("cycle_enrollments")
       .select("id")
@@ -176,7 +176,7 @@ export const POST = withAuth(
       const { error: enError } = await supabase.from("cycle_enrollments").insert({
         participant_id: participantId,
         cycle_id: cycleId,
-        status: "inactive",
+        status: "registered",
       });
       if (enError) {
         return dbError(enError, "cycle-agreement-enrollment");

--- a/app/api/cycles/[cycle_id]/interest/route.ts
+++ b/app/api/cycles/[cycle_id]/interest/route.ts
@@ -109,7 +109,9 @@ export const POST = withAuth(
       }
     }
 
-    // Upsert cycle_enrollments with status='inactive'
+    // Upsert cycle_enrollments with status='registered' — the committed
+    // pre-pod member state (the reconciler promotes it to 'active' once an
+    // active pod membership exists; see lib/enrollment/reconciler.ts).
     const { data: existingEnrollment } = await supabase
       .from("cycle_enrollments")
       .select("id")
@@ -127,7 +129,7 @@ export const POST = withAuth(
         .insert({
           participant_id: participantId,
           cycle_id: cycleId,
-          status: "inactive",
+          status: "registered",
         })
         .select("id")
         .single();

--- a/app/api/learning-logs/route.ts
+++ b/app/api/learning-logs/route.ts
@@ -18,6 +18,8 @@ import {
   type EligibleLogCycle,
 } from "@/lib/learning-logs/eligible";
 import { pendingBaselineCycles } from "@/lib/learning-logs/baseline";
+import { reconcileEnrollmentActivation } from "@/lib/enrollment/reconciler";
+import type { ParticipantStatus } from "@/lib/auth/roles";
 import { getCycleWeek } from "@/lib/cycle/week";
 import {
   milestoneKindForWeek,
@@ -83,6 +85,11 @@ export const POST = withAuth(
     let chosenCycleId: number | null = null;
     let chosenCycleMode: string | null = null;
     let chosenCycleStatus: string | null = null;
+    // The member's ENROLLMENT status in the chosen cycle (distinct from
+    // chosenCycleStatus, which is the cycle's own liveness). Only set on the
+    // non-baseline path, where the cycle comes from eligibleLogCycles (which
+    // carries it). Drives the recover-on-log promotion below.
+    let chosenEnrollmentStatus: ParticipantStatus | null = null;
     let cycleStart: Date | null = null;
     let cycleEnd: Date | null = null;
     let kind: "weekly" | "baseline" | MilestoneKind = "weekly";
@@ -183,8 +190,10 @@ export const POST = withAuth(
 
       chosenCycleId = chosenCycle?.id ?? null;
       chosenCycleMode = chosenCycle?.mode ?? null;
-      // eligibleLogCycles only ever returns status='active' cycles.
+      // eligibleLogCycles only ever returns cycles whose own status='active'.
       chosenCycleStatus = chosenCycle ? "active" : null;
+      // …but the member's ENROLLMENT in it may be registered/active/inactive.
+      chosenEnrollmentStatus = chosenCycle?.status ?? null;
     }
 
     // Work-log fields (00069) belong to the org member tier only — persist
@@ -269,6 +278,18 @@ export const POST = withAuth(
       .select("id, created_at")
       .single();
     if (error || !log) return dbError(error, "learning-log");
+
+    // Recover-on-log: filing a qualifying log against a cycle the member was
+    // flagged 'inactive' in (missed the cadence) clears the engagement exit.
+    // recover:true re-derives from pod reality — they're still in their pod,
+    // so they land back at 'active' (else 'registered'); it also clears
+    // inactive_date / warned_at. Standalone/baseline logs (no cycle) can't
+    // recover anything, so this only fires for a real cycle attribution.
+    if (chosenEnrollmentStatus === "inactive" && chosenCycleId != null) {
+      await reconcileEnrollmentActivation(participantId, chosenCycleId, {
+        recover: true,
+      });
+    }
 
     // Baseline companion row (the eight answers), mapped 1:1 from
     // body.baseline. If this insert fails after the learning_logs row landed,

--- a/app/api/revocations/check/[cycle_id]/route.ts
+++ b/app/api/revocations/check/[cycle_id]/route.ts
@@ -2,14 +2,20 @@ import { NextResponse, NextRequest } from "next/server";
 import { withAdminAuth } from "@/lib/auth/middleware";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 import { parseIntParam } from "@/lib/api/params";
-import { reconcileEnrollmentActivation } from "@/lib/enrollment/reconciler";
 
-// Manual (admin-triggered) revocation sweep. Enrollment status is never
-// written here — memberships are soft-deleted and the reconciler derives
-// the demotion (§3.7: one write path for the enrollment lifecycle). The
-// route keeps its own access_revocations insert because it records the
-// richer reason + revoked_systems detail, so the reconciler's logRevocation
-// stays off to avoid a duplicate audit row.
+// Manual (admin-triggered) mirror of the engagement-revocation cron
+// (app/api/cron/revocation-check). Under the registered/active model
+// (migration 00092) the ONE revocation reason is the missed weekly cadence
+// for an in-pod ('active') member. Being pod-less is no longer a revocation —
+// that member is 'registered', a resting state this active-only sweep never
+// sees — so the old "not_in_pod" check was removed.
+//
+// The reconciler no longer writes exits (it only manages registered <->
+// active), so this route sets status='inactive' + inactive_date directly and
+// records the audit row. The pod membership is LEFT intact: 'inactive' is an
+// engagement flag on a still-in-pod member, and their next qualifying log
+// recovers them to 'active' (app/api/learning-logs/route.ts). An admin who
+// wants to fully remove someone uses the pod-membership / archive routes.
 export const POST = withAdminAuth(
   async (_request: NextRequest, auth: AuthenticatedRequest, params: Record<string, string>) => {
     const cycleId = parseIntParam(params.cycle_id, "cycle_id");
@@ -31,96 +37,49 @@ export const POST = withAdminAuth(
 
     for (const enrollment of enrollments) {
       const pid = enrollment.participant_id;
-      let shouldRevoke = false;
-      let reason = "";
 
-      // Check 1: no active pod membership IN THIS CYCLE. The membership →
-      // pod join is required because pod_memberships has no cycle column;
-      // an unscoped count would let an active pod in another cycle mask
-      // this cycle's absence (the cross-cycle bug class from the May
-      // incident — see docs/architecture-review-onboarding-state-machine.md).
-      const { data: activeMemberships } = await auth.supabase
-        .from("pod_memberships")
-        .select("id, pods!inner(cycle_id)")
-        .eq("participant_id", pid)
-        .eq("pods.cycle_id", cycleId)
-        .is("inactive_at", null);
-
-      const membershipIds = (activeMemberships ?? []).map((m) => m.id);
-      if (membershipIds.length === 0) {
-        shouldRevoke = true;
-        reason = "not_in_pod";
-      }
-
-      // Check 2: Missed 2+ consecutive pulse checks
-      if (!shouldRevoke) {
-        const { data: checks } = await auth.supabase
-          .from("pulse_checks")
-          .select("completed_at")
-          .eq("cycle_id", cycleId)
-          .eq("participant_id", pid)
-          .order("scheduled_date", { ascending: false })
-          .limit(2);
-
-        if (checks && checks.length >= 2) {
-          const missedConsecutive = checks.every((c) => !c.completed_at);
-          if (missedConsecutive) {
-            shouldRevoke = true;
-            reason = "missed_pulse_checks";
-          }
-        }
-      }
-
-      if (!shouldRevoke) continue;
-
-      // Apply inactive access profile
-      // 1. Mark THIS CYCLE's pod memberships inactive. Two-step (select ids,
-      //    then update by id) because PostgREST embedded filters on an
-      //    UPDATE only shape the returned rows — they do not scope the
-      //    mutation — so a joined .eq("pods.cycle_id", …) on the update
-      //    would soft-delete memberships in every cycle.
-      if (membershipIds.length > 0) {
-        await auth.supabase
-          .from("pod_memberships")
-          .update({ inactive_at: now })
-          .in("id", membershipIds);
-      }
-
-      // 2. Revoke project memberships (project_memberships carries cycle_id)
-      await auth.supabase
-        .from("project_memberships")
-        .update({ left_at: now })
-        .eq("participant_id", pid)
+      // Cadence check: missed 2+ consecutive pulse checks.
+      const { data: checks } = await auth.supabase
+        .from("pulse_checks")
+        .select("completed_at")
         .eq("cycle_id", cycleId)
-        .is("left_at", null);
+        .eq("participant_id", pid)
+        .order("scheduled_date", { ascending: false })
+        .limit(2);
 
-      // 3. Enrollment status follows membership reality via the reconciler —
-      //    never written directly here.
-      const reconciled = await reconcileEnrollmentActivation(pid, cycleId);
+      const missedConsecutive =
+        !!checks && checks.length >= 2 && checks.every((c) => !c.completed_at);
+      if (!missedConsecutive) continue;
 
-      // 4. Record revocation
-      await auth.supabase.from("access_revocations").insert({
-        participant_id: pid,
-        cycle_id: cycleId,
-        reason,
-        revocation_scope: "full",
-        revoked_systems: [
-          "pod_membership",
-          "project_membership",
-          "enrollment",
-        ],
-      });
+      // Flag the enrollment 'inactive' directly and record the audit row.
+      const reason = "missed_pulse_checks";
+      await auth.supabase
+        .from("cycle_enrollments")
+        .update({ status: "inactive", inactive_date: now })
+        .eq("participant_id", pid)
+        .eq("cycle_id", cycleId);
+
+      const { error: auditError } = await auth.supabase
+        .from("access_revocations")
+        .insert({
+          participant_id: pid,
+          cycle_id: cycleId,
+          reason,
+          revocation_scope: "full",
+          revoked_systems: ["enrollment"],
+        });
+      if (auditError && auditError.code !== "23505") {
+        console.error(
+          `[revocations/check] audit insert failed participant_id=${pid} cycle_id=${cycleId} error=${auditError.message ?? String(auditError)}`
+        );
+      }
 
       transitioned.push({
         participant_id: pid,
         reason,
         revocation_scope: "full",
-        enrollment_status: reconciled.after,
-        systems_affected: [
-          "pod_membership",
-          "project_membership",
-          "enrollment",
-        ],
+        enrollment_status: "inactive",
+        systems_affected: ["enrollment"],
       });
     }
 

--- a/app/api/revocations/check/[cycle_id]/route.ts
+++ b/app/api/revocations/check/[cycle_id]/route.ts
@@ -2,13 +2,18 @@ import { NextResponse, NextRequest } from "next/server";
 import { withAdminAuth } from "@/lib/auth/middleware";
 import type { AuthenticatedRequest } from "@/lib/auth/middleware";
 import { parseIntParam } from "@/lib/api/params";
+import { consecutiveMissedLogWeeks } from "@/lib/learning-logs/at-risk";
 
 // Manual (admin-triggered) mirror of the engagement-revocation cron
 // (app/api/cron/revocation-check). Under the registered/active model
-// (migration 00092) the ONE revocation reason is the missed weekly cadence
-// for an in-pod ('active') member. Being pod-less is no longer a revocation —
-// that member is 'registered', a resting state this active-only sweep never
-// sees — so the old "not_in_pod" check was removed.
+// (migration 00092) the ONE revocation reason is the missed weekly Learning
+// Log cadence for an in-pod ('active') member. Being pod-less is no longer a
+// revocation — that member is 'registered', a resting state this active-only
+// sweep never sees — so the old "not_in_pod" check was removed.
+//
+// The signal is missed weekly Learning Log windows (consecutiveMissedLogWeeks,
+// reconstructed from the cycle calendar) — identical to the cron, not the
+// legacy pulse-check count.
 //
 // The reconciler no longer writes exits (it only manages registered <->
 // active), so this route sets status='inactive' + inactive_date directly and
@@ -20,7 +25,28 @@ export const POST = withAdminAuth(
   async (_request: NextRequest, auth: AuthenticatedRequest, params: Record<string, string>) => {
     const cycleId = parseIntParam(params.cycle_id, "cycle_id");
     if (cycleId instanceof NextResponse) return cycleId;
-    const now = new Date().toISOString();
+    const nowDate = new Date();
+    const now = nowDate.toISOString();
+
+    // Cycle calendar (for weekly-window reconstruction) + gate-pause holiday
+    // toggle + miss threshold. Without both date bounds there's no cadence to
+    // measure; a paused gate exempts the whole cohort.
+    const { data: cycle } = await auth.supabase
+      .from("cycles")
+      .select(
+        "start_date, end_date, cycle_config(at_risk_consecutive_misses, log_gate_paused)"
+      )
+      .eq("id", cycleId)
+      .maybeSingle();
+    const config = Array.isArray(cycle?.cycle_config)
+      ? cycle?.cycle_config[0]
+      : cycle?.cycle_config;
+    if (!cycle?.start_date || !cycle?.end_date || config?.log_gate_paused) {
+      return NextResponse.json({ transitioned_to_inactive: [] });
+    }
+    const cycleStart = new Date(cycle.start_date);
+    const cycleEnd = new Date(cycle.end_date);
+    const missThreshold = config?.at_risk_consecutive_misses ?? 2;
 
     // Get all active enrollees
     const { data: enrollments } = await auth.supabase
@@ -38,21 +64,22 @@ export const POST = withAdminAuth(
     for (const enrollment of enrollments) {
       const pid = enrollment.participant_id;
 
-      // Cadence check: missed 2+ consecutive pulse checks.
-      const { data: checks } = await auth.supabase
-        .from("pulse_checks")
-        .select("completed_at")
+      // Cadence check: consecutive missed weekly Learning Log windows.
+      const { data: logRows } = await auth.supabase
+        .from("learning_logs")
+        .select("created_at")
         .eq("cycle_id", cycleId)
-        .eq("participant_id", pid)
-        .order("scheduled_date", { ascending: false })
-        .limit(2);
-
-      const missedConsecutive =
-        !!checks && checks.length >= 2 && checks.every((c) => !c.completed_at);
-      if (!missedConsecutive) continue;
+        .eq("participant_id", pid);
+      const missedWeeks = consecutiveMissedLogWeeks(
+        nowDate,
+        cycleStart,
+        cycleEnd,
+        (logRows ?? []).map((r) => new Date(r.created_at))
+      );
+      if (missedWeeks < missThreshold) continue;
 
       // Flag the enrollment 'inactive' directly and record the audit row.
-      const reason = "missed_pulse_checks";
+      const reason = "missed_logs";
       await auth.supabase
         .from("cycle_enrollments")
         .update({ status: "inactive", inactive_date: now })

--- a/app/api/revocations/reactivate/[participant_id]/route.ts
+++ b/app/api/revocations/reactivate/[participant_id]/route.ts
@@ -8,9 +8,13 @@ import { reconcileEnrollmentActivation } from "@/lib/enrollment/reconciler";
 
 // Admin reactivation. Memberships are restored first; the enrollment status
 // then follows membership reality via the reconciler (§3.7: one write path).
-// Consequence of the single source of truth: if the restored memberships'
-// pods aren't status='active', the enrollment stays inactive — the response
-// reports the reconciled status so the admin sees what actually happened.
+// Because 'inactive' is a sticky engagement exit under the registered/active
+// model (migration 00092), the reconcile is invoked with { recover: true } so
+// it re-derives the exit from pod reality instead of no-oping. Consequence: if
+// the restored memberships' pods aren't status='active', the member lands at
+// 'registered' (still a member, just not in an active pod) rather than back at
+// 'active' — the response reports the reconciled status so the admin sees what
+// actually happened.
 export const POST = withAdminAuth(
   async (request: NextRequest, auth: AuthenticatedRequest, params: Record<string, string>) => {
     const participantId = parseIntParam(params.participant_id, "participant_id");
@@ -52,10 +56,12 @@ export const POST = withAdminAuth(
     const restoredProjects = (projectMemberships || []).map((m) => m.project_id);
 
     // 3. Enrollment status follows the restored memberships — reconciler,
-    //    never a direct status write.
+    //    never a direct status write. recover:true clears the sticky
+    //    'inactive' exit and its bookkeeping (inactive_date/warned_at).
     const reconciled = await reconcileEnrollmentActivation(
       participantId,
-      cycle_id
+      cycle_id,
+      { recover: true }
     );
 
     // 4. Record reactivation in audit trail

--- a/docs/requirements/moderator-insights-logs.md
+++ b/docs/requirements/moderator-insights-logs.md
@@ -1,0 +1,198 @@
+# Requirements — Moderator Insights on Learning Logs
+
+| | |
+|---|---|
+| **Status** | Draft — for review (2026-07-27, drafted with Claude Code) |
+| **Related code** | `lib/moderator/pod-insights.ts`, `lib/moderator/cross-pod-insights.ts`, `lib/moderator/rollup.ts`, `app/(dashboard)/moderator/pods/[pod_id]/insights-section.tsx`, `app/(dashboard)/moderator/cross-pod-insights-section.tsx`, `app/(dashboard)/moderator/ai-summary-block.tsx`, `app/(dashboard)/moderator/page.tsx` |
+| **Related docs** | [`PRD-moderator-dashboard.md`](../PRD-moderator-dashboard.md) §7.9/§7.10, [`architecture-review-onboarding-state-machine.md`](../architecture-review-onboarding-state-machine.md) |
+| **Depends on** | The registered/active + Learning-Log-cadence work (migration `00092`; `lib/learning-logs/at-risk.ts`; the `pod-detail.ts` health conversion) |
+
+## Overview
+
+The moderator **Insights** surfaces — the per-pod Insights tab (§7.9.2), the
+cross-pod insights on the All-pods view (§7.9.3), the AI-assisted summary
+(§7.10.3), and the fleet rollup cards (§7.10.2) — still read `pulse_checks`
+(`survey_responses` free-text, `tools_used`, `blockers`/`tailwinds`). The
+weekly **Learning Log** has replaced the pulse check as the engagement
+instrument: new cycles never write `pulse_checks`, so for every current cohort
+these panels render **empty** ("No pulse history yet"). The pod-health header
+and roster at-risk signal were already moved to logs; Insights is the last
+pulse-fed surface.
+
+This document specifies rebuilding Insights on `learning_logs`. It is a
+**requirements** doc, not an implementation plan — it defines the target
+metrics, the field mapping, the legacy-pod behavior, and the open product
+decisions. The one hard gap (AI-tool adoption has no Learning Log source) is
+called out explicitly.
+
+## Current state (pulse-based)
+
+Every metric below is computed from `pulse_checks` rows for the pod's cycle,
+bucketed by `scheduled_date` (the pre-scheduled weekly pulse row):
+
+| Metric | Source | Where |
+|---|---|---|
+| **Top AI tools** (distinct members per tool, top 5) | `survey_responses.tools_used[]` | pod + cross-pod |
+| **Weekly completion trend** (submitted / scheduled per week) | pulse `completed_at` per `scheduled_date` | pod + cross-pod (per-pod comparison) |
+| **Response depth trend** (avg free-text chars per submitted pulse) | concatenated `survey_responses` free-text fields | pod |
+| **Tailwinds vs blockers** (count of pulses mentioning each) | `survey_responses.tailwinds` / `.blockers` | pod |
+| **Recent comments** (feeds the AI summary bundle) | concatenated free-text (`accomplishment`, `highlight`, `challenge`, `blockers`, `tailwinds`, `mitigation_strategy`, `anything_else`), initials + week | pod + cross-pod → `ai-summary-block.tsx` |
+| **Pulses this period** (submitted vs possible, engagement trend) | `rollup.ts` over pulse rows | fleet cards (`moderator/page.tsx`) |
+
+The AI summary bundles the recent comments (initials only) with
+`cycle_config.ai_summary_prompt` for the moderator to paste into their own LLM
+(OLOS runs no model server-side). Both scopes share a 4-week / full-cycle range
+toggle, pre-computed server-side.
+
+## The data shift — pulse fields → Learning Log fields
+
+`learning_logs` (migration `00040` v1, `00091` weekly v2) carries a **richer**
+signal than pulses, but a **different** one. There is no `survey_responses`
+JSONB and no `tools_used`.
+
+**Numeric (1–5) — new, logs-only, ideal for trend viz:**
+- v1 (all kinds): `clarity`, `alignment`
+- v2 (weekly): `progress_rating`, `collab_rating`, `capability_rating`, `energy_rating`
+- `hours_bucket` (availability bucket text, e.g. "2–5 hrs/week")
+
+**Blocked signal (replaces blockers/tailwinds):**
+- `is_blocked` (boolean) + `blocker_context` (v1) / `stuck_tried` (v2)
+
+**Free text (feeds depth + AI summary):**
+- v1: `accomplished`, `exploring`, `next_focus`, `blocker_context`
+- v2: `contribution`, `learned`, `stuck_tried`, `blocker_context`, `recognition`
+- `feeling_word` (optional single word), `recognition` (optional shout-out)
+
+**Structural:** `kind` (`weekly` / `milestone_7` / `milestone_13`),
+`schema_version` (`v1` / `v2`), `cycle_id`, `created_at`, `share_publicly`.
+
+> **Schema-version handling is mandatory.** A cycle can hold both v1 and v2
+> logs. Every extractor (depth, AI-summary text, ratings) MUST read the union
+> of the version-appropriate fields and skip nulls — do not assume v2.
+
+> **Weeks come from the cycle calendar, not scheduled rows.** Logs have no
+> `scheduled_date`. Reuse the reconstruction already shipped in
+> `lib/learning-logs/at-risk.ts` (`consecutiveMissedLogWeeks`) and
+> `lib/cycle/week.ts` (`getCycleWeek` / `getCycleWeekStart`): a member
+> "completed" a cycle-week iff ≥1 cycle-attributed log lands in it. This is
+> the same synthesis `pod-detail.ts` now uses for pod health.
+
+## Requirements — target metrics
+
+Each is the log-based replacement for a current tile. Restrict aggregate
+trends to `kind='weekly'` logs unless noted (milestone reviews are a separate
+instrument).
+
+1. **Weekly completion trend** *(replaces "Pulse completion trend")* — per
+   cycle-week, share of active members with ≥1 log that week. Reuse the
+   synthesized-cadence logic. Keep the per-pod comparison on the cross-pod view.
+
+2. **Response depth trend** *(keep, re-sourced)* — avg concatenated free-text
+   length per week across the version-appropriate text fields. Direct analog;
+   same "paragraphs → one-liners = disengaging" read.
+
+3. **Blocked rate** *(replaces "Tailwinds vs blockers")* — per week, share of
+   logs with `is_blocked = true`. The pulse tailwinds/blockers split has no
+   clean log analog; `is_blocked` is the honest blocker signal. Pair it with
+   (4) rather than inventing a "tailwind".
+
+4. **Health-rating trends** *(new, logs-only — a genuine upgrade)* — weekly
+   averages of the 1–5 ratings, viz'd as trend lines: `progress_rating`,
+   `energy_rating`, `capability_rating`, `collab_rating` (v2) and
+   `clarity`/`alignment` (v1). Decide the featured set in review (see Open
+   Decisions). These replace the crude char-count/keyword proxies pulses used.
+
+5. **Recent reflections → AI summary** *(keep, re-sourced)* — concatenate each
+   log's version-appropriate free-text (initials + week), newest first, capped
+   as today (24 pod / 32 cross-pod). Update `ai-summary-block.tsx` copy from
+   "pulse comments" to "Learning Log reflections" and revise
+   `cycle_config.ai_summary_prompt`'s default wording (it names pulses).
+
+6. **Recognition feed** *(new, optional)* — surface recent non-empty
+   `recognition` shout-outs. Low effort, high morale signal; can also be
+   appended to the AI-summary bundle.
+
+7. **Feeling-word cloud** *(new, optional / nice-to-have)* — frequency of
+   `feeling_word` over the range. Defer if it complicates Phase 1.
+
+## The hard gap — AI-tool adoption
+
+"Top AI tools" has **no Learning Log source.** Logs do not capture a per-week
+tool list the way `pulse_checks.survey_responses.tools_used` did. Resolve one
+of:
+
+- **(a) Drop the tile.** Simplest; accept that per-cycle AI-tool adoption is no
+  longer tracked on the moderator surface.
+- **(b) Add a `tools_used` field to the weekly log** (new migration + form
+  field + validation). Restores the metric natively; costs a log-form change.
+- **(c) Source from `baseline_responses`.** The onboarding baseline captures
+  `ai_usage_frequency` (not a tool list) — a *frequency* proxy, not adoption by
+  tool. Weaker, but zero new capture.
+
+**Recommendation:** (a) for the first cut, revisit (b) if the tool-adoption
+signal proves missed. This is a product decision — flagged, not assumed.
+
+## Legacy pods
+
+Mirror the deterministic split already used by the Recent-activity tab
+(`recent-activity-feed.tsx`) and `pod-detail.ts`: a pod whose cycle has real
+`pulse_checks` rows is a **legacy** pod and keeps the pulse-based insights
+verbatim; every other pod is log-based. Do not backfill or migrate pulse
+history into logs. New code paths read logs; the existing pulse functions stay
+for the legacy branch.
+
+## Privacy constraints
+
+- `clarity` / `alignment` (and the v2 ratings) are documented as private to the
+  member, their Poderator, and admins — "the metrics NEVER travel with a share"
+  (`00040` header). Aggregate rating trends on the **moderator-scoped** Insights
+  tab are fine; they must never leak into public `profile_updates` shares.
+- The AI-summary bundle stays **initials-only** (as today). Free-text pasted to
+  an external LLM is the moderator's action; keep the preview-before-copy flow.
+
+## Affected surfaces (implementation scope, for the eventual plan)
+
+- `lib/moderator/pod-insights.ts`, `lib/moderator/cross-pod-insights.ts` —
+  rewrite the metric computation against `learning_logs`; branch to the legacy
+  pulse path when the pod has pulse rows. Reuse `lib/learning-logs/at-risk.ts` +
+  `lib/cycle/week.ts` for week reconstruction.
+- `lib/moderator/rollup.ts` — `pulsesThisPeriod` → a logs-this-period /
+  completion measure (mechanical; same synthesis).
+- `insights-section.tsx`, `cross-pod-insights-section.tsx` — retitle tiles,
+  swap the depth/sentiment tiles for blocked-rate + rating trends, drop or
+  gate the AI-tools tile per the decision above.
+- `ai-summary-block.tsx` + `cycle_config.ai_summary_prompt` — reflection
+  wording.
+- `moderator/page.tsx` — fleet cards labeled/fed from logs.
+
+## Open decisions
+
+1. **AI-tools tile:** drop (a) / add log field (b) / baseline proxy (c). *Rec: (a).*
+2. **Featured ratings** for the health-trend tile: which of
+   progress/energy/capability/collab (v2) + clarity/alignment (v1) lead, and how
+   to present a cycle that mixes v1 and v2 logs.
+3. **Keep pulse insights for legacy pods**, or retire the panels entirely once
+   no active cycle is pulse-based? *Rec: keep the legacy branch; it's cheap.*
+4. **Recognition feed / feeling-word cloud:** Phase 1 or defer.
+
+## Suggested phasing
+
+- **Phase 1 (mechanical, high value):** completion trend + depth trend + AI
+  summary on logs; fleet rollup on logs. Reuses shipped synthesis; no schema
+  change; unblocks every current cohort.
+- **Phase 2:** blocked-rate + health-rating trends (the logs-only upgrade),
+  recognition feed.
+- **Phase 3:** resolve the AI-tools decision; feeling-word cloud.
+
+## Verification
+
+- Seed a log-based cycle with weekly logs spread across several cycle-weeks
+  (mixed v1/v2), some members skipping weeks. Confirm each Insights tile
+  populates: completion trend matches the synthesized cadence, depth reflects
+  the version-appropriate text, rating trends average correctly, AI bundle
+  lists initials-only reflections with the updated prompt.
+- A **legacy** pod (cycle with `pulse_checks` rows) still shows the original
+  pulse insights unchanged.
+- A brand-new cycle with no completed weeks shows empty-but-not-broken tiles
+  (no "No pulse history yet" copy).
+- Privacy: verify no rating/clarity value appears in any public share surface.

--- a/lib/auth/CLAUDE.md
+++ b/lib/auth/CLAUDE.md
@@ -177,7 +177,7 @@ Files:
   roles: Role[];             // owner, admin, observer, developer, moderator, participant
   permissions: Permission[]; // granular grants from participant_permissions
   moderatorPodIds: number[];
-  cycleEnrollments: { cycleId: number; status: "active" | "inactive" | "revoked" }[];
+  cycleEnrollments: { cycleId: number; status: "registered" | "active" | "inactive" | "revoked" }[];
 }
 ```
 

--- a/lib/auth/roles.test.ts
+++ b/lib/auth/roles.test.ts
@@ -166,6 +166,30 @@ describe("resolveUserRoles authority derivation", () => {
     expect(u.roles).toContain("participant");
   });
 
+  it("registered enrollment adds the participant role (pre-pod member)", async () => {
+    const u = await resolveUserRoles(
+      mockClient(
+        withParticipant({
+          cycle_enrollments: [{ cycle_id: 1, status: "registered" }],
+        })
+      ),
+      "auth-1"
+    );
+    expect(u.roles).toContain("participant");
+  });
+
+  it("inactive enrollment does NOT add the participant role (engagement exit)", async () => {
+    const u = await resolveUserRoles(
+      mockClient(
+        withParticipant({
+          cycle_enrollments: [{ cycle_id: 1, status: "inactive" }],
+        })
+      ),
+      "auth-1"
+    );
+    expect(u.roles).not.toContain("participant");
+  });
+
   it("no participant row → empty authority", async () => {
     const u = await resolveUserRoles(mockClient({ participants: null }), "auth-1");
     expect(u.participantId).toBeNull();
@@ -175,9 +199,10 @@ describe("resolveUserRoles authority derivation", () => {
 });
 
 /* Enrollment predicates for the cycle phase gates. isEnrolledParticipant is
-   the phase-1/2 gate (problem statements, voting): enrolled-but-'inactive'
-   is the normal pre-pod state and must pass; 'revoked' and not-enrolled must
-   not. isActiveParticipant stays the gate for pod-scoped phases. */
+   the phase-1/2 gate (problem statements, voting): 'registered' is the normal
+   pre-pod state and must pass; 'inactive' (an engagement exit) and 'revoked'
+   and not-enrolled must not. isActiveParticipant stays the gate for pod-scoped
+   phases. */
 
 import {
   isActiveParticipant,
@@ -224,9 +249,14 @@ describe("isEnrolledParticipant", () => {
     expect(isEnrolledParticipant(u, 1)).toBe(true);
   });
 
-  it("accepts inactive enrollments (pre-pod-registration state)", () => {
-    const u = fixtureUser({ cycleEnrollments: [{ cycleId: 1, status: "inactive" }] });
+  it("accepts registered enrollments (pre-pod state)", () => {
+    const u = fixtureUser({ cycleEnrollments: [{ cycleId: 1, status: "registered" }] });
     expect(isEnrolledParticipant(u, 1)).toBe(true);
+  });
+
+  it("rejects inactive enrollments (engagement exit)", () => {
+    const u = fixtureUser({ cycleEnrollments: [{ cycleId: 1, status: "inactive" }] });
+    expect(isEnrolledParticipant(u, 1)).toBe(false);
   });
 
   it("rejects revoked enrollments", () => {

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -2,7 +2,11 @@ import { SupabaseClient } from "@supabase/supabase-js";
 import { capabilitiesForRoles, type Permission } from "./permissions";
 
 export type Role = "owner" | "admin" | "observer" | "developer" | "moderator" | "participant";
-export type ParticipantStatus = "active" | "inactive" | "revoked";
+export type ParticipantStatus =
+  | "registered"
+  | "active"
+  | "inactive"
+  | "revoked";
 
 export interface UserRoles {
   userId: string;
@@ -100,7 +104,10 @@ export async function resolveUserRoles(
   if (enrollments) {
     for (const e of enrollments) {
       cycleEnrollments.push({ cycleId: e.cycle_id, status: e.status });
-      if (e.status === "active") {
+      // Membership, not pod-activation: a 'registered' member (committed,
+      // pre-pod) is as much a participant as an 'active' one (in a pod).
+      // Only the engagement exits ('inactive'/'revoked') withhold the role.
+      if (e.status === "registered" || e.status === "active") {
         if (!roles.includes("participant")) roles.push("participant");
       }
     }
@@ -157,20 +164,24 @@ export function isActiveParticipant(roles: UserRoles, cycleId: number): boolean 
 }
 
 /**
- * True if the user is enrolled in the cycle and not revoked.
+ * True if the user is a member of the cycle in good standing — 'registered'
+ * (committed, pre-pod) or 'active' (in a pod). Excludes the engagement exits
+ * 'inactive' and 'revoked'.
  *
  * Use this — not isActiveParticipant — to gate the pre-pod phases (problem
- * statement submission, problem-statement voting). Enrollment `status`
- * tracks pod-membership reality: self-service registration writes
- * 'inactive' by design, and the reconciler (lib/enrollment/reconciler.ts)
- * only flips it to 'active' once the participant has an active pod
- * membership — which cannot exist before pod registration (phase 3).
- * Gating phases 1–2 on status='active' therefore deadlocks every cycle
- * populated through the app: nobody can submit or vote, so pods are never
- * created, so nobody ever becomes 'active'.
+ * statement submission, problem-statement voting). Self-service registration
+ * writes 'registered', and the reconciler (lib/enrollment/reconciler.ts) only
+ * flips it to 'active' once the participant has an active pod membership —
+ * which cannot exist before pod registration (phase 3). Gating phases 1–2 on
+ * status='active' therefore deadlocks every cycle populated through the app:
+ * nobody can submit or vote, so pods are never created, so nobody ever
+ * becomes 'active'. 'inactive' is now a genuine exit (missed the weekly-log
+ * cadence), so it — unlike the old pre-pod 'inactive' — is correctly withheld.
  */
 export function isEnrolledParticipant(roles: UserRoles, cycleId: number): boolean {
   return roles.cycleEnrollments.some(
-    (e) => e.cycleId === cycleId && e.status !== "revoked"
+    (e) =>
+      e.cycleId === cycleId &&
+      (e.status === "registered" || e.status === "active")
   );
 }

--- a/lib/email/revocation-warning-template.ts
+++ b/lib/email/revocation-warning-template.ts
@@ -4,12 +4,15 @@
  * pulse-check-reminder-template.ts so subject/HTML/text are consumed
  * the same way by the cron's Resend integration.
  *
- * Two variants today, distinguishing the WHY behind the warning:
+ * Variants distinguishing the WHY behind the warning:
  *
- *   - 'not_in_pod'    — pod_registration_close has passed and the
- *                       participant still has no active pod
- *   - 'missed_pulses' — participant has the configured number of
- *                       consecutive missed pulses
+ *   - 'missed_logs'   — participant (in a pod) has the configured number of
+ *                       consecutive missed weekly Learning Log windows. This
+ *                       is the live reason under the registered/active model.
+ *   - 'missed_pulses' — legacy: consecutive missed pulse checks (kept for
+ *                       historical audit rows / the manual admin sweep).
+ *   - 'not_in_pod'    — legacy: pod_registration_close passed with no pod.
+ *                       No longer written (being pod-less is 'registered').
  *
  * Tone is firm but recoverable. The deadline language is intentionally
  * concrete: "your access will be paused in 3 days" rather than "your
@@ -18,7 +21,10 @@
  * inactive participant can be reactivated by re-engagement.
  */
 
-export type RevocationWarningReason = "not_in_pod" | "missed_pulses";
+export type RevocationWarningReason =
+  | "missed_logs"
+  | "missed_pulses"
+  | "not_in_pod";
 
 type WarningProps = {
   reason: RevocationWarningReason;
@@ -35,6 +41,14 @@ function variantCopy(reason: RevocationWarningReason): {
   cta: string;
 } {
   switch (reason) {
+    case "missed_logs":
+      return {
+        subject: "Your Upskilling Labs cohort access pauses in 3 days",
+        heading: "We haven't heard from you in a while",
+        lede:
+          "You've missed your last few weekly Learning Logs. To stay active in the cohort, please save a Learning Log from your dashboard in the next <strong style=\"color:#ffffff;\">3 days</strong>. After that your cohort access will be paused — but you can rejoin anytime by logging.",
+        cta: "Open your dashboard →",
+      };
     case "not_in_pod":
       return {
         subject: "Your Upskilling Labs cohort access pauses in 3 days",
@@ -56,6 +70,8 @@ function variantCopy(reason: RevocationWarningReason): {
 
 function variantTextLede(reason: RevocationWarningReason): string {
   switch (reason) {
+    case "missed_logs":
+      return "You've missed your last few weekly Learning Logs. To stay active in the cohort, please save a Learning Log from your dashboard in the next 3 days. After that your cohort access will be paused — but you can rejoin anytime by logging.";
     case "not_in_pod":
       return "Pod registration for this cycle has closed and you haven't joined a pod. To stay active in the cohort, please reach out to your cycle organizer or accept a pod invitation in the next 3 days. After that your cohort access will be paused.";
     case "missed_pulses":

--- a/lib/email/revocation-warning-template.ts
+++ b/lib/email/revocation-warning-template.ts
@@ -1,18 +1,17 @@
 /**
  * Warning email sent by the two-stage revocation cron (#110 Phase C)
- * three days before any actual revocation. Mirrors the structure of
- * pulse-check-reminder-template.ts so subject/HTML/text are consumed
- * the same way by the cron's Resend integration.
+ * three days before any actual revocation. Mirrors the structure of the
+ * learning-log-reminder template so subject/HTML/text are consumed the same
+ * way by the cron's Resend integration.
  *
- * Variants distinguishing the WHY behind the warning:
+ * One reason under the registered/active model (migration 00092):
  *
- *   - 'missed_logs'   — participant (in a pod) has the configured number of
- *                       consecutive missed weekly Learning Log windows. This
- *                       is the live reason under the registered/active model.
- *   - 'missed_pulses' — legacy: consecutive missed pulse checks (kept for
- *                       historical audit rows / the manual admin sweep).
- *   - 'not_in_pod'    — legacy: pod_registration_close passed with no pod.
- *                       No longer written (being pod-less is 'registered').
+ *   - 'missed_logs' — an in-pod ('active') member has the configured number
+ *                     of consecutive missed weekly Learning Log windows.
+ *
+ * (The earlier 'missed_pulses' / 'not_in_pod' reasons are retired: the weekly
+ * Learning Log replaced the pulse cadence, and being pod-less is now the
+ * 'registered' resting state rather than a revocation.)
  *
  * Tone is firm but recoverable. The deadline language is intentionally
  * concrete: "your access will be paused in 3 days" rather than "your
@@ -21,10 +20,7 @@
  * inactive participant can be reactivated by re-engagement.
  */
 
-export type RevocationWarningReason =
-  | "missed_logs"
-  | "missed_pulses"
-  | "not_in_pod";
+export type RevocationWarningReason = "missed_logs";
 
 type WarningProps = {
   reason: RevocationWarningReason;
@@ -49,22 +45,6 @@ function variantCopy(reason: RevocationWarningReason): {
           "You've missed your last few weekly Learning Logs. To stay active in the cohort, please save a Learning Log from your dashboard in the next <strong style=\"color:#ffffff;\">3 days</strong>. After that your cohort access will be paused — but you can rejoin anytime by logging.",
         cta: "Open your dashboard →",
       };
-    case "not_in_pod":
-      return {
-        subject: "Your Upskilling Labs cohort access pauses in 3 days",
-        heading: "You haven't joined a pod yet",
-        lede:
-          "Pod registration for this cycle has closed and you haven't joined a pod. To stay active in the cohort, please reach out to your cycle organizer or accept a pod invitation in the next <strong style=\"color:#ffffff;\">3 days</strong>. After that your cohort access will be paused.",
-        cta: "Open your dashboard →",
-      };
-    case "missed_pulses":
-      return {
-        subject: "Your Upskilling Labs cohort access pauses in 3 days",
-        heading: "We haven't heard from you in a while",
-        lede:
-          "You've missed your last two pulse checks. To stay active in the cohort, please submit a pulse check in the next <strong style=\"color:#ffffff;\">3 days</strong>. After that your cohort access will be paused — but you can rejoin anytime.",
-        cta: "Submit pulse check →",
-      };
   }
 }
 
@@ -72,10 +52,6 @@ function variantTextLede(reason: RevocationWarningReason): string {
   switch (reason) {
     case "missed_logs":
       return "You've missed your last few weekly Learning Logs. To stay active in the cohort, please save a Learning Log from your dashboard in the next 3 days. After that your cohort access will be paused — but you can rejoin anytime by logging.";
-    case "not_in_pod":
-      return "Pod registration for this cycle has closed and you haven't joined a pod. To stay active in the cohort, please reach out to your cycle organizer or accept a pod invitation in the next 3 days. After that your cohort access will be paused.";
-    case "missed_pulses":
-      return "You've missed your last two pulse checks. To stay active in the cohort, please submit a pulse check in the next 3 days. After that your cohort access will be paused — but you can rejoin anytime.";
   }
 }
 

--- a/lib/enrollment/reconciler.test.ts
+++ b/lib/enrollment/reconciler.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-/* The reconciler is THE single write path for the enrollment lifecycle
-   (§3.7). These tests pin its contract with a hand-rolled Supabase mock:
+/* The reconciler is THE single write path for the registered <-> active
+   enrollment lifecycle. These tests pin its contract with a hand-rolled
+   Supabase mock:
    - no enrollment row → no mutation
-   - membership reality decides the target status
+   - membership reality decides the target ('active' vs 'registered')
    - already-correct status → no write
-   - demotion with logRevocation → audit row */
+   - it NEVER writes 'inactive'; a demote from active lands at 'registered'
+   - exits ('inactive'/'revoked') are sticky unless opts.recover re-derives */
 
 const state: {
   enrollment: { id: number; status: string } | null;
@@ -128,20 +130,20 @@ describe("reconcileEnrollmentActivation", () => {
     expect(state.updates).toHaveLength(0);
   });
 
-  it("promotes to active when an active-pod membership exists", async () => {
-    state.enrollment = { id: 10, status: "inactive" };
+  it("promotes registered → active when an active-pod membership exists", async () => {
+    state.enrollment = { id: 10, status: "registered" };
     state.memberships = [activePod];
     const result = await reconcileEnrollmentActivation(7, 1);
-    expect(result).toMatchObject({ before: "inactive", after: "active", mutated: true });
+    expect(result).toMatchObject({ before: "registered", after: "active", mutated: true });
     expect(state.updates[0]).toMatchObject({ status: "active", inactive_date: null });
   });
 
-  it("a forming pod is not enough to activate", async () => {
-    state.enrollment = { id: 10, status: "inactive" };
+  it("a forming pod is not enough to activate — stays registered", async () => {
+    state.enrollment = { id: 10, status: "registered" };
     state.memberships = [formingPod];
     const result = await reconcileEnrollmentActivation(7, 1);
     expect(result.mutated).toBe(false);
-    expect(result.after).toBe("inactive");
+    expect(result.after).toBe("registered");
   });
 
   it("is idempotent when status already matches reality", async () => {
@@ -152,27 +154,43 @@ describe("reconcileEnrollmentActivation", () => {
     expect(state.updates).toHaveLength(0);
   });
 
-  it("demotes and audits when asked (the cron path)", async () => {
-    state.enrollment = { id: 10, status: "active" };
-    state.memberships = [];
-    const result = await reconcileEnrollmentActivation(7, 1, {
-      logRevocation: true,
-      reason: "test",
-    });
-    expect(result).toMatchObject({ after: "inactive", mutated: true, audited: true });
-    expect(state.inserts[0].row).toMatchObject({
-      participant_id: 7,
-      cycle_id: 1,
-      reason: "test",
-    });
-  });
-
-  it("demotes silently without logRevocation (mechanical after-leave path)", async () => {
+  it("demotes active → registered when the last active pod is gone (never inactive, no audit)", async () => {
     state.enrollment = { id: 10, status: "active" };
     state.memberships = [];
     const result = await reconcileEnrollmentActivation(7, 1);
-    expect(result.audited).toBe(false);
-    expect(state.inserts).toHaveLength(0);
+    expect(result).toMatchObject({ before: "active", after: "registered", mutated: true });
+    expect(state.updates[0]).toMatchObject({ status: "registered", inactive_date: null });
+    expect(state.inserts).toHaveLength(0); // reconciler never writes access_revocations
+  });
+
+  it("leaves an inactive exit sticky — does not undo a revocation", async () => {
+    state.enrollment = { id: 10, status: "inactive" };
+    state.memberships = [activePod];
+    const result = await reconcileEnrollmentActivation(7, 1);
+    expect(result.mutated).toBe(false);
+    expect(result.after).toBe("inactive");
+    expect(state.updates).toHaveLength(0);
+  });
+
+  it("recover re-derives an inactive row from pod reality and clears the exit bookkeeping", async () => {
+    state.enrollment = { id: 10, status: "inactive" };
+    state.memberships = [activePod];
+    const result = await reconcileEnrollmentActivation(7, 1, { recover: true });
+    expect(result).toMatchObject({ before: "inactive", after: "active", mutated: true });
+    expect(state.updates[0]).toMatchObject({
+      status: "active",
+      inactive_date: null,
+      warned_at: null,
+      warning_reason: null,
+    });
+  });
+
+  it("recover with no active pod lands the member at registered", async () => {
+    state.enrollment = { id: 10, status: "inactive" };
+    state.memberships = [];
+    const result = await reconcileEnrollmentActivation(7, 1, { recover: true });
+    expect(result).toMatchObject({ after: "registered", mutated: true });
+    expect(state.updates[0]).toMatchObject({ status: "registered", warned_at: null });
   });
 });
 
@@ -184,7 +202,7 @@ describe("ensureActivePodMembership", () => {
 
   it("inserts a new pod_memberships row, seeds cycle_enrollments, and reconciles", async () => {
     state.membershipRow = null;
-    state.enrollment = { id: 20, status: "inactive" };
+    state.enrollment = { id: 20, status: "registered" };
     state.memberships = [activePod];
 
     await ensureActivePodMembership(7, 6, 2);
@@ -218,7 +236,7 @@ describe("ensureActivePodMembership", () => {
     // this helper for org runs — the helper must tolerate the row it didn't
     // create and still seed + reconcile the enrollment.
     state.membershipRow = { id: 99, inactive_at: null };
-    state.enrollment = { id: 20, status: "inactive" };
+    state.enrollment = { id: 20, status: "registered" };
     state.memberships = [activePod];
 
     await ensureActivePodMembership(7, 6, 2);

--- a/lib/enrollment/reconciler.ts
+++ b/lib/enrollment/reconciler.ts
@@ -1,20 +1,34 @@
 import { createServiceClient } from "@/lib/supabase/server";
 import { followPageSilently } from "@/lib/follows/seed";
 
-export type EnrollmentStatus = "active" | "inactive";
+/**
+ * The two states the reconciler manages. 'registered' (committed member, no
+ * active pod yet) and 'active' (member with an active pod) are the two ends
+ * of the pod-activation axis. 'inactive' (engagement exit) and 'revoked'
+ * (archive) live OUTSIDE this axis — the reconciler never writes them and,
+ * by default, never touches a row that already holds one (see opts.recover).
+ */
+export type EnrollmentStatus = "registered" | "active" | "inactive";
 
 export interface ReconcileOptions {
-  reason?: string;
-  logRevocation?: boolean;
+  /**
+   * When true, a current exit ('inactive' engagement revocation) is treated
+   * as recoverable: the status is re-derived from pod reality (→ 'active' if
+   * an active pod exists, else 'registered') and the exit bookkeeping
+   * (inactive_date / warned_at / warning_reason) is cleared. The two recovery
+   * callers — admin reactivation and auto-recover-on-log — pass this; normal
+   * pod join/leave reconciles do not, so an engagement exit stays put until a
+   * deliberate recovery.
+   */
+  recover?: boolean;
 }
 
 export interface ReconcileResult {
   participantId: number;
   cycleId: number;
-  before: EnrollmentStatus | null;
-  after: EnrollmentStatus | null;
+  before: string | null;
+  after: string | null;
   mutated: boolean;
-  audited: boolean;
 }
 
 interface PodMembershipRow {
@@ -25,20 +39,23 @@ interface PodMembershipRow {
 /**
  * Brings cycle_enrollments.status in line with current pod membership reality
  * for one (participant, cycle) pair. Single source of truth for the
- * inactive <-> active enrollment transition across the codebase.
+ * registered <-> active enrollment transition across the codebase.
  *
  * Target status:
  *   - 'active' if the participant has at least one active pod_memberships
  *     row (inactive_at IS NULL) whose pod is itself status='active'.
- *   - 'inactive' otherwise.
+ *   - 'registered' otherwise (committed member, just not in an active pod).
+ *
+ * The reconciler NEVER writes 'inactive'. That value is an engagement exit
+ * owned exclusively by the revocation cron / admin sweep (which also write
+ * the access_revocations audit row). Exits are sticky here: a row already at
+ * 'inactive' or 'revoked' is left untouched — otherwise the next pod reconcile
+ * would silently undo a revocation. Deliberate recovery comes through
+ * opts.recover (admin reactivation, or the member's next qualifying log).
  *
  * Idempotent. If no cycle_enrollments row exists, returns without mutating
  * (creation belongs in registration / cycle-interest routes). If status
  * already matches target, returns without mutating.
- *
- * On demotion (active -> inactive), optionally writes an access_revocations
- * audit row when opts.logRevocation === true. The cron will opt in; inline
- * after-leave callers will not, since their demotions are mechanical.
  *
  * Uses a service client internally because cycle_enrollments is gated by
  * is_admin_or_owner() RLS — a cookie-bound user client would silently
@@ -58,20 +75,15 @@ export async function reconcileEnrollmentActivation(
     .eq("cycle_id", cycleId)
     .maybeSingle();
 
-  const before: EnrollmentStatus | null =
-    enrollment?.status === "active" || enrollment?.status === "inactive"
-      ? enrollment.status
-      : null;
+  const before: string | null = enrollment?.status ?? null;
 
   if (!enrollment) {
-    return {
-      participantId,
-      cycleId,
-      before,
-      after: null,
-      mutated: false,
-      audited: false,
-    };
+    return { participantId, cycleId, before, after: null, mutated: false };
+  }
+
+  // Exits are sticky (see doc above): only a recover call may re-derive them.
+  if ((before === "inactive" || before === "revoked") && !opts.recover) {
+    return { participantId, cycleId, before, after: before, mutated: false };
   }
 
   const { data: memberships } = await client
@@ -83,47 +95,32 @@ export async function reconcileEnrollmentActivation(
 
   const rows = (memberships ?? []) as unknown as PodMembershipRow[];
   const hasActivePod = rows.some((m) => m.pods?.status === "active");
-  const target: EnrollmentStatus = hasActivePod ? "active" : "inactive";
+  const target: EnrollmentStatus = hasActivePod ? "active" : "registered";
 
   if (before === target) {
-    return {
-      participantId,
-      cycleId,
-      before,
-      after: before,
-      mutated: false,
-      audited: false,
-    };
+    return { participantId, cycleId, before, after: target, mutated: false };
   }
 
-  const nowIso = new Date().toISOString();
+  const update: {
+    status: EnrollmentStatus;
+    inactive_date: null;
+    warned_at?: null;
+    warning_reason?: null;
+  } = { status: target, inactive_date: null };
+
+  if (opts.recover) {
+    // Recovering out of an exit — clear the engagement-exit bookkeeping so
+    // the member is fully reset, not merely re-statused.
+    update.warned_at = null;
+    update.warning_reason = null;
+  }
+
   await client
     .from("cycle_enrollments")
-    .update({
-      status: target,
-      inactive_date: target === "inactive" ? nowIso : null,
-    })
+    .update(update)
     .eq("id", enrollment.id);
 
-  let audited = false;
-  if (target === "inactive" && opts.logRevocation) {
-    await client.from("access_revocations").insert({
-      participant_id: participantId,
-      cycle_id: cycleId,
-      reason: opts.reason ?? "reconciler: no active pod memberships",
-      revocation_scope: "full",
-    });
-    audited = true;
-  }
-
-  return {
-    participantId,
-    cycleId,
-    before,
-    after: target,
-    mutated: true,
-    audited,
-  };
+  return { participantId, cycleId, before, after: target, mutated: true };
 }
 
 /**

--- a/lib/learning-logs/at-risk.test.ts
+++ b/lib/learning-logs/at-risk.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { consecutiveMissedLogWeeks } from "./at-risk";
+
+// A 13-week cycle: getCycleWeek slices [start, end] into weeks 0–12, so each
+// week is 1/13 of the span. With a 13-day cycle, week N ≈ day N.
+const start = new Date("2026-01-01T00:00:00Z");
+const end = new Date("2026-01-14T00:00:00Z"); // 13 days → ~1 day per week
+
+/** created_at at the midpoint of cycle-week `w`. */
+function weekMid(w: number): Date {
+  const totalMs = end.getTime() - start.getTime();
+  return new Date(start.getTime() + ((w + 0.5) * totalMs) / 13);
+}
+/** "now" at the midpoint of week `w` (so weeks 0..w-1 are completed). */
+const nowInWeek = weekMid;
+
+describe("consecutiveMissedLogWeeks", () => {
+  it("returns 0 before the cycle has any completed week", () => {
+    // now during week 0 → no completed week yet
+    expect(consecutiveMissedLogWeeks(nowInWeek(0), start, end, [])).toBe(0);
+    // before the cycle starts
+    expect(
+      consecutiveMissedLogWeeks(new Date("2025-12-01T00:00:00Z"), start, end, [])
+    ).toBe(0);
+  });
+
+  it("counts consecutive empty completed weeks back from the last completed one", () => {
+    // now in week 4 → weeks 0,1,2,3 completed; no logs at all → 4 misses
+    expect(consecutiveMissedLogWeeks(nowInWeek(4), start, end, [])).toBe(4);
+  });
+
+  it("does not count the in-progress current week as a miss", () => {
+    // now in week 2 → completed weeks 0,1. A log in week 0 breaks the run at
+    // the earliest completed week, so only week 1 is missed.
+    expect(
+      consecutiveMissedLogWeeks(nowInWeek(2), start, end, [weekMid(0)])
+    ).toBe(1);
+  });
+
+  it("stops at the most recent completed week that has a log", () => {
+    // now in week 5 → completed 0..4. Log in week 3 → weeks 4 missed (just 1),
+    // run stops at week 3.
+    expect(
+      consecutiveMissedLogWeeks(nowInWeek(5), start, end, [weekMid(3)])
+    ).toBe(1);
+  });
+
+  it("a log in the current (in-progress) week does not reset earlier misses", () => {
+    // now in week 3 → completed 0,1,2 all empty; the only log is in week 3
+    // (current, not completed) → 3 misses stand.
+    expect(
+      consecutiveMissedLogWeeks(nowInWeek(3), start, end, [weekMid(3)])
+    ).toBe(3);
+  });
+
+  it("baseline logs before week 0 satisfy nothing", () => {
+    const beforeStart = new Date("2025-12-20T00:00:00Z");
+    expect(
+      consecutiveMissedLogWeeks(nowInWeek(3), start, end, [beforeStart])
+    ).toBe(3);
+  });
+});

--- a/lib/learning-logs/at-risk.ts
+++ b/lib/learning-logs/at-risk.ts
@@ -1,0 +1,44 @@
+import { getCycleWeek } from "@/lib/cycle/week";
+
+/**
+ * The weekly Learning Log's engagement signal, the counterpart to
+ * deriveAtRiskRun (lib/moderator/nudges.ts) for pulse checks. The pulse
+ * detector reads per-week pulse_checks rows; the Learning Log has no such
+ * per-window schedule table (the gate is driven by a single rolling
+ * cycle_config.log_due_at stamp), so we reconstruct the weekly windows from
+ * the cycle calendar the way the rest of the app does — getCycleWeek buckets
+ * [start, end] into 13 equal weeks (0–12).
+ *
+ * "Missed a week" = a completed cycle-week with no learning_logs row
+ * attributed to the cycle in it. Any kind counts (weekly, milestone review,
+ * org) — filing *something* that week is engagement. The in-progress current
+ * week is never counted as a miss (the member still has time to log it), and
+ * baseline/standalone logs filed before week 0 satisfy nothing.
+ *
+ * Returns the number of consecutive missed weeks counting back from the most
+ * recently COMPLETED week; 0 before the cycle has any completed week.
+ */
+export function consecutiveMissedLogWeeks(
+  now: Date,
+  cycleStart: Date,
+  cycleEnd: Date,
+  logCreatedAts: Date[]
+): number {
+  const currentWeek = getCycleWeek(now, cycleStart, cycleEnd);
+  // Completed weeks are 0 .. currentWeek-1. getCycleWeek returns -1 before the
+  // cycle starts and 13 after it ends; clamp so "last completed" never exceeds
+  // week 12.
+  const lastCompleted = Math.min(currentWeek, 13) - 1;
+  if (lastCompleted < 0) return 0;
+
+  const loggedWeeks = new Set(
+    logCreatedAts.map((d) => getCycleWeek(d, cycleStart, cycleEnd))
+  );
+
+  let consecutive = 0;
+  for (let w = lastCompleted; w >= 0; w--) {
+    if (loggedWeeks.has(w)) break;
+    consecutive++;
+  }
+  return consecutive;
+}

--- a/lib/learning-logs/eligible.ts
+++ b/lib/learning-logs/eligible.ts
@@ -1,25 +1,48 @@
 import { createServiceClient } from "@/lib/supabase/server";
+import type { ParticipantStatus } from "@/lib/auth/roles";
 
 /* The single definition of "cycles this member can log against": every
    currently active cycle (any mode — org cycles included, migration 00060)
-   intersected with the member's own active enrollment in it. Three call
-   sites used to run near-duplicates of this pair of queries and drifted
+   intersected with the member's own enrollment in it. Three call sites used
+   to run near-duplicates of this pair of queries and drifted
    (lib/learning-logs/gate.ts's gate prologue, app/api/learning-logs/route.ts's
    resolveEligibleCycles, and app/(dashboard)/dashboard/page.tsx's inline
    two-mode list) — this is now the only place that answers the question, so
    a mode='closed' active-cycle enrollment (or any future mode) is handled
    identically everywhere instead of only wherever someone remembered to
-   list it. */
+   list it.
+
+   Eligibility (who may FILE a log) spans every in-cohort status —
+   'registered' (committed, pre-pod), 'active' (in a pod), and 'inactive'
+   (an engagement exit). Registered members log because logging is available
+   from the moment someone joins the cohort, before pods form; inactive
+   members log because a qualifying log is exactly what RECOVERS them to
+   'active' (app/api/learning-logs/route.ts). Only 'revoked' (hard archive) is
+   excluded. The weekly-log LOCK is narrower: gate.ts asks for
+   statuses:['active'] only, so a pre-pod 'registered' member can log but is
+   never locked out. Each returned cycle carries the member's enrollment
+   `status` so the gate can filter a wide precomputed list down to the
+   active-only lockable set. */
 
 export interface EligibleLogCycle {
   id: number;
   name: string;
   mode: string;
+  /** The member's cycle_enrollments.status for this cycle. */
+  status: ParticipantStatus;
 }
 
+const DEFAULT_STATUSES: ParticipantStatus[] = [
+  "registered",
+  "active",
+  "inactive",
+];
+
 export async function eligibleLogCycles(
-  participantId: number
+  participantId: number,
+  opts: { statuses?: ParticipantStatus[] } = {}
 ): Promise<EligibleLogCycle[]> {
+  const statuses = opts.statuses ?? DEFAULT_STATUSES;
   const supabase = createServiceClient();
 
   const { data: cycles } = await supabase
@@ -32,11 +55,15 @@ export async function eligibleLogCycles(
 
   const { data: enrollments } = await supabase
     .from("cycle_enrollments")
-    .select("cycle_id")
+    .select("cycle_id, status")
     .eq("participant_id", participantId)
-    .eq("status", "active")
+    .in("status", statuses)
     .in("cycle_id", cycleIds);
-  const enrolledCycleIds = new Set((enrollments ?? []).map((e) => e.cycle_id));
+  const statusByCycle = new Map<number, ParticipantStatus>(
+    (enrollments ?? []).map((e) => [e.cycle_id, e.status as ParticipantStatus])
+  );
 
-  return cycles.filter((c) => enrolledCycleIds.has(c.id));
+  return cycles
+    .filter((c) => statusByCycle.has(c.id))
+    .map((c) => ({ ...c, status: statusByCycle.get(c.id) as ParticipantStatus }));
 }

--- a/lib/learning-logs/gate.ts
+++ b/lib/learning-logs/gate.ts
@@ -61,13 +61,17 @@ export async function learningLogGate(
 ): Promise<LogGateState> {
   const supabase = createServiceClient();
 
-  // Every currently active cycle, across modes, the member is actively
-  // enrolled in — 00060 means more than one can legitimately come back (the
-  // participant cycle and the org cycle). The single definition lives in
-  // lib/learning-logs/eligible.ts so gate.ts, the learning-logs route, and
-  // the dashboard never drift on what "eligible" means.
-  const enrolledCycles =
-    precomputedEligibleCycles ?? (await eligibleLogCycles(participantId));
+  // The lock has teeth ONLY for 'active' (in-a-pod) members — a pre-pod
+  // 'registered' member can file logs but is never locked out (the weekly
+  // cadence is a pod practice). So the gate narrows to active-only: it either
+  // fetches active-only itself, or filters a wide precomputed list (the log
+  // route hands us the registered|active composer list) down to active. 00060
+  // means more than one active cycle can come back (the participant cycle and
+  // the org cycle) for a dual-enrolled staff member.
+  const enrolledCycles = (
+    precomputedEligibleCycles ??
+    (await eligibleLogCycles(participantId, { statuses: ["active"] }))
+  ).filter((c) => c.status === "active");
   if (enrolledCycles.length === 0) return INACTIVE;
 
   const { data: configs } = await supabase

--- a/lib/moderator/pod-detail.ts
+++ b/lib/moderator/pod-detail.ts
@@ -20,8 +20,60 @@ import {
   type PulseHealthCfg,
 } from "./pulse-health";
 import { atRiskNudgeKey, deriveAtRiskRun, loadDismissedKeys, isDismissed } from "./nudges";
+import { getCycleWeek, getCycleWeekStart } from "@/lib/cycle/week";
 
 const DEFAULT_AT_RISK_MISSES = 2;
+
+// A member's weekly cadence, expressed as pulse-shaped rows so the whole
+// status/streak/miss/bucket engine below works unchanged regardless of source.
+// Legacy pods feed real pulse_checks rows; log-based (current) cycles feed
+// rows SYNTHESIZED from the weekly Learning Log windows — one row per
+// completed cycle-week, completed_at set iff a log was filed that week.
+type CadenceRow = {
+  participant_id: number;
+  scheduled_date: string;
+  completed_at: string | null;
+};
+
+/**
+ * Synthesize a member's weekly cadence from their Learning Logs: for each
+ * completed cycle-week (getCycleWeek buckets [start,end] into weeks 0–12), a
+ * row keyed by that week's start, marked completed iff any cycle-attributed
+ * log lands in it. The in-progress current week is not emitted (can't be
+ * "missed" yet). Mirrors the pulse stream shape consumed downstream.
+ */
+function synthesizeLogCadence(
+  participantId: number,
+  now: Date,
+  cycleStart: Date,
+  cycleEnd: Date,
+  logCreatedAts: Date[]
+): CadenceRow[] {
+  const currentWeek = getCycleWeek(now, cycleStart, cycleEnd);
+  const lastCompleted = Math.min(currentWeek, 13) - 1;
+  if (lastCompleted < 0) return [];
+
+  const latestLogByWeek = new Map<number, string>();
+  for (const d of logCreatedAts) {
+    const w = getCycleWeek(d, cycleStart, cycleEnd);
+    const iso = d.toISOString();
+    const prev = latestLogByWeek.get(w);
+    if (!prev || iso > prev) latestLogByWeek.set(w, iso);
+  }
+
+  const rows: CadenceRow[] = [];
+  for (let w = 0; w <= lastCompleted; w++) {
+    const weekKey = getCycleWeekStart(w, cycleStart, cycleEnd)
+      .toISOString()
+      .slice(0, 10);
+    rows.push({
+      participant_id: participantId,
+      scheduled_date: weekKey,
+      completed_at: latestLogByWeek.get(w) ?? null,
+    });
+  }
+  return rows;
+}
 
 export type PulseStatus = "current" | "pending" | "late" | "at_risk";
 
@@ -103,7 +155,7 @@ export async function getPodDetail(
     .select(`
       id, name, status, cycle_id,
       slack_channel_id, drive_folder_id, github_repo_url,
-      cycles (id, name, mode)
+      cycles (id, name, mode, start_date, end_date)
     `)
     .eq("id", podId)
     .single();
@@ -152,12 +204,7 @@ export async function getPodDetail(
   const fourWeeksAgo = new Date();
   fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
 
-  type PulseRow = {
-    participant_id: number;
-    scheduled_date: string;
-    completed_at: string | null;
-  };
-  let pulseRows: PulseRow[] = [];
+  let pulseRows: CadenceRow[] = [];
   if (memberIds.length > 0) {
     const { data } = await supabase
       .from("pulse_checks")
@@ -166,14 +213,62 @@ export async function getPodDetail(
       .eq("cycle_id", pod.cycle_id as number)
       .gte("scheduled_date", fourWeeksAgo.toISOString().slice(0, 10))
       .order("scheduled_date");
-    pulseRows = (data ?? []) as PulseRow[];
+    pulseRows = (data ?? []) as CadenceRow[];
   }
 
-  const pulsesByMember = new Map<number, PulseRow[]>();
-  for (const p of pulseRows) {
-    const arr = pulsesByMember.get(p.participant_id) ?? [];
-    arr.push(p);
-    pulsesByMember.set(p.participant_id, arr);
+  // The engagement signal is now the weekly Learning Log. A pod with real
+  // pulse_checks rows is a LEGACY pod (old cycle) and keeps its pulse-based
+  // health, deterministically — matching the Recent-activity tab's split
+  // (app/(dashboard)/moderator/pods/[pod_id]/recent-activity-feed.tsx). Every
+  // other pod's cadence is synthesized from Learning Log windows.
+  const now = new Date();
+  const cycleInfo = pod.cycles as unknown as {
+    start_date: string | null;
+    end_date: string | null;
+  } | null;
+  const isLegacyPulsePod = pulseRows.length > 0;
+
+  let logCreatedAtsByMember = new Map<number, Date[]>();
+  if (!isLegacyPulsePod && memberIds.length > 0) {
+    const { data: logRows } = await supabase
+      .from("learning_logs")
+      .select("participant_id, created_at")
+      .in("participant_id", memberIds)
+      .eq("cycle_id", pod.cycle_id as number);
+    logCreatedAtsByMember = new Map();
+    for (const r of logRows ?? []) {
+      const arr = logCreatedAtsByMember.get(r.participant_id as number) ?? [];
+      arr.push(new Date(r.created_at as string));
+      logCreatedAtsByMember.set(r.participant_id as number, arr);
+    }
+  }
+
+  // cadenceByMember drives the roster status/streak/miss/nudge and the
+  // pod-level health below — pulses for legacy pods, synthesized weekly log
+  // windows otherwise. Empty for a log-based pod whose cycle has no calendar
+  // (no start/end) — there are no weeks to reconstruct, so no one is flagged.
+  const cadenceByMember = new Map<number, CadenceRow[]>();
+  if (isLegacyPulsePod) {
+    for (const p of pulseRows) {
+      const arr = cadenceByMember.get(p.participant_id) ?? [];
+      arr.push(p);
+      cadenceByMember.set(p.participant_id, arr);
+    }
+  } else if (cycleInfo?.start_date && cycleInfo?.end_date) {
+    const cycleStart = new Date(cycleInfo.start_date);
+    const cycleEnd = new Date(cycleInfo.end_date);
+    for (const id of memberIds) {
+      cadenceByMember.set(
+        id,
+        synthesizeLogCadence(
+          id,
+          now,
+          cycleStart,
+          cycleEnd,
+          logCreatedAtsByMember.get(id) ?? []
+        )
+      );
+    }
   }
 
   // Load this poderator's nudge dismissals for this pod.
@@ -197,7 +292,7 @@ export async function getPodDetail(
     const display = lastInitial ? `${first} ${lastInitial}.` : first;
     const initials = `${first[0] ?? "?"}${lastInitial}`.toUpperCase();
 
-    const memberPulses = pulsesByMember.get(m.participant_id as number) ?? [];
+    const memberPulses = cadenceByMember.get(m.participant_id as number) ?? [];
     const status = computePulseStatus(memberPulses, atRiskThreshold);
     const streak = computeStreak(memberPulses);
     const consecutiveMisses = countConsecutiveMisses(memberPulses);
@@ -255,11 +350,12 @@ export async function getPodDetail(
     .filter((m) => m.inactive_at === null)
     .map((m) => m.participant_id as number)
     .filter((id) => !staffTestIds.has(id));
-  const activeMemberIdSet = new Set(activeMemberIds);
-  const activePulses = pulseRows.filter((p) => activeMemberIdSet.has(p.participant_id));
+  const activeCadence = activeMemberIds.flatMap(
+    (id) => cadenceByMember.get(id) ?? []
+  );
 
   const { missingThisWeek, weeklyRates } = bucketPulses(
-    activePulses,
+    activeCadence,
     activeMemberIds.length
   );
 

--- a/scripts/verify/cycle-e2e.mjs
+++ b/scripts/verify/cycle-e2e.mjs
@@ -224,8 +224,8 @@ async function run() {
     .select("participant_id, status")
     .eq("cycle_id", cycle.id);
   check(
-    "enrollments default to 'inactive' (self-service pre-pod state)",
-    enrollments.length === 6 && enrollments.every((e) => e.status === "inactive"),
+    "enrollments default to 'registered' (self-service pre-pod state)",
+    enrollments.length === 6 && enrollments.every((e) => e.status === "registered"),
     JSON.stringify(enrollments)
   );
 
@@ -390,10 +390,10 @@ async function run() {
     [0, 1, 2].every((i) => statusOf(i) === "active")
   );
   check(
-    "pod B members (under-min) still 'inactive'",
-    [3, 4].every((i) => statusOf(i) === "inactive")
+    "pod B members (under-min) still 'registered'",
+    [3, 4].every((i) => statusOf(i) === "registered")
   );
-  check("never-joined participant still 'inactive'", statusOf(5) === "inactive");
+  check("never-joined participant still 'registered'", statusOf(5) === "registered");
 
   // -- 7. Admin force-activate the under-min pod --------------------------
   step("7. Force-activate pod B (admin PATCH semantics) + reconcile");

--- a/supabase/migrations/00092_enrollment_registered_status.sql
+++ b/supabase/migrations/00092_enrollment_registered_status.sql
@@ -1,0 +1,62 @@
+-- 00092_enrollment_registered_status.sql
+--
+-- Splits cycle_enrollments.status into a MEMBERSHIP axis and a POD-ACTIVATION
+-- axis by adding a positive pre-pod state, 'registered'.
+--
+-- Before this change, self-service registration wrote 'inactive' and the
+-- reconciler (lib/enrollment/reconciler.ts) only flipped it to 'active' once
+-- the participant held an active pod membership. So every registrant read as
+-- 'inactive' until pods formed — they couldn't log, didn't show as a
+-- participant, and the admin roster flagged the whole pre-pod cohort as
+-- "stuck". The new model:
+--
+--   registered  committed member, no active pod yet  (self-service resting
+--               state; grants the participant role and can log)
+--   active      committed member WITH an active pod  (meaning unchanged)
+--   inactive    the only true exit: was active, fell behind the weekly logs
+--               (always carries an access_revocations audit row)
+--   revoked     hard erasure / archive (lib/owner/archive.ts), unchanged
+--
+-- The reconciler now only manages registered <-> active; it never writes
+-- 'inactive'. 'inactive' is written solely by the engagement paths (cron /
+-- admin sweep), which also write the access_revocations audit row.
+--
+-- 00056 already extended the CHECK to add 'interested'/'completed'; this
+-- keeps that full vocabulary and adds 'registered'.
+--
+-- DOWN:
+--   ALTER TABLE cycle_enrollments ALTER COLUMN status SET DEFAULT 'inactive';
+--   UPDATE cycle_enrollments SET status = 'inactive' WHERE status = 'registered';
+--   ALTER TABLE cycle_enrollments DROP CONSTRAINT IF EXISTS cycle_enrollments_status_check;
+--   ALTER TABLE cycle_enrollments ADD CONSTRAINT cycle_enrollments_status_check
+--     CHECK (status IN ('interested','active','inactive','revoked','stepped_back','completed')) NOT VALID;
+
+-- 1. Extend the vocabulary with 'registered'.
+ALTER TABLE cycle_enrollments DROP CONSTRAINT IF EXISTS cycle_enrollments_status_check;
+ALTER TABLE cycle_enrollments ADD CONSTRAINT cycle_enrollments_status_check
+  CHECK (status IN ('registered','interested','active','inactive','revoked','stepped_back','completed'));
+-- ⚠ Verify no out-of-vocabulary values exist before promoting to prod:
+--   SELECT DISTINCT status FROM cycle_enrollments;
+
+-- 2. Backfill: every 'inactive' row that is NOT a genuine engagement exit
+--    becomes 'registered'. An engagement exit is distinguished by an
+--    access_revocations audit row for the (participant, cycle). This sweeps
+--    up both pre-pod never-activated rows AND old "left a pod" demotions
+--    (which the pre-00092 reconciler wrote as 'inactive' without an audit
+--    row) — under the new model both are 'registered'. Genuine revocations
+--    (audit row present) stay 'inactive'.
+UPDATE cycle_enrollments ce
+   SET status = 'registered',
+       inactive_date = NULL
+ WHERE ce.status = 'inactive'
+   AND NOT EXISTS (
+     SELECT 1 FROM access_revocations ar
+      WHERE ar.participant_id = ce.participant_id
+        AND ar.cycle_id = ce.cycle_id
+   );
+
+-- 3. New self-service resting state is the default (was 'inactive').
+ALTER TABLE cycle_enrollments ALTER COLUMN status SET DEFAULT 'registered';
+
+-- 4. The constraint was created VALID above (all existing rows now conform),
+--    so no separate VALIDATE step is required.


### PR DESCRIPTION
## What

Replaces the pulse-check engagement signal with the weekly Learning Log cadence in the revocation cron and admin sweep. Under the new registered/active model (migration 00092), the sole revocation reason is consecutive missed weekly Learning Log windows for in-pod ('active') members. Being pod-less is no longer revocation-worthy — that member is 'registered', a permanent resting state.

## Changes

- **Migration 00092** (`supabase/migrations/00092_enrollment_registered_status.sql`): Adds 'registered' status to `cycle_enrollments`, the committed pre-pod member state. The reconciler now only manages registered ↔ active; 'inactive' is written exclusively by revocation paths (cron/admin sweep).

- **Revocation cron** (`app/api/cron/revocation-check/route.ts`): 
  - Replaces `deriveAtRiskRun` (pulse-based) with `consecutiveMissedLogWeeks` (Learning Log windows reconstructed from cycle calendar).
  - Removes 'not_in_pod' check entirely (pod-less → 'registered', not revocation-worthy).
  - Stage 2 now writes `status='inactive'` + `inactive_date` directly (reconciler no longer produces exits).
  - Respects `log_gate_paused` holiday toggle to exempt whole cohorts.

- **Admin revocation sweep** (`app/api/revocations/check/[cycle_id]/route.ts`): Mirrors cron logic; removes pulse/pod checks, uses `consecutiveMissedLogWeeks`.

- **Learning Log cadence synthesis** (`lib/learning-logs/at-risk.ts`, `lib/learning-logs/at-risk.test.ts`): New `consecutiveMissedLogWeeks()` function counts consecutive empty cycle-weeks (reconstructed via `getCycleWeek`). Replaces pulse-check counting.

- **Pod health** (`lib/moderator/pod-detail.ts`): Adds `synthesizeLogCadence()` to convert Learning Log windows into pulse-shaped rows for the existing health/streak engine. Legacy pulse pods keep pulse-based health; log-based cycles synthesize from logs.

- **Reconciler** (`lib/enrollment/reconciler.ts`, `lib/enrollment/reconciler.test.ts`):
  - Now manages registered ↔ active only; never writes 'inactive'.
  - Adds `opts.recover` flag for admin reactivation and auto-recovery on qualifying log.
  - Exits ('inactive'/'revoked') are sticky unless recovery is explicitly requested.

- **Role resolution** (`lib/auth/roles.ts`, `lib/auth/roles.test.ts`): 'registered' members now grant the participant role (they can log before pods form). Only 'inactive'/'revoked' withhold it.

- **Log eligibility** (`lib/learning-logs/eligible.ts`): Clarifies that 'registered' and 'inactive' members can file logs (registered: pre-pod; inactive: recovery path).

- **Log submission** (`app/api/learning-logs/route.ts`): On qualifying log, auto-recover 'inactive' → 'active' via reconciler with `recover=true`.

- **Admin UI** (`app/(dashboard)/admin/cycles/[cycle_id]/page.tsx`, `participants-table.tsx`): Renames "stuck inactive" to "stuck registered" (committed member with active pod but enrollment never promoted). Adds `has_active_pod` field to identify them.

- **Email template** (`lib/email/revocation-warning-template.ts`): Updates reason from 'missed_pulses'/'not_in_pod' to 'missed_logs'.

- **Docs** (`docs/requirements/moderator-insights-logs.md`): New requirements doc for rebuilding Moderator Insights on Learning Logs (replaces pulse-based metrics).

- **Tests & scripts**: Updated to reflect 'registered' as the new self-service enrollment default; existing reconciler tests updated to cover recovery semantics.

Closes #110 (Phase C.3).

## Verify

- [x] `npm

https://claude.ai/code/session_019c5qQgnjJMY5cCCgjo79g9