### PR TITLE
Backmerge main into dev (picks up #314)

### DIFF
--- a/app/(dashboard)/cycles/[cycle_id]/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/page.tsx
@@ -11,7 +11,6 @@ import {
   ArrowRight,
   ChevronLeft,
   ExternalLink,
-  FolderKanban,
 } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
@@ -146,13 +145,6 @@ export default async function CycleDetailPage({
         .eq("participant_id", me.id)
         .order("created_at")
     : { data: null };
-
-  // Door to the proposal gallery — shown as soon as the cycle has any
-  // statements at all (the gallery page itself applies the per-lab filter).
-  const { count: statementCount } = await serviceClient
-    .from("problem_statements")
-    .select("id", { count: "exact", head: true })
-    .eq("cycle_id", cycle.id);
 
   const now = new Date();
   const activeWindows: { label: string; route: string; closesAt: string }[] = [];
@@ -305,37 +297,6 @@ export default async function CycleDetailPage({
                 <p className="mt-0.5 text-sm text-meta">
                   A few lines each week on what you&apos;re figuring out. That&apos;s
                   the check-in that keeps you in the cycle.
-                </p>
-              </div>
-            </div>
-            <ArrowRight
-              className="h-4 w-4 flex-shrink-0 text-teal-deep transition-transform duration-150 ease-spring group-hover:translate-x-0.5"
-              aria-hidden
-            />
-          </Link>
-        </div>
-      )}
-
-      {/* Proposal gallery — browsable in every phase, unlike the ballot,
-          which only renders while the voting window is open */}
-      {(statementCount ?? 0) > 0 && (
-        <div className="mb-8">
-          <Link
-            href={`/cycles/${cycle.id}/proposals`}
-            className="group flex items-center justify-between gap-3 rounded-card border border-ink/10 border-l-4 border-l-teal bg-white p-4 shadow-card transition-colors duration-150 ease-out hover:bg-ink/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
-          >
-            <div className="flex items-center gap-3">
-              <FolderKanban
-                className="h-5 w-5 flex-shrink-0 text-teal-deep"
-                aria-hidden
-              />
-              <div>
-                <span className="font-semibold tracking-tight text-ink">
-                  Problem situation gallery
-                </span>
-                <p className="mt-0.5 text-sm text-meta">
-                  Browse what your cohort is proposing this cycle — with links
-                  to the maps behind each statement.
                 </p>
               </div>
             </div>

--- a/app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx
@@ -1,31 +1,15 @@
 import Link from "next/link";
 import { windowOpen } from "@/lib/cycles/lab-time";
-import { ArrowRight, ChevronLeft, ExternalLink } from "lucide-react";
+import { ArrowRight, ChevronLeft } from "lucide-react";
 import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { resolveUserRoles, isAdmin } from "@/lib/auth/roles";
 import { notFound } from "next/navigation";
-
-interface ProposalData {
-  about?: { background?: string };
-  // Triangulator-aligned shape (current submissions)…
-  situation?: {
-    title?: string;
-    description?: string;
-    openness?: string;
-    paradox?: string;
-    beneficiaries?: string;
-    problematization?: string;
-  };
-  // …and the legacy who/need/barrier/success block (pre-alignment rows).
-  problem?: { who?: string; need?: string; barrier?: string; success?: string };
-  statement?: { question?: string; repo_url?: string };
-  voter_context?: {
-    tried?: string;
-    scale?: string;
-    pod_work?: string;
-    skills_needed?: string;
-  };
-}
+import {
+  ProposalDetails,
+  ProposalMapLink,
+  proposalMapUrl,
+  type ProposalData,
+} from "@/app/components/proposal-details";
 
 // Read-only gallery of the cycle's problem situations. Unlike the vote
 // ballot, this renders in every phase — the ballot only exists while the
@@ -154,17 +138,6 @@ export default async function ProposalsGalleryPage({
         <div className="mt-4 space-y-4">
           {statements.map((stmt) => {
             const pd = (stmt.proposal_data ?? null) as ProposalData | null;
-            const hasDetails = !!(
-              pd?.situation ||
-              pd?.problem ||
-              pd?.voter_context
-            );
-            // Scheme-checked before rendering as an href — rows written
-            // before the schema restricted repo_url to http(s) are
-            // untrusted here.
-            const rawRepo = pd?.statement?.repo_url;
-            const mapUrl =
-              rawRepo && /^https?:\/\//i.test(rawRepo) ? rawRepo : null;
 
             return (
               <div
@@ -184,17 +157,7 @@ export default async function ProposalsGalleryPage({
                   </p>
                 )}
 
-                {mapUrl && (
-                  <a
-                    href={mapUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="mt-2 inline-flex items-center gap-1 text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline"
-                  >
-                    View the map
-                    <ExternalLink className="h-3 w-3" aria-hidden />
-                  </a>
-                )}
+                <ProposalMapLink href={proposalMapUrl(pd)} />
 
                 {pd?.about?.background && (
                   <p className="mt-2 text-xs text-meta">
@@ -202,112 +165,12 @@ export default async function ProposalsGalleryPage({
                   </p>
                 )}
 
-                {hasDetails && (
-                  <details className="group mt-2">
-                    <summary className="inline-flex cursor-pointer list-none items-center text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline [&::-webkit-details-marker]:hidden">
-                      <span className="group-open:hidden">
-                        Read full proposal
-                      </span>
-                      <span className="hidden group-open:inline">
-                        Show less
-                      </span>
-                    </summary>
-                    <div className="mt-4 space-y-3 border-t border-ink/10 pt-4">
-                      {pd?.situation?.description && (
-                        <DetailBlock
-                          label="The situation"
-                          text={pd.situation.description}
-                        />
-                      )}
-                      {pd?.situation?.openness && (
-                        <DetailBlock
-                          label="What makes it open"
-                          text={pd.situation.openness}
-                        />
-                      )}
-                      {pd?.situation?.paradox && (
-                        <DetailBlock
-                          label="The paradox"
-                          text={pd.situation.paradox}
-                        />
-                      )}
-                      {pd?.situation?.beneficiaries && (
-                        <DetailBlock
-                          label="Who benefits from its persistence"
-                          text={pd.situation.beneficiaries}
-                        />
-                      )}
-                      {pd?.situation?.problematization && (
-                        <DetailBlock
-                          label="Pressure-test"
-                          text={pd.situation.problematization}
-                        />
-                      )}
-                      {pd?.problem?.who && (
-                        <DetailBlock
-                          label="Who is struggling"
-                          text={pd.problem.who}
-                        />
-                      )}
-                      {pd?.problem?.need && (
-                        <DetailBlock
-                          label="What they need to do"
-                          text={pd.problem.need}
-                        />
-                      )}
-                      {pd?.problem?.barrier && (
-                        <DetailBlock
-                          label="Why they can't do it now"
-                          text={pd.problem.barrier}
-                        />
-                      )}
-                      {pd?.problem?.success && (
-                        <DetailBlock
-                          label="What success looks like"
-                          text={pd.problem.success}
-                        />
-                      )}
-                      {pd?.voter_context?.tried && (
-                        <DetailBlock
-                          label="What has been tried"
-                          text={pd.voter_context.tried}
-                        />
-                      )}
-                      {pd?.voter_context?.scale && (
-                        <DetailBlock
-                          label="Why it matters beyond the individual"
-                          text={pd.voter_context.scale}
-                        />
-                      )}
-                      {pd?.voter_context?.pod_work && (
-                        <DetailBlock
-                          label="What the Research Pod would do"
-                          text={pd.voter_context.pod_work}
-                        />
-                      )}
-                      {pd?.voter_context?.skills_needed && (
-                        <DetailBlock
-                          label="Skills & people needed"
-                          text={pd.voter_context.skills_needed}
-                        />
-                      )}
-                    </div>
-                  </details>
-                )}
+                <ProposalDetails data={pd} />
               </div>
             );
           })}
         </div>
       )}
-    </div>
-  );
-}
-
-function DetailBlock({ label, text }: { label: string; text: string }) {
-  return (
-    <div>
-      <p className="lbl">{label}</p>
-      <p className="mt-0.5 text-sm text-charcoal">{text}</p>
     </div>
   );
 }

--- a/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import {
+  ProposalDetails,
+  ProposalMapLink,
+  proposalMapUrl,
+  type ProposalData,
+} from "@/app/components/proposal-details";
 
 interface Pod {
   id: number;
@@ -8,6 +14,8 @@ interface Pod {
   status: string;
   registrantCount: number;
   problemStatement: string | null;
+  /** The pod's originating submission — same payload the gallery renders. */
+  proposal: ProposalData | null;
   registered: boolean;
 }
 
@@ -40,12 +48,14 @@ export default function PodRegistration({
                 status: string;
                 registrant_count: number;
                 problem_statement_title: string | null;
+                proposal_data: ProposalData | null;
               }) => ({
                 id: p.id,
                 name: p.name,
                 status: p.status,
                 registrantCount: p.registrant_count,
                 problemStatement: p.problem_statement_title,
+                proposal: p.proposal_data ?? null,
                 registered: initialMyPodIds.includes(p.id),
               })
             )
@@ -174,7 +184,7 @@ export default function PodRegistration({
         </p>
       )}
 
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid items-start gap-3 sm:grid-cols-2">
         {pods.map((pod) => (
           <div
             key={pod.id}
@@ -212,11 +222,24 @@ export default function PodRegistration({
                 </button>
               )}
             </div>
+            {/* The submission this pod came out of: the same situation title,
+                map link and "Read full proposal" block the gallery shows, so a
+                member can size up a pod without leaving the join page. */}
+            {pod.proposal?.situation?.title && (
+              <p className="lbl lbl-teal mb-1">{pod.proposal.situation.title}</p>
+            )}
             {pod.problemStatement && (
               <p className="text-xs leading-relaxed text-slate">
                 {pod.problemStatement}
               </p>
             )}
+            {pod.proposal?.statement?.question && (
+              <p className="mt-2 text-xs italic leading-relaxed text-slate">
+                {pod.proposal.statement.question}
+              </p>
+            )}
+            <ProposalMapLink href={proposalMapUrl(pod.proposal)} />
+            <ProposalDetails data={pod.proposal} />
           </div>
         ))}
       </div>

--- a/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
+++ b/app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx
@@ -185,7 +185,7 @@ export default function PodRegistration({
             }`}
           >
             <div className="mb-2 flex items-start justify-between gap-3">
-              <div>
+              <div className="min-w-0">
                 <p className="font-semibold tracking-tight text-ink">
                   {pod.name || `Pod ${pod.id}`}
                 </p>
@@ -198,7 +198,7 @@ export default function PodRegistration({
                 <button
                   onClick={() => unregisterFromPod(pod.id)}
                   disabled={actionPodId !== null}
-                  className="rounded-card ring-1 ring-ink/10 px-3 py-2 text-xs font-semibold tracking-tight text-charcoal transition-all duration-150 ease-spring hover:bg-ink/[0.04] hover:text-ink hover:ring-ink/20 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+                  className="flex-shrink-0 rounded-card ring-1 ring-ink/10 px-3 py-2 text-xs font-semibold tracking-tight text-charcoal transition-all duration-150 ease-spring hover:bg-ink/[0.04] hover:text-ink hover:ring-ink/20 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
                 >
                   {actionPodId === pod.id ? "..." : "Leave"}
                 </button>
@@ -206,14 +206,16 @@ export default function PodRegistration({
                 <button
                   onClick={() => registerForPod(pod.id)}
                   disabled={actionPodId !== null || registeredCount >= podLimit}
-                  className="rounded-card bg-teal/10 px-3 py-2 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
+                  className="flex-shrink-0 rounded-card bg-teal/10 px-3 py-2 text-xs font-semibold tracking-tight text-teal-deep transition-all duration-150 hover:bg-teal/20 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal focus-visible:ring-offset-2"
                 >
                   {actionPodId === pod.id ? "..." : "Join"}
                 </button>
               )}
             </div>
             {pod.problemStatement && (
-              <p className="text-xs text-slate">{pod.problemStatement}</p>
+              <p className="text-xs leading-relaxed text-slate">
+                {pod.problemStatement}
+              </p>
             )}
           </div>
         ))}

--- a/app/api/cycles/[cycle_id]/pods/route.ts
+++ b/app/api/cycles/[cycle_id]/pods/route.ts
@@ -15,7 +15,7 @@ export const GET = withAuth(
       .select(`
         id, name, problem_statement_id, status, lab_id,
         slack_channel_id, drive_folder_id, github_repo_url,
-        problem_statements (statement_text)
+        problem_statements (statement_text, proposal_data)
       `)
       .eq("cycle_id", cycleId)
       .order("created_at");
@@ -60,6 +60,9 @@ export const GET = withAuth(
       // Full statement text — a 100-char slice used to cut every description
       // off mid-word on the pod registration cards (statements run ~400).
       problem_statement_title: ((p.problem_statements as unknown) as Record<string, string>)?.statement_text,
+      // The rest of the submission, so a pod card can show the same situation
+      // title, map link and "Read full proposal" block as the gallery.
+      proposal_data: ((p.problem_statements as unknown) as Record<string, unknown>)?.proposal_data ?? null,
       status: p.status,
       registrant_count: countMap[p.id] || 0,
       slack_channel_id: p.slack_channel_id,

--- a/app/api/cycles/[cycle_id]/pods/route.ts
+++ b/app/api/cycles/[cycle_id]/pods/route.ts
@@ -57,7 +57,9 @@ export const GET = withAuth(
       id: p.id,
       name: p.name,
       problem_statement_id: p.problem_statement_id,
-      problem_statement_title: ((p.problem_statements as unknown) as Record<string, string>)?.statement_text?.slice(0, 100),
+      // Full statement text — a 100-char slice used to cut every description
+      // off mid-word on the pod registration cards (statements run ~400).
+      problem_statement_title: ((p.problem_statements as unknown) as Record<string, string>)?.statement_text,
       status: p.status,
       registrant_count: countMap[p.id] || 0,
       slack_channel_id: p.slack_channel_id,

--- a/app/api/pods/[pod_id]/route.ts
+++ b/app/api/pods/[pod_id]/route.ts
@@ -30,7 +30,9 @@ export const GET = withAuth(
 
     return NextResponse.json({
       ...pod,
-      problem_statement_title: ((pod.problem_statements as unknown) as Record<string, string>)?.statement_text?.slice(0, 100),
+      // Full statement text — see the cycle pods route: the 100-char slice
+      // truncated descriptions mid-word wherever they were rendered.
+      problem_statement_title: ((pod.problem_statements as unknown) as Record<string, string>)?.statement_text,
       registrant_count: count || 0,
     });
   }

--- a/app/components/proposal-details.tsx
+++ b/app/components/proposal-details.tsx
@@ -1,0 +1,161 @@
+import { ExternalLink } from "lucide-react";
+
+/**
+ * Shape of problem_statements.proposal_data. Every field is optional: rows
+ * span two generations of the propose form, and both the gallery and the pod
+ * cards render whatever a given row happens to carry.
+ */
+export interface ProposalData {
+  about?: { background?: string };
+  // Triangulator-aligned shape (current submissions)…
+  situation?: {
+    title?: string;
+    description?: string;
+    openness?: string;
+    paradox?: string;
+    beneficiaries?: string;
+    problematization?: string;
+  };
+  // …and the legacy who/need/barrier/success block (pre-alignment rows).
+  problem?: { who?: string; need?: string; barrier?: string; success?: string };
+  statement?: { question?: string; repo_url?: string };
+  voter_context?: {
+    tried?: string;
+    scale?: string;
+    pod_work?: string;
+    skills_needed?: string;
+  };
+}
+
+/** True when there is anything to put behind the "Read full proposal" toggle. */
+export function hasProposalDetails(pd: ProposalData | null | undefined) {
+  return !!(pd?.situation || pd?.problem || pd?.voter_context);
+}
+
+/**
+ * repo_url as a safe href, or null. Rows written before the schema restricted
+ * repo_url to http(s) are untrusted, so the scheme is checked every time.
+ */
+export function proposalMapUrl(pd: ProposalData | null | undefined) {
+  const raw = pd?.statement?.repo_url;
+  return raw && /^https?:\/\//i.test(raw) ? raw : null;
+}
+
+/**
+ * The "Read full proposal" expander — every detail block the submitter filled
+ * in, in submission order. Presentational only (no hooks, no client state), so
+ * the server-rendered gallery and the client-side pod cards share one copy.
+ */
+export function ProposalDetails({ data }: { data: ProposalData | null }) {
+  if (!hasProposalDetails(data)) return null;
+
+  return (
+    <details className="group mt-2">
+      <summary className="inline-flex cursor-pointer list-none items-center text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline [&::-webkit-details-marker]:hidden">
+        <span className="group-open:hidden">Read full proposal</span>
+        <span className="hidden group-open:inline">Show less</span>
+      </summary>
+      <div className="mt-4 space-y-3 border-t border-ink/10 pt-4">
+        {data?.situation?.description && (
+          <DetailBlock
+            label="The situation"
+            text={data.situation.description}
+          />
+        )}
+        {data?.situation?.openness && (
+          <DetailBlock
+            label="What makes it open"
+            text={data.situation.openness}
+          />
+        )}
+        {data?.situation?.paradox && (
+          <DetailBlock label="The paradox" text={data.situation.paradox} />
+        )}
+        {data?.situation?.beneficiaries && (
+          <DetailBlock
+            label="Who benefits from its persistence"
+            text={data.situation.beneficiaries}
+          />
+        )}
+        {data?.situation?.problematization && (
+          <DetailBlock
+            label="Pressure-test"
+            text={data.situation.problematization}
+          />
+        )}
+        {data?.problem?.who && (
+          <DetailBlock label="Who is struggling" text={data.problem.who} />
+        )}
+        {data?.problem?.need && (
+          <DetailBlock label="What they need to do" text={data.problem.need} />
+        )}
+        {data?.problem?.barrier && (
+          <DetailBlock
+            label="Why they can't do it now"
+            text={data.problem.barrier}
+          />
+        )}
+        {data?.problem?.success && (
+          <DetailBlock
+            label="What success looks like"
+            text={data.problem.success}
+          />
+        )}
+        {data?.voter_context?.tried && (
+          <DetailBlock
+            label="What has been tried"
+            text={data.voter_context.tried}
+          />
+        )}
+        {data?.voter_context?.scale && (
+          <DetailBlock
+            label="Why it matters beyond the individual"
+            text={data.voter_context.scale}
+          />
+        )}
+        {data?.voter_context?.pod_work && (
+          <DetailBlock
+            label="What the Research Pod would do"
+            text={data.voter_context.pod_work}
+          />
+        )}
+        {data?.voter_context?.skills_needed && (
+          <DetailBlock
+            label="Skills & people needed"
+            text={data.voter_context.skills_needed}
+          />
+        )}
+      </div>
+    </details>
+  );
+}
+
+/**
+ * The map link that sits above the expander on both surfaces. Takes the
+ * nullable result of proposalMapUrl directly and renders nothing for a
+ * missing or non-http(s) URL.
+ */
+export function ProposalMapLink({ href }: { href: string | null }) {
+  if (!href) return null;
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="mt-2 inline-flex items-center gap-1 text-xs font-semibold tracking-tight text-teal-deep transition-colors duration-150 hover:underline focus-visible:underline"
+    >
+      View the map
+      <ExternalLink className="h-3 w-3" aria-hidden />
+    </a>
+  );
+}
+
+function DetailBlock({ label, text }: { label: string; text: string }) {
+  return (
+    <div>
+      <p className="lbl">{label}</p>
+      <p className="mt-0.5 text-sm text-charcoal">{text}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Brings `dev` back in line with `main`. PR #314 was based on `main` and merged straight into it, skipping `dev`, so the pod-card and cycle-page changes were live in prod but missing from `dev` — the next branch cut from `dev` would not have had them.

## Changes

- Merge commit of `origin/main` into `dev`. No hand-written changes; the merge was clean with no conflicts.
- The content this carries into `dev` is #314's six files:
  - `app/components/proposal-details.tsx` (new) — shared `ProposalDetails` / `ProposalMapLink` / `proposalMapUrl` / `ProposalData`
  - `app/(dashboard)/cycles/[cycle_id]/proposals/page.tsx` — gallery renders through the shared component
  - `app/(dashboard)/cycles/[cycle_id]/register-pods/pod-registration.tsx` — pod cards show situation title, question, map link, "Read full proposal"
  - `app/api/cycles/[cycle_id]/pods/route.ts` — returns `proposal_data`; drops the 100-char slice
  - `app/api/pods/[pod_id]/route.ts` — drops the 100-char slice
  - `app/(dashboard)/cycles/[cycle_id]/page.tsx` — removes the problem situation gallery CTA

After this merge, `git diff origin/main HEAD` is empty and zero commits remain in `main` that are not in this branch.

## Verify

- [x] `npm run lint` passes (0 errors; 8 pre-existing warnings)
- [x] `npm run test` passes (53 files, 411 tests)
- [x] `npm run build` passes

## Manual testing

None specific to this PR — it introduces no new code, only moves already-merged commits from `main` onto `dev`. The flows it carries were exercised under #314. Worth a smoke check on a `dev` preview once merged:

1. Open `/cycles/[id]/register-pods` — each pod card shows the situation title, the statement in full (not cut mid-word), the map link, and a working "Read full proposal" expander.
2. Open `/cycles/[id]/proposals` — the gallery renders unchanged from before the shared-component extraction.
3. Open `/cycles/[id]` — the "Problem situation gallery" CTA card is gone; the "Your problem situations" list is still there.

## Database

- [x] No schema change

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ljwts3BKmoazUSkKAhkcP)_