### PR TITLE
Show the map link and full proposal on the pod page (cherry-pick of #316 to main)

### DIFF
--- a/app/(dashboard)/pods/[pod_id]/page.tsx
+++ b/app/(dashboard)/pods/[pod_id]/page.tsx
@@ -16,6 +16,12 @@ import CharterProjectForm from "./charter-project-form";
 import FollowButton from "@/app/components/follow-button";
 import PageUpdatesSection from "@/app/(dashboard)/page-updates-section";
 import { resolvePageContext } from "@/lib/pages/server";
+import {
+  ProposalDetails,
+  ProposalMapLink,
+  proposalMapUrl,
+  type ProposalData,
+} from "@/app/components/proposal-details";
 
 // Matches pods_status_check (00063): forming/active/inactive/dissolved.
 type PodStatus = "active" | "forming" | "inactive" | "dissolved";
@@ -46,7 +52,7 @@ export default async function PodDetailPage({
   const { data: pod } = await supabase
     .from("pods")
     .select(
-      "id, name, status, cycle_id, lab_id, workstream_id, problem_statement_id, problem_statements(statement_text), cycles(mode)"
+      "id, name, status, cycle_id, lab_id, workstream_id, problem_statement_id, problem_statements(statement_text, proposal_data), cycles(mode)"
     )
     .eq("id", parseInt(pod_id))
     .single();
@@ -71,7 +77,14 @@ export default async function PodDetailPage({
     .eq("pod_id", pod.id)
     .order("created_at");
 
-  const ps = (pod.problem_statements as unknown) as Record<string, string> | null;
+  const ps = (pod.problem_statements as unknown) as {
+    statement_text?: string;
+    proposal_data?: ProposalData | null;
+  } | null;
+  // The submission this pod came out of, so the pod's own page carries the
+  // same map link and "Read full proposal" detail as the gallery and the
+  // registration cards — previously it showed the bare statement text.
+  const proposal = ps?.proposal_data ?? null;
 
   // Viewer roles are only needed for the org charter affordance below.
   const userRoles = user
@@ -142,7 +155,19 @@ export default async function PodDetailPage({
           <h3 className="lbl mb-1">
             Problem situation
           </h3>
+          {proposal?.situation?.title && (
+            <p className="mb-1 font-semibold tracking-tight text-ink">
+              {proposal.situation.title}
+            </p>
+          )}
           <p className="text-charcoal">{ps.statement_text}</p>
+          {proposal?.statement?.question && (
+            <p className="mt-2 text-sm italic leading-relaxed text-slate">
+              {proposal.statement.question}
+            </p>
+          )}
+          <ProposalMapLink href={proposalMapUrl(proposal)} />
+          <ProposalDetails data={proposal} />
         </div>
       )}
 


### PR DESCRIPTION
## What

Promotes #316 to prod. Cherry-pick of the single commit `483ac02` onto `main` (as `45f7eee`), so `/pods/[pod_id]` shows the map link and the full proposal in prod, matching what just landed on `dev`.

Cherry-pick rather than a `dev` → `main` promotion, so this carries only #316 and nothing else that may be sitting on `dev`. The pick applied cleanly — `main` already has the shared `proposal-details.tsx` from #314 — and the branch is exactly `main` plus one commit.

## Changes

- `app/(dashboard)/pods/[pod_id]/page.tsx`:
  - Selects `proposal_data` alongside `statement_text` from the embedded `problem_statements` row
  - Types the embed properly instead of `Record<string, string>`
  - Renders, inside the existing "Problem situation" card: the situation title, the "how might we" question, `ProposalMapLink`, and the `ProposalDetails` expander

No API change, no new files — the shared component this imports is already on `main`.

## Verify

Run against this branch (i.e. on top of `main`), not the `dev` copy:

- [x] `npm run lint` passes (0 errors; 8 pre-existing warnings)
- [x] `npm run test` passes (53 files, 411 tests)
- [x] `npm run build` passes

## Manual testing

On prod after deploy. Cycle 2's pods have submissions with `proposal_data`.

1. Open `/pods/8` (Effort vs. Impact). The "Problem situation" card should show the `Problem situation` label, the situation title in semibold, the statement in full, the "how might we" question in italic, a "View the map" link, and a "Read full proposal" toggle.
2. Click "Read full proposal" — the detail blocks expand and match the same proposal on `/cycles/2/proposals`. Clicking again collapses to "Show less".
3. Click "View the map" — opens the submitter's map in a new tab.
4. Open an org-mode workstream pod with no problem statement — the card stays hidden, as before.
5. Open a pod whose submission has a statement but no `proposal_data` — the statement renders alone, with no empty title, map link, or expander.

## Database

- [x] No schema change

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ljwts3BKmoazUSkKAhkcP)_